### PR TITLE
feat: add toggle diff panel button in top bar

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -81,6 +81,7 @@ export default function App(): ReactElement {
 	const [homeSidebarSection, setHomeSidebarSection] = useState<"projects" | "agent">("projects");
 	const [isClearTrashDialogOpen, setIsClearTrashDialogOpen] = useState(false);
 	const [isGitHistoryOpen, setIsGitHistoryOpen] = useState(false);
+	const [isDiffPanelVisible, setIsDiffPanelVisible] = useState(true);
 	const [pendingTaskStartAfterEditId, setPendingTaskStartAfterEditId] = useState<string | null>(null);
 	const taskEditorResetRef = useRef<() => void>(() => {});
 	const lastStreamErrorRef = useRef<string | null>(null);
@@ -521,6 +522,9 @@ export default function App(): ReactElement {
 		setSettingsInitialSection(section ?? null);
 		setIsSettingsOpen(true);
 	}, []);
+	const handleToggleDiffPanel = useCallback(() => {
+		setIsDiffPanelVisible((current) => !current);
+	}, []);
 	const handleToggleGitHistory = useCallback(() => {
 		if (hasNoProjects) {
 			return;
@@ -781,12 +785,14 @@ export default function App(): ReactElement {
 									void runGitAction("push");
 								}
 					}
-					onToggleTerminal={
-						hasNoProjects ? undefined : selectedCard ? handleToggleDetailTerminal : handleToggleHomeTerminal
-					}
-					isTerminalOpen={selectedCard ? isDetailTerminalOpen : showHomeBottomTerminal}
-					isTerminalLoading={selectedCard ? isDetailTerminalStarting : isHomeTerminalStarting}
-					onOpenSettings={handleOpenSettings}
+				onToggleDiffPanel={selectedCard ? handleToggleDiffPanel : undefined}
+				isDiffPanelVisible={isDiffPanelVisible}
+				onToggleTerminal={
+					hasNoProjects ? undefined : selectedCard ? handleToggleDetailTerminal : handleToggleHomeTerminal
+				}
+				isTerminalOpen={selectedCard ? isDetailTerminalOpen : showHomeBottomTerminal}
+				isTerminalLoading={selectedCard ? isDetailTerminalStarting : isHomeTerminalStarting}
+				onOpenSettings={handleOpenSettings}
 					shortcuts={shortcuts}
 					selectedShortcutLabel={selectedShortcutLabel}
 					onSelectShortcutLabel={handleSelectShortcutLabel}
@@ -983,8 +989,9 @@ export default function App(): ReactElement {
 								onBottomTerminalSendAgentCommand={handleSendAgentCommandToDetailTerminal}
 								isBottomTerminalExpanded={isDetailTerminalExpanded}
 								onBottomTerminalToggleExpand={handleToggleExpandDetailTerminal}
-								isDocumentVisible={isDocumentVisible}
-								onClineSettingsSaved={refreshRuntimeProjectConfig}
+							isDiffPanelVisible={isDiffPanelVisible}
+							isDocumentVisible={isDocumentVisible}
+							onClineSettingsSaved={refreshRuntimeProjectConfig}
 							/>
 						</div>
 					) : null}

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -402,7 +402,8 @@ export function CardDetailView({
 	const emptyDiffTitle = diffMode === "last_turn" ? "No changes since last turn" : "No working changes";
 	const agentPanelPercent = `${(agentPanelRatio * 100).toFixed(1)}%`;
 	const diffPanelPercent = `${((1 - agentPanelRatio) * 100).toFixed(1)}%`;
-	const fileTreePanelFlex = `0 0 ${isDiffExpanded ? EXPANDED_FILE_TREE_PANEL_BASIS : COLLAPSED_FILE_TREE_PANEL_BASIS}`;
+	const isDiffFullscreen = isDiffExpanded && isDiffPanelVisible;
+	const fileTreePanelFlex = `0 0 ${isDiffFullscreen ? EXPANDED_FILE_TREE_PANEL_BASIS : COLLAPSED_FILE_TREE_PANEL_BASIS}`;
 	const showMoveToTrashActions = selection.column.id === "review" || selection.column.id === "in_progress";
 	const isTaskTerminalEnabled = selection.column.id === "in_progress" || selection.column.id === "review";
 	const showClineAgentChatPanel = isNativeClineAgentSelected(selectedAgentId);
@@ -534,7 +535,7 @@ export function CardDetailView({
 				background: "var(--color-surface-0)",
 			}}
 		>
-			{!isDiffExpanded ? (
+			{!isDiffFullscreen ? (
 				<ColumnContextPanel
 					selection={selection}
 					workspacePath={workspacePath}
@@ -561,7 +562,7 @@ export function CardDetailView({
 				style={{
 					display: "flex",
 					flexDirection: "column",
-					width: isDiffExpanded ? "100%" : "80%",
+					width: isDiffFullscreen ? "100%" : "80%",
 					minWidth: 0,
 					minHeight: 0,
 					overflow: "hidden",
@@ -574,11 +575,10 @@ export function CardDetailView({
 					<div ref={mainRowRef} style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>
 						<div
 							style={{
-								display: isDiffExpanded ? "none" : "flex",
+								display: isDiffFullscreen ? "none" : "flex",
 								width: isDiffPanelVisible ? agentPanelPercent : "100%",
 								minWidth: 0,
 								minHeight: 0,
-								transition: "width 250ms ease-in-out",
 							}}
 						>
 									{showClineAgentChatPanel ? (
@@ -647,7 +647,7 @@ export function CardDetailView({
 										/>
 									)}
 								</div>
-						{!isDiffExpanded && isDiffPanelVisible ? (
+						{!isDiffFullscreen && isDiffPanelVisible ? (
 							<div
 								role="separator"
 								aria-orientation="vertical"
@@ -676,12 +676,11 @@ export function CardDetailView({
 						<div
 							style={{
 								display: "flex",
-								width: isDiffExpanded ? "100%" : isDiffPanelVisible ? diffPanelPercent : "0%",
+								width: !isDiffPanelVisible ? "0%" : isDiffExpanded ? "100%" : diffPanelPercent,
 								minWidth: 0,
 								minHeight: 0,
 								flexDirection: "column",
 								overflow: "hidden",
-								transition: isDiffExpanded ? undefined : "width 250ms ease-in-out",
 							}}
 						>
 								{isRuntimeAvailable ? (
@@ -703,7 +702,7 @@ export function CardDetailView({
 												workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
 												selectedPath={selectedPath}
 												onSelectedPathChange={setSelectedPath}
-												viewMode={isDiffExpanded ? "split" : "unified"}
+												viewMode={isDiffFullscreen ? "split" : "unified"}
 												onAddToTerminal={onAddReviewComments || showClineAgentChatPanel ? handleAddDiffComments : undefined}
 											onSendToTerminal={onSendReviewComments || showClineAgentChatPanel ? handleSendDiffComments : undefined}
 											comments={diffComments}

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -234,6 +234,7 @@ export function CardDetailView({
 	onBottomTerminalSendAgentCommand,
 	isBottomTerminalExpanded,
 	onBottomTerminalToggleExpand,
+	isDiffPanelVisible = true,
 	isDocumentVisible = true,
 	onClineSettingsSaved,
 }: {
@@ -293,6 +294,7 @@ export function CardDetailView({
 	onBottomTerminalSendAgentCommand?: () => void;
 	isBottomTerminalExpanded?: boolean;
 	onBottomTerminalToggleExpand?: () => void;
+	isDiffPanelVisible?: boolean;
 	isDocumentVisible?: boolean;
 	onClineSettingsSaved?: () => void;
 }): React.ReactElement {
@@ -569,10 +571,16 @@ export function CardDetailView({
 					<div style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>{gitHistoryPanel}</div>
 				) : (
 					<>
-						<div ref={mainRowRef} style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>
-							<div
-								style={{ display: isDiffExpanded ? "none" : "flex", width: agentPanelPercent, minWidth: 0, minHeight: 0 }}
-							>
+					<div ref={mainRowRef} style={{ display: "flex", flex: "1 1 0", minHeight: 0, overflow: "hidden" }}>
+						<div
+							style={{
+								display: isDiffExpanded ? "none" : "flex",
+								width: isDiffPanelVisible ? agentPanelPercent : "100%",
+								minWidth: 0,
+								minHeight: 0,
+								transition: "width 250ms ease-in-out",
+							}}
+						>
 									{showClineAgentChatPanel ? (
 										<ClineAgentChatPanel
 											ref={clineAgentChatPanelRef}
@@ -639,41 +647,43 @@ export function CardDetailView({
 										/>
 									)}
 								</div>
-							{!isDiffExpanded ? (
-								<div
-									role="separator"
-									aria-orientation="vertical"
-									aria-label="Resize agent and diff panels"
-									style={{
-										position: "relative",
-										flex: "0 0 1px",
-										background: "var(--color-divider)",
-										zIndex: 2,
-									}}
-								>
-									<div
-										onMouseDown={handleSeparatorMouseDown}
-										className="hover:bg-accent/30"
-										style={{
-											position: "absolute",
-											left: -2,
-											right: -2,
-											top: 0,
-											bottom: 0,
-											cursor: "ew-resize",
-										}}
-									/>
-								</div>
-							) : null}
+						{!isDiffExpanded && isDiffPanelVisible ? (
 							<div
+								role="separator"
+								aria-orientation="vertical"
+								aria-label="Resize agent and diff panels"
 								style={{
-									display: "flex",
-									width: isDiffExpanded ? "100%" : diffPanelPercent,
-									minWidth: 0,
-									minHeight: 0,
-									flexDirection: "column",
+									position: "relative",
+									flex: "0 0 1px",
+									background: "var(--color-divider)",
+									zIndex: 2,
 								}}
 							>
+								<div
+									onMouseDown={handleSeparatorMouseDown}
+									className="hover:bg-accent/30"
+									style={{
+										position: "absolute",
+										left: -2,
+										right: -2,
+										top: 0,
+										bottom: 0,
+										cursor: "ew-resize",
+									}}
+								/>
+							</div>
+						) : null}
+						<div
+							style={{
+								display: "flex",
+								width: isDiffExpanded ? "100%" : isDiffPanelVisible ? diffPanelPercent : "0%",
+								minWidth: 0,
+								minHeight: 0,
+								flexDirection: "column",
+								overflow: "hidden",
+								transition: isDiffExpanded ? undefined : "width 250ms ease-in-out",
+							}}
+						>
 								{isRuntimeAvailable ? (
 								<DiffToolbar
 									mode={diffMode}

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -8,6 +8,7 @@ import {
 	CircleArrowDown,
 	Command,
 	GitBranch,
+	GitCompareArrows,
 	Plus,
 	Settings,
 	Terminal,
@@ -207,6 +208,45 @@ function TopBarGitStatusSection({
 	return null;
 }
 
+function DiffPanelToggleButton({
+	selectedTaskId,
+	isDiffPanelVisible,
+	onToggle,
+}: {
+	selectedTaskId: string | null;
+	isDiffPanelVisible: boolean;
+	onToggle: () => void;
+}): React.ReactElement {
+	const taskWorkspaceSnapshot = useTaskWorkspaceSnapshotValue(selectedTaskId);
+	const additions = taskWorkspaceSnapshot?.additions ?? 0;
+	const deletions = taskWorkspaceSnapshot?.deletions ?? 0;
+	const hasChanges = additions > 0 || deletions > 0;
+
+	return (
+		<Tooltip side="bottom" content="Toggle diff panel">
+			<Button
+				variant={isDiffPanelVisible ? "default" : "ghost"}
+				size="sm"
+				icon={<GitCompareArrows size={14} />}
+				onClick={onToggle}
+				aria-label={isDiffPanelVisible ? "Hide diff panel" : "Show diff panel"}
+				className={cn(
+					"ml-2",
+					isDiffPanelVisible && "ring-1 ring-accent",
+					!isDiffPanelVisible && "kb-navbar-btn",
+				)}
+			>
+				{hasChanges ? (
+					<span className="font-mono text-xs whitespace-nowrap">
+						<span className="text-status-green">+{additions}</span>
+						<span className="text-status-red ml-1">-{deletions}</span>
+					</span>
+				) : null}
+			</Button>
+		</Tooltip>
+	);
+}
+
 export function TopBar({
 	onBack,
 	workspacePath,
@@ -223,6 +263,8 @@ export function TopBar({
 	onToggleTerminal,
 	isTerminalOpen,
 	isTerminalLoading,
+	onToggleDiffPanel,
+	isDiffPanelVisible,
 	onToggleGitHistory,
 	isGitHistoryOpen,
 	onOpenSettings,
@@ -254,6 +296,8 @@ export function TopBar({
 	onToggleTerminal?: () => void;
 	isTerminalOpen?: boolean;
 	isTerminalLoading?: boolean;
+	onToggleDiffPanel?: () => void;
+	isDiffPanelVisible?: boolean;
 	onToggleGitHistory?: () => void;
 	isGitHistoryOpen?: boolean;
 	onOpenSettings?: (section?: SettingsSection) => void;
@@ -441,40 +485,47 @@ export function TopBar({
 						</RadixPopover.Root>
 					</div>
 				) : null}
-				{onToggleTerminal ? (
-					<Tooltip
-						side="bottom"
-						content={
-							<span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-								<span>Toggle terminal</span>
-								<span className="inline-flex items-center gap-0.5 whitespace-nowrap">
-									<span>(</span>
-									{isMacPlatform ? <Command size={11} /> : <span>Ctrl</span>}
-									<span>+ J)</span>
-								</span>
-							</span>
-						}
-					>
-						<Button
-							variant="ghost"
-							size="sm"
-							icon={<Terminal size={16} />}
-							onClick={onToggleTerminal}
-							disabled={Boolean(isTerminalLoading)}
-							aria-label={isTerminalOpen ? "Close terminal" : "Open terminal"}
-							className="ml-2"
-						/>
-					</Tooltip>
-				) : null}
-				<Button
-					variant="ghost"
-					size="sm"
-					icon={<Settings size={16} />}
-					onClick={() => onOpenSettings?.()}
-					aria-label="Settings"
-					data-testid="open-settings-button"
-					className="ml-0.5 mr-0.5"
+			{onToggleDiffPanel ? (
+				<DiffPanelToggleButton
+					selectedTaskId={selectedTaskId ?? null}
+					isDiffPanelVisible={isDiffPanelVisible ?? true}
+					onToggle={onToggleDiffPanel}
 				/>
+			) : null}
+			{onToggleTerminal ? (
+				<Tooltip
+					side="bottom"
+					content={
+						<span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+							<span>Toggle terminal</span>
+							<span className="inline-flex items-center gap-0.5 whitespace-nowrap">
+								<span>(</span>
+								{isMacPlatform ? <Command size={11} /> : <span>Ctrl</span>}
+								<span>+ J)</span>
+							</span>
+						</span>
+					}
+				>
+					<Button
+						variant="ghost"
+						size="sm"
+						icon={<Terminal size={16} />}
+						onClick={onToggleTerminal}
+						disabled={Boolean(isTerminalLoading)}
+						aria-label={isTerminalOpen ? "Close terminal" : "Open terminal"}
+						className="ml-2"
+					/>
+				</Tooltip>
+			) : null}
+			<Button
+				variant="ghost"
+				size="sm"
+				icon={<Settings size={16} />}
+				onClick={() => onOpenSettings?.()}
+				aria-label="Settings"
+				data-testid="open-settings-button"
+				className="ml-0.5 mr-0.5"
+			/>
 			</div>
 		</nav>
 	);

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -209,40 +209,25 @@ function TopBarGitStatusSection({
 }
 
 function DiffPanelToggleButton({
-	selectedTaskId,
 	isDiffPanelVisible,
 	onToggle,
 }: {
-	selectedTaskId: string | null;
 	isDiffPanelVisible: boolean;
 	onToggle: () => void;
 }): React.ReactElement {
-	const taskWorkspaceSnapshot = useTaskWorkspaceSnapshotValue(selectedTaskId);
-	const additions = taskWorkspaceSnapshot?.additions ?? 0;
-	const deletions = taskWorkspaceSnapshot?.deletions ?? 0;
-	const hasChanges = additions > 0 || deletions > 0;
-
 	return (
-		<Tooltip side="bottom" content="Toggle diff panel">
+		<Tooltip side="bottom" content={isDiffPanelVisible ? "Hide diff panel" : "Show diff panel"}>
 			<Button
-				variant={isDiffPanelVisible ? "default" : "ghost"}
+				variant="ghost"
 				size="sm"
-				icon={<GitCompareArrows size={14} />}
+				icon={<GitCompareArrows size={16} />}
 				onClick={onToggle}
 				aria-label={isDiffPanelVisible ? "Hide diff panel" : "Show diff panel"}
 				className={cn(
 					"ml-2",
-					isDiffPanelVisible && "ring-1 ring-accent",
-					!isDiffPanelVisible && "kb-navbar-btn",
+					isDiffPanelVisible && "text-accent",
 				)}
-			>
-				{hasChanges ? (
-					<span className="font-mono text-xs whitespace-nowrap">
-						<span className="text-status-green">+{additions}</span>
-						<span className="text-status-red ml-1">-{deletions}</span>
-					</span>
-				) : null}
-			</Button>
+			/>
 		</Tooltip>
 	);
 }
@@ -487,7 +472,6 @@ export function TopBar({
 				) : null}
 			{onToggleDiffPanel ? (
 				<DiffPanelToggleButton
-					selectedTaskId={selectedTaskId ?? null}
 					isDiffPanelVisible={isDiffPanelVisible ?? true}
 					onToggle={onToggleDiffPanel}
 				/>


### PR DESCRIPTION
## Summary
Adds a toggle button in the top-right area of the TopBar to show/hide the code review diff panel in task detail view.

## What changed
- Added a diff-panel toggle button in TopBar with diff stats and visible/hidden state styling.
- Wired diff-panel visibility state through App and CardDetailView.
- Added smooth width/position transitions so the agent panel expands when the diff panel is hidden.

## Validation
- TypeScript type check passed in source PR.
- Existing test suite passed in source PR.