### PR TITLE
Add collapsible diff panel in task detail view

### DIFF
--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -183,6 +183,120 @@ describe("CardDetailView", () => {
 		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeInstanceOf(HTMLButtonElement);
 	});
 
+	it("collapses and restores the diff panel", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const collapseButton = container.querySelector('button[aria-label="Collapse diff panel"]');
+		expect(collapseButton).toBeInstanceOf(HTMLButtonElement);
+		if (!(collapseButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected a collapse diff panel button.");
+		}
+
+		await act(async () => {
+			collapseButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			collapseButton.click();
+		});
+
+		expect(container.querySelector('[data-testid="diff-viewer-panel"]')).toBeNull();
+		expect(container.querySelector('[data-testid="file-tree-panel"]')).toBeNull();
+		expect(container.querySelector('[role="separator"][aria-label="Resize agent and diff panels"]')).toBeNull();
+		expect(container.querySelector('button[aria-label="Show diff panel"]')).toBeInstanceOf(HTMLButtonElement);
+		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeNull();
+
+		const showButton = container.querySelector('button[aria-label="Show diff panel"]');
+		expect(showButton).toBeInstanceOf(HTMLButtonElement);
+		if (!(showButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected a show diff panel button.");
+		}
+
+		await act(async () => {
+			showButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			showButton.click();
+		});
+
+		expect(container.querySelector('[data-testid="diff-viewer-panel"]')).toBeInstanceOf(HTMLDivElement);
+		expect(container.querySelector('[data-testid="file-tree-panel"]')).toBeInstanceOf(HTMLDivElement);
+		expect(container.querySelector('button[aria-label="Collapse diff panel"]')).toBeInstanceOf(HTMLButtonElement);
+		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeInstanceOf(HTMLButtonElement);
+	});
+
+	it("collapses the diff panel from expanded mode and restores to unified mode", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const expandButton = container.querySelector('button[aria-label="Expand split diff view"]');
+		expect(expandButton).toBeInstanceOf(HTMLButtonElement);
+		if (!(expandButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected an expand diff button.");
+		}
+
+		await act(async () => {
+			expandButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			expandButton.click();
+		});
+
+		const collapseDiffButton = container.querySelector('button[aria-label="Collapse diff panel"]');
+		expect(collapseDiffButton).toBeInstanceOf(HTMLButtonElement);
+		if (!(collapseDiffButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected a collapse diff panel button in expanded mode.");
+		}
+
+		await act(async () => {
+			collapseDiffButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			collapseDiffButton.click();
+		});
+
+		expect(container.querySelector('button[aria-label="Collapse expanded diff view"]')).toBeNull();
+		expect(container.querySelector('button[aria-label="Show diff panel"]')).toBeInstanceOf(HTMLButtonElement);
+
+		const showButton = container.querySelector('button[aria-label="Show diff panel"]');
+		expect(showButton).toBeInstanceOf(HTMLButtonElement);
+		if (!(showButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected a show diff panel button.");
+		}
+
+		await act(async () => {
+			showButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+			showButton.click();
+		});
+
+		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeInstanceOf(HTMLButtonElement);
+		expect(container.querySelector('button[aria-label="Collapse expanded diff view"]')).toBeNull();
+	});
+
 	it("clears stale diff content when switching from all changes to last turn", async () => {
 		await act(async () => {
 			root.render(

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -1,5 +1,5 @@
 import type { DropResult } from "@hello-pangea/dnd";
-import { GitCompareArrows, Maximize2, Minimize2, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, GitCompareArrows, Maximize2, Minimize2, X } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -121,11 +121,15 @@ function WorkspaceChangesEmptyPanel({ title }: { title: string }): React.ReactEl
 function DiffToolbar({
 	mode,
 	onModeChange,
+	onCollapse,
+	modeButtonsDisabled = false,
 	isExpanded,
 	onToggleExpand,
 }: {
 	mode: RuntimeWorkspaceChangesMode;
 	onModeChange: (mode: RuntimeWorkspaceChangesMode) => void;
+	onCollapse: () => void;
+	modeButtonsDisabled?: boolean;
 	isExpanded: boolean;
 	onToggleExpand: () => void;
 }): React.ReactElement {
@@ -146,6 +150,7 @@ function DiffToolbar({
 					variant="ghost"
 					size="sm"
 					onClick={() => onModeChange("working_copy")}
+					disabled={modeButtonsDisabled}
 					className="h-5 rounded-sm text-xs"
 					style={
 						mode === "working_copy"
@@ -159,6 +164,7 @@ function DiffToolbar({
 					variant="ghost"
 					size="sm"
 					onClick={() => onModeChange("last_turn")}
+					disabled={modeButtonsDisabled}
 					className="h-5 rounded-sm text-xs"
 					style={
 						mode === "last_turn"
@@ -172,9 +178,17 @@ function DiffToolbar({
 			<Button
 				variant="ghost"
 				size="sm"
+				icon={<ChevronRight size={14} />}
+				onClick={onCollapse}
+				className="ml-auto h-5"
+				aria-label="Collapse diff panel"
+			/>
+			<Button
+				variant="ghost"
+				size="sm"
 				icon={isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
 				onClick={onToggleExpand}
-				className="ml-auto h-5"
+				className="h-5"
 				aria-label={isExpanded ? "Collapse split diff view" : "Expand split diff view"}
 			/>
 		</div>
@@ -298,6 +312,7 @@ export function CardDetailView({
 	const [diffComments, setDiffComments] = useState<Map<string, DiffLineComment>>(new Map());
 	const [diffMode, setDiffMode] = useState<RuntimeWorkspaceChangesMode>("working_copy");
 	const [isDiffExpanded, setIsDiffExpanded] = useState(false);
+	const [isDiffCollapsed, setIsDiffCollapsed] = useState(false);
 	const [agentPanelRatio, setAgentPanelRatio] = useState(DEFAULT_AGENT_PANEL_RATIO);
 	const [isResizing, setIsResizing] = useState(false);
 	const resizeDragRef = useRef<{ startX: number; startRatio: number; containerWidth: number } | null>(null);
@@ -487,12 +502,24 @@ export function CardDetailView({
 		setDiffMode("working_copy");
 	}, [selection.card.id]);
 
+	const handleCollapseDiffPanel = useCallback(() => {
+		setIsDiffExpanded(false);
+		setIsDiffCollapsed(true);
+	}, []);
+
+	const handleShowDiffPanel = useCallback(() => {
+		setIsDiffCollapsed(false);
+	}, []);
+
 	const handleToggleDiffExpand = useCallback(() => {
+		if (isDiffCollapsed) {
+			setIsDiffCollapsed(false);
+		}
 		if (!isDiffExpanded && bottomTerminalOpen) {
 			onBottomTerminalClose();
 		}
 		setIsDiffExpanded((previous) => !previous);
-	}, [bottomTerminalOpen, isDiffExpanded, onBottomTerminalClose]);
+	}, [bottomTerminalOpen, isDiffCollapsed, isDiffExpanded, onBottomTerminalClose]);
 
 	return (
 		<div
@@ -541,9 +568,19 @@ export function CardDetailView({
 					<div style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>{gitHistoryPanel}</div>
 				) : (
 					<>
-						<div ref={mainRowRef} style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>
+						<div
+							ref={mainRowRef}
+							style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden", position: "relative" }}
+						>
 							{!isDiffExpanded ? (
-								<div style={{ display: "flex", width: agentPanelPercent, minWidth: 0, minHeight: 0 }}>
+								<div
+									style={{
+										display: "flex",
+										width: isDiffCollapsed ? "100%" : agentPanelPercent,
+										minWidth: 0,
+										minHeight: 0,
+									}}
+								>
 									{showClineAgentChatPanel ? (
 										<ClineAgentChatPanel
 											taskId={selection.card.id}
@@ -609,7 +646,7 @@ export function CardDetailView({
 									)}
 								</div>
 							) : null}
-							{!isDiffExpanded ? (
+							{!isDiffExpanded && !isDiffCollapsed ? (
 								<div
 									role="separator"
 									aria-orientation="vertical"
@@ -634,61 +671,76 @@ export function CardDetailView({
 									/>
 								</div>
 							) : null}
-							<div
-								style={{
-									display: "flex",
-									width: isDiffExpanded ? "100%" : diffPanelPercent,
-									minWidth: 0,
-									minHeight: 0,
-									flexDirection: "column",
-								}}
-							>
-								{isRuntimeAvailable ? (
-								<DiffToolbar
-									mode={diffMode}
-									onModeChange={setDiffMode}
-									isExpanded={isDiffExpanded}
-									onToggleExpand={handleToggleDiffExpand}
-								/>
-							) : null}
-								<div style={{ display: "flex", flex: "1 1 0", minHeight: 0 }}>
-									{isWorkspaceChangesPending ? (
-										<WorkspaceChangesLoadingPanel panelFlex={fileTreePanelFlex} />
-									) : hasNoWorkspaceFileChanges ? (
-										<WorkspaceChangesEmptyPanel title={emptyDiffTitle} />
-									) : (
-										<>
-											<DiffViewerPanel
-												workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
-												selectedPath={selectedPath}
-												onSelectedPathChange={setSelectedPath}
-												viewMode={isDiffExpanded ? "split" : "unified"}
-												onAddToTerminal={
-													onAddReviewComments
-														? (formatted) => onAddReviewComments(selection.card.id, formatted)
-														: undefined
-												}
-												onSendToTerminal={
-													onSendReviewComments
-														? (formatted) => {
-																onSendReviewComments(selection.card.id, formatted);
-																setIsDiffExpanded(false);
-															}
-														: undefined
-												}
-												comments={diffComments}
-												onCommentsChange={setDiffComments}
-											/>
-											<FileTreePanel
-												workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
-												selectedPath={selectedPath}
-												onSelectPath={setSelectedPath}
-												panelFlex={fileTreePanelFlex}
-											/>
-										</>
-									)}
+							{isDiffCollapsed ? (
+								<div style={{ position: "absolute", top: 8, right: 8, zIndex: 3 }}>
+									<Button
+										variant="default"
+										size="sm"
+										icon={<ChevronLeft size={14} />}
+										onClick={handleShowDiffPanel}
+										className="h-7"
+										aria-label="Show diff panel"
+									>
+										Diff View
+									</Button>
 								</div>
-							</div>
+							) : (
+								<div
+									style={{
+										display: "flex",
+										width: isDiffExpanded ? "100%" : diffPanelPercent,
+										minWidth: 0,
+										minHeight: 0,
+										flexDirection: "column",
+									}}
+								>
+									<DiffToolbar
+										mode={diffMode}
+										onModeChange={setDiffMode}
+										onCollapse={handleCollapseDiffPanel}
+										modeButtonsDisabled={!isRuntimeAvailable}
+										isExpanded={isDiffExpanded}
+										onToggleExpand={handleToggleDiffExpand}
+									/>
+									<div style={{ display: "flex", flex: "1 1 0", minHeight: 0 }}>
+										{isWorkspaceChangesPending ? (
+											<WorkspaceChangesLoadingPanel panelFlex={fileTreePanelFlex} />
+										) : hasNoWorkspaceFileChanges ? (
+											<WorkspaceChangesEmptyPanel title={emptyDiffTitle} />
+										) : (
+											<>
+												<DiffViewerPanel
+													workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
+													selectedPath={selectedPath}
+													onSelectedPathChange={setSelectedPath}
+													viewMode={isDiffExpanded ? "split" : "unified"}
+													onAddToTerminal={
+														onAddReviewComments
+															? (formatted) => onAddReviewComments(selection.card.id, formatted)
+															: undefined
+													}
+													onSendToTerminal={
+														onSendReviewComments
+															? (formatted) => {
+																	onSendReviewComments(selection.card.id, formatted);
+																	setIsDiffExpanded(false);
+																}
+															: undefined
+													}
+													comments={diffComments}
+													onCommentsChange={setDiffComments}
+												/>
+												<FileTreePanel
+													workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
+													selectedPath={selectedPath}
+													onSelectPath={setSelectedPath}
+													panelFlex={fileTreePanelFlex}
+												/>
+											</>
+										)}
+									</div>
+								</div>
+							)}
 						</div>
 						{bottomTerminalOpen && bottomTerminalTaskId ? (
 							<ResizableBottomPane


### PR DESCRIPTION
## Summary
- add a dedicated collapsed state for the task detail diff panel
- let the agent panel expand when the diff is hidden and add an explicit Diff View restore button
- cover collapse/restore and expanded-mode interactions in card detail view tests

## Testing
- npm test -- src/components/card-detail-view.test.tsx
- pre-commit checks: npm run lint && npm run typecheck && npm run test


## Screenshots
<img width="180" height="127" alt="Screenshot 2026-03-20 at 1 38 07 PM" src="https://github.com/user-attachments/assets/8c1d8270-bc33-427e-bde6-b2079c2cbfb6" />
<img width="155" height="84" alt="Screenshot 2026-03-20 at 1 38 12 PM" src="https://github.com/user-attachments/assets/1b895cf0-983b-4839-a43d-928e662a022d" />