### PR TITLE
Sanitize MCP tool names

### DIFF
--- a/src/cline-sdk/cline-mcp-runtime-service.ts
+++ b/src/cline-sdk/cline-mcp-runtime-service.ts
@@ -180,6 +180,39 @@ function hasAccessToken(tokens: Record<string, unknown> | undefined): boolean {
 	return typeof accessToken === "string" && accessToken.trim().length > 0;
 }
 
+/**
+ * Ensure MCP tool input schemas always include `type: "object"` and at least
+ * one declared property. Without a concrete property, some OpenAI-compatible
+ * streaming providers emit `arguments: ""` (empty string) for no-parameter
+ * tools. The agent framework treats an empty string as falsy and classifies
+ * the tool call as "missing_arguments", crashing the session. Adding a single
+ * optional no-op property forces the model to always send a parseable JSON
+ * argument chunk (at minimum `{}`), which the streaming layer serialises
+ * into a non-empty delta.
+ */
+function normalizeMcpToolInputSchema(raw: unknown): Record<string, unknown> {
+	const schema: Record<string, unknown> =
+		raw && typeof raw === "object" && !Array.isArray(raw)
+			? { ...(raw as Record<string, unknown>) }
+			: {};
+
+	if (!schema.type) {
+		schema.type = "object";
+	}
+
+	const properties = schema.properties as Record<string, unknown> | undefined;
+	if (!properties || Object.keys(properties).length === 0) {
+		schema.properties = {
+			_meta: {
+				type: "object",
+				description: "Reserved. Omit or pass an empty object.",
+			},
+		};
+	}
+
+	return schema;
+}
+
 function toMcpRegistration(server: RuntimeClineMcpServer): SdkMcpServerRegistration {
 	return {
 		name: server.name,
@@ -466,10 +499,7 @@ class RuntimeMcpServerClient implements SdkMcpServerClient {
 			return result.tools.map((tool) => ({
 				name: tool.name,
 				description: tool.description,
-				inputSchema:
-					tool.inputSchema && typeof tool.inputSchema === "object" && !Array.isArray(tool.inputSchema)
-						? (tool.inputSchema as Record<string, unknown>)
-						: {},
+				inputSchema: normalizeMcpToolInputSchema(tool.inputSchema),
 			}));
 		});
 	}

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -301,6 +301,20 @@ export function createSdkInMemoryMcpManager(options: SdkMcpManagerOptions): SdkM
 	return new managerConstructor(options);
 }
 
+/**
+ * Sanitize MCP tool names so they conform to the Claude API requirement:
+ * `^[a-zA-Z0-9_-]{1,128}$`. Server names often contain dots, slashes, or
+ * other characters (e.g. "github.com/org/repo") that the default
+ * `${serverName}__${toolName}` transform passes through verbatim.
+ */
+export function sanitizeMcpToolName(input: { serverName: string; toolName: string }): string {
+	const raw = `${input.serverName}__${input.toolName}`;
+	return raw.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+}
+
 export async function createSdkMcpTools(options: SdkCreateMcpToolsOptions): Promise<SdkMcpTool[]> {
-	return await createMcpTools(options);
+	return await createMcpTools({
+		...options,
+		nameTransform: options.nameTransform ?? sanitizeMcpToolName,
+	});
 }

--- a/test/runtime/cline-sdk/cline-sdk-provider-boundary.test.ts
+++ b/test/runtime/cline-sdk/cline-sdk-provider-boundary.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeMcpToolName } from "../../../src/cline-sdk/sdk-provider-boundary.js";
+
+const API_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+describe("sanitizeMcpToolName", () => {
+	it("passes through already-valid names unchanged", () => {
+		const result = sanitizeMcpToolName({ serverName: "my-server", toolName: "list_tools" });
+		expect(result).toBe("my-server__list_tools");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("replaces dots in server names with underscores", () => {
+		const result = sanitizeMcpToolName({ serverName: "github.com", toolName: "search" });
+		expect(result).toBe("github_com__search");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("replaces slashes in server names with underscores", () => {
+		const result = sanitizeMcpToolName({
+			serverName: "github.com/cline/linear-mcp",
+			toolName: "linear_create_issue",
+		});
+		expect(result).toBe("github_com_cline_linear-mcp__linear_create_issue");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("replaces spaces and special characters", () => {
+		const result = sanitizeMcpToolName({ serverName: "My Server (v2)", toolName: "do stuff!" });
+		expect(result).toBe("My_Server__v2___do_stuff_");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("preserves hyphens and underscores", () => {
+		const result = sanitizeMcpToolName({ serverName: "my_server-v2", toolName: "get-data_v3" });
+		expect(result).toBe("my_server-v2__get-data_v3");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("truncates names longer than 128 characters", () => {
+		const longServer = "a".repeat(100);
+		const longTool = "b".repeat(100);
+		const result = sanitizeMcpToolName({ serverName: longServer, toolName: longTool });
+		expect(result).toHaveLength(128);
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("handles empty server name", () => {
+		const result = sanitizeMcpToolName({ serverName: "", toolName: "my_tool" });
+		expect(result).toBe("__my_tool");
+		expect(result).toMatch(API_NAME_PATTERN);
+	});
+
+	it("handles the real-world github.com/cline/linear-mcp pattern from the original error", () => {
+		const result = sanitizeMcpToolName({
+			serverName: "github.com/cline/linear-mcp",
+			toolName: "linear_auth",
+		});
+		expect(result).toMatch(API_NAME_PATTERN);
+		expect(result).not.toContain(".");
+		expect(result).not.toContain("/");
+	});
+});


### PR DESCRIPTION
## Problem

When launching kanban with MCP servers configured (e.g. the Linear MCP server), the Cline SDK fails to start with two related errors:

1. **Invalid tool name**: `tools.5.custom.name: String should match pattern '"'"'^[a-zA-Z0-9_-]{1,128}$'"'"'`
   - MCP server names like `github.com/cline/linear-mcp` contain dots and slashes that get passed through verbatim into the tool name (`${serverName}__${toolName}`), violating the Claude API requirement.

2. **Missing arguments**: `One or more tool calls were invalid or missing required parameters (github_com_cline_linear-mcp__linear_get_user: missing arguments)`
   - Tools with no parameters (e.g. `linear_get_user`, `linear_get_teams`) have empty input schemas. The `cline` provider uses OpenAI-compatible streaming, which emits `arguments: ""` (empty string) for these tools. The agent framework treats empty string as falsy and classifies the tool call as `missing_arguments`, crashing the session.

## Root Cause

The OpenAI-compatible streaming format sends tool call arguments incrementally. For tools with no parameters (`input: {}`), the streaming layer may only emit a single delta with `arguments: ""` and no subsequent argument chunks. Unlike the native Anthropic handler (which defaults empty arguments to `{}`), the OpenAI tool processor passes through the empty string, which the agent framework rejects.

## Fix

Updated `normalizeMcpToolInputSchema` in `cline-mcp-runtime-service.ts` to:

1. **Ensure `type: "object"`** is always present in tool input schemas.
2. **Inject a `_meta` property** for schemas with no declared properties. This forces the model to always generate a non-empty JSON argument chunk in the stream (at minimum `{}`), preventing the "missing_arguments" classification.

The `sanitizeMcpToolName` function (already added in `sdk-provider-boundary.ts`) handles the tool name issue by replacing invalid characters with underscores and truncating to 128 chars.

## Testing
