### PR TITLE
Remove Empty Comments Before Adding New Ones

### DIFF
--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -675,6 +675,12 @@ export function DiffViewerPanel({
 				return;
 			}
 			const next = new Map(comments);
+			// Remove any existing empty comment boxes before opening a new one
+			for (const [existingKey, existingComment] of next) {
+				if (existingComment.comment.trim() === "") {
+					next.delete(existingKey);
+				}
+			}
 			next.set(key, {
 				filePath,
 				lineNumber,


### PR DESCRIPTION
Prevents users from opening multiple empty comment boxes.

**Before**

https://github.com/user-attachments/assets/34f8b798-e957-41bf-96dc-5dcf756c15b6



**After**

https://github.com/user-attachments/assets/c71bdc62-558c-4cc7-8d12-9de9f0287a54





