### PR TITLE
Resume Session On Restart (Claude/Codex)

### DIFF
--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -615,10 +615,10 @@ export class TerminalSessionManager implements TerminalSessionService {
 			return cloneSummary(entry.summary);
 		}
 
+		// Preserve agentId and workspacePath so the frontend can detect which agent
+		// was running and auto-resume the session with --continue/--resume.
 		const summary = updateSummary(entry, {
 			state: "idle",
-			agentId: null,
-			workspacePath: null,
 			pid: null,
 			startedAt: null,
 			lastOutputAt: null,

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -79,8 +79,10 @@ describe("TerminalSessionManager", () => {
 
 		expect(recovered?.state).toBe("idle");
 		expect(recovered?.pid).toBeNull();
-		expect(recovered?.agentId).toBeNull();
-		expect(recovered?.workspacePath).toBeNull();
+		// agentId and workspacePath are preserved so the frontend can auto-resume
+		// the session with --continue/--resume to reload conversation history.
+		expect(recovered?.agentId).toBe("claude");
+		expect(recovered?.workspacePath).toBe("/tmp/worktree");
 		expect(recovered?.reviewReason).toBeNull();
 	});
 

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -54,6 +54,7 @@ import { useStartupOnboarding } from "@/hooks/use-startup-onboarding";
 import { useTerminalPanels } from "@/hooks/use-terminal-panels";
 import { useWorkspaceSync } from "@/hooks/use-workspace-sync";
 import {
+	isNativeClineAgentSelected,
 	isTaskAgentSetupSatisfied,
 	selectLatestTaskChatMessageForTask,
 	selectTaskChatMessagesForTask,
@@ -632,6 +633,39 @@ export default function App(): ReactElement {
 	const detailSession = selectedCard
 		? (sessions[selectedCard.card.id] ?? createIdleTaskSession(selectedCard.card.id))
 		: null;
+
+	// Auto-resume stale terminal-agent sessions after a kanban restart.
+	// When a task was running with a terminal agent (claude, codex, etc.) but the
+	// runtime restarted, the session becomes idle with a preserved agentId.
+	// Re-launching the agent with resumeFromTrash triggers --continue/--resume
+	// so the agent replays its conversation history natively.
+	const autoResumedTaskIdsRef = useRef<Set<string>>(new Set());
+	useEffect(() => {
+		if (!selectedCard || !detailSession) {
+			return;
+		}
+		const { agentId, state, pid } = detailSession;
+		// Only auto-resume terminal agents (not cline which uses the native SDK).
+		if (!agentId || isNativeClineAgentSelected(agentId)) {
+			return;
+		}
+		// Only resume idle sessions with no live process (stale after restart).
+		if (state !== "idle" || pid !== null) {
+			return;
+		}
+		// Only for tasks in active columns.
+		const columnId = selectedCard.column.id;
+		if (columnId !== "in_progress" && columnId !== "review") {
+			return;
+		}
+		// Prevent re-triggering for the same task.
+		if (autoResumedTaskIdsRef.current.has(selectedCard.card.id)) {
+			return;
+		}
+		autoResumedTaskIdsRef.current.add(selectedCard.card.id);
+		void startTaskSession(selectedCard.card, { resumeFromTrash: true });
+	}, [detailSession, selectedCard, startTaskSession]);
+
 	const detailTerminalSummary = detailTerminalTaskId ? (sessions[detailTerminalTaskId] ?? null) : null;
 	const detailTerminalSubtitle = useMemo(() => {
 		if (!selectedCard) {


### PR DESCRIPTION
Reload terminal-agent conversation history after kanban restarts
