### PR TITLE
Fix WS proxy

### DIFF
--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
 			"/api": {
 				target: "http://127.0.0.1:3484",
 				changeOrigin: true,
+				ws: true
 			},
 		},
 	},


### PR DESCRIPTION
When testing this locally, I noticed `127.0.0.1` wouldn't connect to the proxy because `ws` isn't allowed.
This PR fixes that and makes localhost work locally.