### PR TITLE
feat: copy prompt icon

### DIFF
--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -146,7 +146,6 @@ export function BoardCard({
 	isDependencyLinking?: boolean;
 	workspacePath?: string | null;
 }): React.ReactElement {
-	const [isHovered, setIsHovered] = useState(false);
 	const [titleContainerRef, titleRect] = useMeasure<HTMLDivElement>();
 	const [descriptionContainerRef, descriptionRect] = useMeasure<HTMLDivElement>();
 	const titleRef = useRef<HTMLParagraphElement | null>(null);
@@ -341,7 +340,6 @@ export function BoardCard({
 							cursor: "grab",
 						}}
 						onMouseEnter={() => {
-							setIsHovered(true);
 							onDependencyPointerEnter?.(card.id);
 						}}
 						onMouseMove={() => {
@@ -350,14 +348,12 @@ export function BoardCard({
 							}
 							onDependencyPointerEnter?.(card.id);
 						}}
-						onMouseLeave={() => setIsHovered(false)}
 					>
 						<div
 							className={cn(
-								"rounded-md border border-border-bright bg-surface-2 p-2.5",
+								"group/card rounded-md border border-border-bright bg-surface-2 p-2.5",
 								isCardInteractive && "cursor-pointer hover:bg-surface-3 hover:border-border-bright",
 								isDragging && "shadow-lg",
-								isHovered && isCardInteractive && "bg-surface-3 border-border-bright",
 								isDependencySource && "kb-board-card-dependency-source",
 								isDependencyTarget && "kb-board-card-dependency-target",
 							)}
@@ -375,67 +371,68 @@ export function BoardCard({
 										{displayPromptSplit.title}
 									</p>
 								</div>
-								{isHovered && (
+								<div className="flex items-center">
 									<Tooltip content={isCopied ? "Copied!" : "Copy prompt"}>
 										<Button
 											icon={<Copy size={14} />}
 											variant="ghost"
 											size="sm"
 											aria-label="Copy task prompt"
+											className="opacity-0 group-hover/card:opacity-100 transition-opacity duration-100"
 											onMouseDown={stopEvent}
 											onClick={handleCopyPrompt}
 										/>
 									</Tooltip>
-								)}
-								{columnId === "backlog" ? (
-									<Button
-										icon={<Play size={14} />}
-										variant="ghost"
-										size="sm"
-										aria-label="Start task"
-										onMouseDown={stopEvent}
-										onClick={(event) => {
-											stopEvent(event);
-											onStart?.(card.id);
-										}}
-									/>
-								) : columnId === "review" ? (
-									<Button
-										icon={isMoveToTrashLoading ? <Spinner size={13} /> : <Trash2 size={13} />}
-										variant="ghost"
-										size="sm"
-										disabled={isMoveToTrashLoading}
-										aria-label="Move task to trash"
-										onMouseDown={stopEvent}
-										onClick={(event) => {
-											stopEvent(event);
-											onMoveToTrash?.(card.id);
-										}}
-									/>
-								) : columnId === "trash" ? (
-									<Tooltip
-										side="bottom"
-										content={
-											<>
-												Restore session
-												<br />
-												in new worktree
-											</>
-										}
-									>
+									{columnId === "backlog" ? (
 										<Button
-											icon={<RotateCcw size={12} />}
+											icon={<Play size={14} />}
 											variant="ghost"
 											size="sm"
-											aria-label="Restore task from trash"
+											aria-label="Start task"
 											onMouseDown={stopEvent}
 											onClick={(event) => {
 												stopEvent(event);
-												onRestoreFromTrash?.(card.id);
+												onStart?.(card.id);
 											}}
 										/>
-									</Tooltip>
-								) : null}
+									) : columnId === "review" ? (
+										<Button
+											icon={isMoveToTrashLoading ? <Spinner size={13} /> : <Trash2 size={13} />}
+											variant="ghost"
+											size="sm"
+											disabled={isMoveToTrashLoading}
+											aria-label="Move task to trash"
+											onMouseDown={stopEvent}
+											onClick={(event) => {
+												stopEvent(event);
+												onMoveToTrash?.(card.id);
+											}}
+										/>
+									) : columnId === "trash" ? (
+										<Tooltip
+											side="bottom"
+											content={
+												<>
+													Restore session
+													<br />
+													in new worktree
+												</>
+											}
+										>
+											<Button
+												icon={<RotateCcw size={12} />}
+												variant="ghost"
+												size="sm"
+												aria-label="Restore task from trash"
+												onMouseDown={stopEvent}
+												onClick={(event) => {
+													stopEvent(event);
+													onRestoreFromTrash?.(card.id);
+												}}
+											/>
+										</Tooltip>
+									) : null}
+								</div>
 							</div>
 							{displayPromptSplit.description ? (
 								<div ref={descriptionContainerRef}>


### PR DESCRIPTION


https://github.com/user-attachments/assets/fc877484-e63c-4846-a0bf-84d075fc24fc




## feat: add copy prompt button to task card header

Adds a hover-revealed copy-to-clipboard button to every task card header. Hovering over a card fades in the copy icon to the left of the column's action button (Play/Trash/Restore) with no gap between them. Clicking it writes the full task prompt to the clipboard and briefly shows a "Copied!" tooltip.

**Implementation notes:**
- Visibility is driven by CSS `group-hover/card:opacity-100` rather than a JS hover state — this avoids a known issue where `@hello-pangea/dnd` can swallow `mouseenter`/`mouseleave` events on draggable elements, which would cause the button to never appear
- Removed the pre-existing `isHovered` state entirely; the card background highlight was already covered by Tailwind's `hover:bg-surface-3` class, making the JS state redundant
- Copy icon and column action button are grouped in a zero-gap flex container so they appear as a tight pair on hover