### PR TITLE
feat(web-ui): only show review actions when files have changed (CLINE-1561)

### DIFF
--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.test.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ClineAgentChatPanel } from "@/components/detail-panels/cline-agent-chat-panel";
 import type { ClineChatMessage } from "@/hooks/use-cline-chat-session";
 import type { RuntimeTaskHookActivity, RuntimeTaskSessionSummary } from "@/runtime/types";
+import { resetWorkspaceMetadataStore, setTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 
 function createSummary(
 	state: RuntimeTaskSessionSummary["state"],
@@ -38,6 +39,7 @@ describe("ClineAgentChatPanel", () => {
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		resetWorkspaceMetadataStore();
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = createRoot(container);
@@ -52,6 +54,7 @@ describe("ClineAgentChatPanel", () => {
 		act(() => {
 			root.unmount();
 		});
+		resetWorkspaceMetadataStore();
 		container.remove();
 		if (previousActEnvironment === undefined) {
 			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
@@ -330,6 +333,16 @@ describe("ClineAgentChatPanel", () => {
 				createdAt: 1,
 			},
 		];
+		setTaskWorkspaceSnapshot({
+			taskId: "task-1",
+			path: "/tmp/worktree",
+			branch: "task-1",
+			isDetached: false,
+			headCommit: "abc1234",
+			changedFiles: 2,
+			additions: 3,
+			deletions: 1,
+		});
 
 		await act(async () => {
 			root.render(
@@ -362,5 +375,38 @@ describe("ClineAgentChatPanel", () => {
 		});
 
 		expect(scrollIntoViewMock).toHaveBeenCalled();
+	});
+
+	it("does not show commit actions when the review workspace is clean", async () => {
+		setTaskWorkspaceSnapshot({
+			taskId: "task-1",
+			path: "/tmp/worktree",
+			branch: "task-1",
+			isDetached: false,
+			headCommit: "def5678",
+			changedFiles: 0,
+			additions: 0,
+			deletions: 0,
+		});
+
+		await act(async () => {
+			root.render(
+				<ClineAgentChatPanel
+					taskId="task-1"
+					summary={createSummary("awaiting_review")}
+					onLoadMessages={async () => []}
+					taskColumnId="review"
+					onCommit={() => {}}
+					onOpenPr={() => {}}
+					onMoveToTrash={() => {}}
+					showMoveToTrash
+				/>,
+			);
+			await Promise.resolve();
+		});
+
+		expect(container.textContent).not.toContain("Commit");
+		expect(container.textContent).not.toContain("Open PR");
+		expect(container.textContent).toContain("Move Card To Trash");
 	});
 });

--- a/web-ui/src/hooks/use-cline-chat-panel-controller.test.tsx
+++ b/web-ui/src/hooks/use-cline-chat-panel-controller.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useClineChatPanelController } from "@/hooks/use-cline-chat-panel-controller";
 import type { RuntimeTaskSessionSummary } from "@/runtime/types";
+import { resetWorkspaceMetadataStore, setTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 
 interface HookSnapshot {
 	draft: string;
@@ -127,6 +128,7 @@ describe("useClineChatPanelController", () => {
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		resetWorkspaceMetadataStore();
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = createRoot(container);
@@ -136,6 +138,7 @@ describe("useClineChatPanelController", () => {
 		act(() => {
 			root.unmount();
 		});
+		resetWorkspaceMetadataStore();
 		container.remove();
 		if (previousActEnvironment === undefined) {
 			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
@@ -189,6 +192,16 @@ describe("useClineChatPanelController", () => {
 
 	it("derives footer and action flags from the panel inputs", async () => {
 		let latestSnapshot: HookSnapshot | null = null;
+		setTaskWorkspaceSnapshot({
+			taskId: "task-1",
+			path: "/tmp/worktree",
+			branch: "task-1",
+			isDetached: false,
+			headCommit: "abc1234",
+			changedFiles: 2,
+			additions: 4,
+			deletions: 1,
+		});
 
 		await act(async () => {
 			root.render(
@@ -210,6 +223,51 @@ describe("useClineChatPanelController", () => {
 		expect(requireSnapshot(latestSnapshot).showAgentProgressIndicator).toBe(true);
 		expect(requireSnapshot(latestSnapshot).showActionFooter).toBe(true);
 		expect(requireSnapshot(latestSnapshot).showCancelAutomaticAction).toBe(true);
+	});
+
+	it("hides review actions after the workspace becomes clean", async () => {
+		let latestSnapshot: HookSnapshot | null = null;
+		setTaskWorkspaceSnapshot({
+			taskId: "task-1",
+			path: "/tmp/worktree",
+			branch: "task-1",
+			isDetached: false,
+			headCommit: "abc1234",
+			changedFiles: 1,
+			additions: 1,
+			deletions: 0,
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					summary={createSummary("awaiting_review")}
+					taskColumnId="review"
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await Promise.resolve();
+		});
+
+		expect(requireSnapshot(latestSnapshot).showReviewActions).toBe(true);
+
+		await act(async () => {
+			setTaskWorkspaceSnapshot({
+				taskId: "task-1",
+				path: "/tmp/worktree",
+				branch: "task-1",
+				isDetached: false,
+				headCommit: "def5678",
+				changedFiles: 0,
+				additions: 0,
+				deletions: 0,
+			});
+			await Promise.resolve();
+		});
+
+		expect(requireSnapshot(latestSnapshot).showReviewActions).toBe(false);
 	});
 
 	it("hides the thinking indicator as soon as an assistant stream event arrives", async () => {

--- a/web-ui/src/hooks/use-cline-chat-panel-controller.ts
+++ b/web-ui/src/hooks/use-cline-chat-panel-controller.ts
@@ -6,6 +6,7 @@ import { useCallback, useState } from "react";
 import type { ClineChatActionResult } from "@/hooks/use-cline-chat-runtime-actions";
 import { type ClineChatMessage, useClineChatSession } from "@/hooks/use-cline-chat-session";
 import type { RuntimeTaskSessionSummary } from "@/runtime/types";
+import { useTaskWorkspaceSnapshotValue } from "@/stores/workspace-metadata-store";
 
 interface UseClineChatPanelControllerInput {
 	taskId: string;
@@ -78,6 +79,7 @@ export function useClineChatPanelController({
 	showMoveToTrash = false,
 }: UseClineChatPanelControllerInput): UseClineChatPanelControllerResult {
 	const [draft, setDraft] = useState("");
+	const reviewWorkspaceSnapshot = useTaskWorkspaceSnapshotValue(taskId);
 	const { messages, isSending, isCanceling, error, sendMessage, cancelTurn } = useClineChatSession({
 		taskId,
 		onSendMessage,
@@ -87,7 +89,11 @@ export function useClineChatPanelController({
 	});
 	const canSend = Boolean(onSendMessage) && !isSending && !isCanceling;
 	const canCancel = Boolean(onCancelTurn) && summary?.state === "running" && !isCanceling;
-	const showReviewActions = taskColumnId === "review" && Boolean(onCommit) && Boolean(onOpenPr);
+	const showReviewActions =
+		taskColumnId === "review" &&
+		(reviewWorkspaceSnapshot?.changedFiles ?? 0) > 0 &&
+		Boolean(onCommit) &&
+		Boolean(onOpenPr);
 	const showAgentProgressIndicator =
 		summary?.state === "running" && !hasVisibleStreamingMessage(summary, messages, incomingMessage);
 	const showActionFooter = showMoveToTrash && Boolean(onMoveToTrash);


### PR DESCRIPTION
Updated the chat panel controller to check for modified files before showing the "Commit" and "Open PR" actions. This ensures that these review-specific actions are only visible when there is a workspace snapshot containing actual changes, preventing users from attempting to commit empty changesets.

https://linear.app/cline-bot/issue/CLINE-1561/hide-the-commit-button-after-commit-completes