### PR TITLE
feat(web-ui): make footer branding clickable and hoverable

### DIFF
--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -130,12 +130,15 @@ export function ProjectNavigationPanel({
 				))}
 			</div>
 			<ShortcutsCard />
-			<div
-				className="text-text-tertiary text-center"
+			<a
+				href="https://cline.bot"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-text-tertiary hover:text-text-primary text-center block transition-colors"
 				style={{ padding: "6px 12px", fontSize: 10 }}
 			>
 				Made with <Heart size={10} fill="currentColor" className="inline-block" /> by Cline
-			</div>
+			</a>
 			<AlertDialog
 				open={pendingProjectRemoval !== null}
 				onOpenChange={(open) => {


### PR DESCRIPTION
## Summary

The "Made with ♥ by Cline" text in the project navigation sidebar was a static `<div>`. This converts it to an `<a>` tag that:

- Links to https://cline.bot (opens in a new tab)
- Transitions from tertiary text color to primary (white) on hover
- Uses `transition-colors` for a smooth hover effect

Single-line change in `project-navigation-panel.tsx` swapping the `<div>` for an `<a>` with appropriate link attributes and hover styling.