### PR TITLE
fix: sanitize MCP tool names to conform with Anthropic API constraints

### DIFF
--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -301,6 +301,18 @@ export function createSdkInMemoryMcpManager(options: SdkMcpManagerOptions): SdkM
 	return new managerConstructor(options);
 }
 
+/**
+ * Sanitize an MCP tool name so it conforms to the Anthropic API constraint
+ * (`^[a-zA-Z0-9_-]{1,128}$`).  The MCP spec allows dots and slashes in
+ * server/tool names, but the model API does not.
+ */
+function sanitizeMcpToolName(input: { serverName: string; toolName: string }): string {
+	return `${input.serverName}__${input.toolName}`.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+}
+
 export async function createSdkMcpTools(options: SdkCreateMcpToolsOptions): Promise<SdkMcpTool[]> {
-	return await createMcpTools(options);
+	return await createMcpTools({
+		...options,
+		nameTransform: options.nameTransform ?? sanitizeMcpToolName,
+	});
 }


### PR DESCRIPTION
- MCP server names can contain dots and slashes (e.g. github.com/cline/linear-mcp), which the MCP spec allows   
  (^[A-Za-z0-9._-]{1,128}$). However, the Anthropic API requires tool names to match ^[a-zA-Z0-9_-]{1,128}$ — no
  dots or slashes.                                                                                                
  - When the Cline SDK's default nameTransform produces tool names like github.com/cline/linear-mcp__list_issues,
  the API rejects every request with a 400 error, causing the Vercel AI Gateway to exhaust all provider fallbacks 
  (anthropic → vertex → bedrock).
  - Added a sanitizeMcpToolName transform in createSdkMcpTools that replaces invalid characters with underscores  
  and truncates to 128 chars, used as the default when no custom nameTransform is provided.                       
  
  Test plan                                                                                                       
                                                                                                                
  - Configure an MCP server with dots/slashes in its name (e.g. github.com/cline/linear-mcp)                      
  - Start a Cline task using an Anthropic model — verify it no longer fails with the tools.*.custom.name
  validation error                                                                                                
  - Verify MCP tool calls still route to the correct server and tool