### PR TITLE
feat(featurebase): switch to JWT auth and restore feedback widget

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -20,6 +20,7 @@ import {
 	addSdkCustomProvider,
 	fetchSdkClineAccountProfile,
 	fetchSdkClineUserRemoteConfig,
+	fetchSdkFeaturebaseToken,
 	fetchSdkOrgData,
 	getLastUsedSdkProviderSettings,
 	getSdkProviderSettings,
@@ -457,6 +458,41 @@ export function createClineProviderService() {
 					error: toErrorMessage(error),
 				};
 			}
+		},
+
+		async getFeaturebaseToken(): Promise<{ featurebaseJwt: string }> {
+			const selectedSettings = getSelectedProviderSettings();
+			if (!selectedSettings) {
+				throw new Error("No provider settings configured.");
+			}
+
+			const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
+			if (normalizedProviderId !== "cline") {
+				throw new Error("Featurebase token requires a Cline provider.");
+			}
+
+			const tryFetchToken = async (settings: SdkProviderSettings): Promise<{ featurebaseJwt: string }> => {
+				const rawAccessToken = settings.auth?.accessToken?.trim() ?? "";
+				if (!rawAccessToken) {
+					throw new Error("No access token configured for Cline provider.");
+				}
+				return await fetchSdkFeaturebaseToken({
+					apiBaseUrl: settings.baseUrl?.trim() || DEFAULT_CLINE_API_BASE_URL,
+					accessToken: ensureWorkosPrefix(rawAccessToken),
+				});
+			};
+
+			try {
+				return await tryFetchToken(selectedSettings);
+			} catch {
+				// Retry once after OAuth refresh.
+			}
+
+			const oauthResolution = await refreshManagedOauthSettings(selectedSettings);
+			if (oauthResolution?.settings) {
+				return await tryFetchToken(oauthResolution.settings);
+			}
+			throw new Error("Failed to fetch Featurebase token.");
 		},
 
 		async resolveLaunchConfig(): Promise<ResolvedClineLaunchConfig> {

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -366,6 +366,18 @@ export async function fetchSdkOrgData(input: ApiRequestParams & { organizatinId:
 	return await accountService.fetchOrganization(input.organizatinId);
 }
 
+export async function fetchSdkFeaturebaseToken(input: ApiRequestParams): Promise<{ featurebaseJwt: string }> {
+	const accountService = new ClineAccountService({
+		apiBaseUrl: input.apiBaseUrl,
+		getAuthToken: async () => input.accessToken,
+	});
+	const response = await accountService.fetchFeaturebaseToken();
+	if (!response) {
+		throw new Error("Failed to fetch Featurebase token from SDK");
+	}
+	return { featurebaseJwt: response.featurebaseJwt };
+}
+
 export async function fetchSdkClineUserRemoteConfig(input: ApiRequestParams): Promise<SdkUserRemoteConfigResponse> {
 	const accountServiceConstructor = ClineAccountService;
 	if (!accountServiceConstructor) {

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -543,6 +543,11 @@ export const runtimeClineKanbanAccessResponseSchema = z.object({
 });
 export type RuntimeClineKanbanAccessResponse = z.infer<typeof runtimeClineKanbanAccessResponseSchema>;
 
+export const runtimeFeaturebaseTokenResponseSchema = z.object({
+	featurebaseJwt: z.string(),
+});
+export type RuntimeFeaturebaseTokenResponse = z.infer<typeof runtimeFeaturebaseTokenResponseSchema>;
+
 export const runtimeClineProviderCatalogItemSchema = z.object({
 	id: z.string(),
 	name: z.string(),

--- a/src/trpc/app-router.ts
+++ b/src/trpc/app-router.ts
@@ -28,6 +28,7 @@ import type {
 	RuntimeConfigResponse,
 	RuntimeConfigSaveRequest,
 	RuntimeDebugResetAllStateResponse,
+	RuntimeFeaturebaseTokenResponse,
 	RuntimeGitCheckoutRequest,
 	RuntimeGitCheckoutResponse,
 	RuntimeGitCommitDiffRequest,
@@ -105,6 +106,7 @@ import {
 	runtimeConfigResponseSchema,
 	runtimeConfigSaveRequestSchema,
 	runtimeDebugResetAllStateResponseSchema,
+	runtimeFeaturebaseTokenResponseSchema,
 	runtimeGitCheckoutRequestSchema,
 	runtimeGitCheckoutResponseSchema,
 	runtimeGitCommitDiffRequestSchema,
@@ -220,6 +222,7 @@ export interface RuntimeTrpcContext {
 		) => Promise<RuntimeClineProviderCatalogResponse>;
 		getClineAccountProfile: (scope: RuntimeTrpcWorkspaceScope | null) => Promise<RuntimeClineAccountProfileResponse>;
 		getClineKanbanAccess: (scope: RuntimeTrpcWorkspaceScope | null) => Promise<RuntimeClineKanbanAccessResponse>;
+		getFeaturebaseToken: (scope: RuntimeTrpcWorkspaceScope | null) => Promise<RuntimeFeaturebaseTokenResponse>;
 		getClineProviderModels: (
 			scope: RuntimeTrpcWorkspaceScope | null,
 			input: RuntimeClineProviderModelsRequest,
@@ -456,6 +459,9 @@ export const runtimeAppRouter = t.router({
 		}),
 		getClineKanbanAccess: t.procedure.output(runtimeClineKanbanAccessResponseSchema).query(async ({ ctx }) => {
 			return await ctx.runtimeApi.getClineKanbanAccess(ctx.workspaceScope);
+		}),
+		getFeaturebaseToken: t.procedure.output(runtimeFeaturebaseTokenResponseSchema).query(async ({ ctx }) => {
+			return await ctx.runtimeApi.getFeaturebaseToken(ctx.workspaceScope);
 		}),
 		getClineProviderModels: t.procedure
 			.input(runtimeClineProviderModelsRequestSchema)

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -452,6 +452,9 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		getClineKanbanAccess: async (_workspaceScope) => {
 			return await clineProviderService.getClineKanbanAccess();
 		},
+		getFeaturebaseToken: async (_workspaceScope) => {
+			return await clineProviderService.getFeaturebaseToken();
+		},
 		getClineProviderModels: async (_workspaceScope, input) => {
 			const body = parseClineProviderModelsRequest(input);
 			return await clineProviderService.getProviderModels(body.providerId);

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -43,6 +43,7 @@ const clineAccountMocks = vi.hoisted(() => ({
 	fetchMe: vi.fn(),
 	fetchRemoteConfig: vi.fn(),
 	fetchOrganization: vi.fn(),
+	fetchFeaturebaseToken: vi.fn(),
 	constructedOptions: [] as Array<{ apiBaseUrl: string; getAuthToken: () => Promise<string | undefined | null> }>,
 }));
 
@@ -81,6 +82,7 @@ vi.mock("@clinebot/core/node", () => ({
 		fetchMe = clineAccountMocks.fetchMe;
 		fetchRemoteConfig = clineAccountMocks.fetchRemoteConfig;
 		fetchOrganization = clineAccountMocks.fetchOrganization;
+		fetchFeaturebaseToken = clineAccountMocks.fetchFeaturebaseToken;
 	},
 	ProviderSettingsManager: class {
 		saveProviderSettings = oauthMocks.saveProviderSettings;
@@ -2004,5 +2006,139 @@ describe("createRuntimeApi startTaskSession", () => {
 			}
 			rmSync(tempHome, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("createRuntimeApi getFeaturebaseToken", () => {
+	beforeEach(() => {
+		oauthMocks.getProviderSettings.mockReset();
+		oauthMocks.getLastUsedProviderSettings.mockReset();
+		oauthMocks.getValidClineCredentials.mockReset();
+		oauthMocks.saveProviderSettings.mockReset();
+		clineAccountMocks.fetchFeaturebaseToken.mockReset();
+		clineAccountMocks.constructedOptions.length = 0;
+	});
+
+	it("returns JWT from SDK method", async () => {
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => ({}) as never),
+			getScopedClineTaskSessionService: vi.fn(async () => createClineTaskSessionServiceMock() as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+		setSelectedProviderSettings({
+			provider: "cline",
+			auth: {
+				accessToken: "workos:oauth-access",
+				refreshToken: "oauth-refresh",
+				accountId: "acct-1",
+				expiresAt: 1_700_000_000_000,
+			},
+		});
+		clineAccountMocks.fetchFeaturebaseToken.mockResolvedValueOnce({
+			featurebaseJwt: "jwt-token-123",
+		});
+
+		const response = await api.getFeaturebaseToken({
+			workspaceId: "workspace-1",
+			workspacePath: "/tmp/repo",
+		});
+
+		expect(response).toEqual({ featurebaseJwt: "jwt-token-123" });
+	});
+
+	it("throws when no provider settings configured", async () => {
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => ({}) as never),
+			getScopedClineTaskSessionService: vi.fn(async () => createClineTaskSessionServiceMock() as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+		setSelectedProviderSettings(null);
+
+		await expect(
+			api.getFeaturebaseToken({
+				workspaceId: "workspace-1",
+				workspacePath: "/tmp/repo",
+			}),
+		).rejects.toThrow("Failed to fetch Featurebase token.");
+	});
+
+	it("throws when provider is not cline", async () => {
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => ({}) as never),
+			getScopedClineTaskSessionService: vi.fn(async () => createClineTaskSessionServiceMock() as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+		setSelectedProviderSettings({
+			provider: "oca",
+			auth: {
+				accessToken: "some-token",
+				refreshToken: "some-refresh",
+			},
+		});
+
+		await expect(
+			api.getFeaturebaseToken({
+				workspaceId: "workspace-1",
+				workspacePath: "/tmp/repo",
+			}),
+		).rejects.toThrow("Featurebase token requires a Cline provider.");
+	});
+
+	it("retries after OAuth refresh when first attempt fails", async () => {
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => ({}) as never),
+			getScopedClineTaskSessionService: vi.fn(async () => createClineTaskSessionServiceMock() as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+		setSelectedProviderSettings({
+			provider: "cline",
+			auth: {
+				accessToken: "workos:stale-access",
+				refreshToken: "oauth-refresh",
+				accountId: "acct-1",
+				expiresAt: 1_700_000_000_000,
+			},
+		});
+
+		// First attempt fails (e.g. expired token)
+		clineAccountMocks.fetchFeaturebaseToken.mockRejectedValueOnce(new Error("Unauthorized"));
+
+		// OAuth refresh returns fresh credentials
+		oauthMocks.getValidClineCredentials.mockResolvedValueOnce({
+			access: "fresh-access",
+			refresh: "fresh-refresh",
+			expires: 1_800_000_000_000,
+			accountId: "acct-1",
+		});
+
+		// Second attempt succeeds with refreshed token
+		clineAccountMocks.fetchFeaturebaseToken.mockResolvedValueOnce({
+			featurebaseJwt: "refreshed-jwt-456",
+		});
+
+		const response = await api.getFeaturebaseToken({
+			workspaceId: "workspace-1",
+			workspacePath: "/tmp/repo",
+		});
+
+		expect(response).toEqual({ featurebaseJwt: "refreshed-jwt-456" });
+		expect(clineAccountMocks.fetchFeaturebaseToken).toHaveBeenCalledTimes(2);
+		expect(oauthMocks.getValidClineCredentials).toHaveBeenCalledTimes(1);
 	});
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -39,6 +39,7 @@ import { useAppHotkeys } from "@/hooks/use-app-hotkeys";
 import { useBoardInteractions } from "@/hooks/use-board-interactions";
 import { useDebugTools } from "@/hooks/use-debug-tools";
 import { useDocumentVisibility } from "@/hooks/use-document-visibility";
+import { useFeaturebaseFeedbackWidget } from "@/hooks/use-featurebase-feedback-widget";
 import { useGitActions } from "@/hooks/use-git-actions";
 import { useHomeSidebarAgentPanel } from "@/hooks/use-home-sidebar-agent-panel";
 import { useKanbanAccessGate } from "@/hooks/use-kanban-access-gate";
@@ -140,6 +141,10 @@ export default function App(): ReactElement {
 	const settingsWorkspaceId = navigationCurrentProjectId ?? currentProjectId;
 	const { config: settingsRuntimeProjectConfig, refresh: refreshSettingsRuntimeProjectConfig } =
 		useRuntimeProjectConfig(settingsWorkspaceId);
+	const featurebaseFeedbackState = useFeaturebaseFeedbackWidget({
+		workspaceId: settingsWorkspaceId,
+		clineProviderSettings: settingsRuntimeProjectConfig?.clineProviderSettings ?? null,
+	});
 	const {
 		isStartupOnboardingDialogOpen,
 		handleOpenStartupOnboardingDialog,
@@ -757,6 +762,9 @@ export default function App(): ReactElement {
 					onAddProject={() => {
 						void handleAddProject();
 					}}
+					selectedAgentId={settingsRuntimeProjectConfig?.selectedAgentId ?? null}
+					clineProviderSettings={settingsRuntimeProjectConfig?.clineProviderSettings ?? null}
+					featurebaseFeedbackState={featurebaseFeedbackState}
 				/>
 			) : null}
 			<div className="flex flex-col flex-1 min-w-0 overflow-hidden">

--- a/web-ui/src/components/project-navigation-panel.test.tsx
+++ b/web-ui/src/components/project-navigation-panel.test.tsx
@@ -2,9 +2,12 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { ProjectNavigationPanel } from "@/components/project-navigation-panel";
-import type { RuntimeProjectSummary } from "@/runtime/types";
+import { FeedbackCard, ProjectNavigationPanel } from "@/components/project-navigation-panel";
+import type { FeaturebaseFeedbackState } from "@/hooks/use-featurebase-feedback-widget";
+import type { RuntimeClineProviderSettings, RuntimeProjectSummary } from "@/runtime/types";
 import { LocalStorageKey } from "@/storage/local-storage-store";
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
 
 const SIDEBAR_MIN_EXPANDED_WIDTH = 200;
 const SIDEBAR_MAX_EXPANDED_WIDTH = 600;
@@ -24,6 +27,33 @@ const PROJECTS: RuntimeProjectSummary[] = [
 	},
 ];
 
+const defaultClineProviderSettings: RuntimeClineProviderSettings = {
+	providerId: null,
+	modelId: null,
+	baseUrl: null,
+	apiKeyConfigured: false,
+	oauthProvider: null,
+	oauthAccessTokenConfigured: false,
+	oauthRefreshTokenConfigured: false,
+	oauthAccountId: null,
+	oauthExpiresAt: null,
+};
+
+const authenticatedClineSettings: RuntimeClineProviderSettings = {
+	...defaultClineProviderSettings,
+	oauthProvider: "cline",
+	oauthAccessTokenConfigured: true,
+	oauthRefreshTokenConfigured: true,
+	oauthAccountId: "acc-1",
+};
+
+const tokensOnlySettings: RuntimeClineProviderSettings = {
+	...defaultClineProviderSettings,
+	oauthProvider: null,
+	oauthAccessTokenConfigured: true,
+	oauthRefreshTokenConfigured: true,
+};
+
 function getSidebar(container: HTMLElement): HTMLElement {
 	const sidebar = container.querySelector("aside");
 	if (!sidebar) {
@@ -39,6 +69,8 @@ function getResizeHandle(container: HTMLElement): HTMLElement {
 	}
 	return handle as HTMLElement;
 }
+
+// ─── ProjectNavigationPanel width persistence ────────────────────────────────
 
 describe("ProjectNavigationPanel width persistence", () => {
 	let container: HTMLDivElement;
@@ -147,5 +179,161 @@ describe("ProjectNavigationPanel width persistence", () => {
 		renderPanel();
 		const sidebar = getSidebar(container);
 		expect(sidebar.style.width).toBe(`${expectedResizedWidth}px`);
+	});
+});
+
+// ─── FeedbackCard ────────────────────────────────────────────────────────────
+
+describe("FeedbackCard", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	function getFeedbackButton(): HTMLButtonElement | null {
+		const buttons = container.querySelectorAll("button");
+		for (const btn of buttons) {
+			if (btn.textContent?.includes("Share Feedback")) {
+				return btn;
+			}
+		}
+		return null;
+	}
+
+	it("renders nothing when selected agent is not Cline", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "ready" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"claude" as never}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders nothing when not authenticated", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "ready" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={defaultClineProviderSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders nothing when tokens present but oauthProvider is not cline", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "ready" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={tokensOnlySettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders nothing when Featurebase is idle", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "idle" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders nothing when Featurebase is loading", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "loading" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders nothing when Featurebase has error", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "error" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("renders enabled Share Feedback when fully authenticated and Featurebase is ready", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "ready" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		const button = getFeedbackButton();
+		expect(button).toBeTruthy();
+		expect(button!.disabled).toBe(false);
+		expect(button!.textContent).toContain("Share Feedback");
+	});
+
+	it("renders data-featurebase-feedback attribute on the Share Feedback button (regression)", () => {
+		const fbState: FeaturebaseFeedbackState = { authState: "ready" };
+		act(() => {
+			root.render(
+				<FeedbackCard
+					selectedAgentId={"cline"}
+					clineProviderSettings={authenticatedClineSettings}
+					featurebaseFeedbackState={fbState}
+				/>,
+			);
+		});
+		const button = getFeedbackButton();
+		expect(button).toBeTruthy();
+		expect(button!.hasAttribute("data-featurebase-feedback")).toBe(true);
+	});
+
+	it("renders nothing when featurebaseFeedbackState is undefined", () => {
+		act(() => {
+			root.render(<FeedbackCard selectedAgentId={"cline"} clineProviderSettings={authenticatedClineSettings} />);
+		});
+		expect(container.innerHTML).toBe("");
 	});
 });

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -17,7 +17,9 @@ import {
 } from "@/components/ui/dialog";
 import { Kbd } from "@/components/ui/kbd";
 import { Spinner } from "@/components/ui/spinner";
-import type { RuntimeProjectSummary } from "@/runtime/types";
+import type { FeaturebaseFeedbackState } from "@/hooks/use-featurebase-feedback-widget";
+import { isClineOauthAuthenticated, isNativeClineAgentSelected } from "@/runtime/native-agent";
+import type { RuntimeAgentId, RuntimeClineProviderSettings, RuntimeProjectSummary } from "@/runtime/types";
 import { LocalStorageKey, readLocalStorageItem, writeLocalStorageItem } from "@/storage/local-storage-store";
 import { formatPathForDisplay } from "@/utils/path-display";
 import { isMacPlatform, modifierKeyLabel } from "@/utils/platform";
@@ -80,6 +82,9 @@ export function ProjectNavigationPanel({
 	onSelectProject,
 	onRemoveProject,
 	onAddProject,
+	selectedAgentId = null,
+	clineProviderSettings = null,
+	featurebaseFeedbackState,
 }: {
 	projects: RuntimeProjectSummary[];
 	isLoadingProjects?: boolean;
@@ -92,6 +97,9 @@ export function ProjectNavigationPanel({
 	onSelectProject: (projectId: string) => void;
 	onRemoveProject: (projectId: string) => Promise<boolean>;
 	onAddProject: () => void;
+	selectedAgentId?: RuntimeAgentId | null;
+	clineProviderSettings?: RuntimeClineProviderSettings | null;
+	featurebaseFeedbackState?: FeaturebaseFeedbackState;
 }): React.ReactElement {
 	const sortedProjects = [...projects].sort((a, b) => a.path.localeCompare(b.path));
 
@@ -344,6 +352,11 @@ export function ProjectNavigationPanel({
 						) : null}
 					</div>
 					<ShortcutsCard />
+					<FeedbackCard
+						selectedAgentId={selectedAgentId}
+						clineProviderSettings={clineProviderSettings}
+						featurebaseFeedbackState={featurebaseFeedbackState}
+					/>
 				</>
 			) : (
 				<div className="flex flex-1 min-h-0 flex-col">
@@ -485,6 +498,40 @@ function ShortcutsCard(): React.ReactElement {
 					</Collapsible.Trigger>
 				</Collapsible.Root>
 			</div>
+		</div>
+	);
+}
+
+export function FeedbackCard({
+	selectedAgentId,
+	clineProviderSettings,
+	featurebaseFeedbackState,
+}: {
+	selectedAgentId?: RuntimeAgentId | null;
+	clineProviderSettings?: RuntimeClineProviderSettings | null;
+	featurebaseFeedbackState?: FeaturebaseFeedbackState;
+}): React.ReactElement | null {
+	const isClineAgent = isNativeClineAgentSelected(selectedAgentId);
+	const isAuthenticated = isClineOauthAuthenticated(clineProviderSettings);
+	const isReady = (featurebaseFeedbackState?.authState ?? "idle") === "ready";
+
+	// Only show for authenticated Cline OAuth users when Featurebase is ready.
+	// Silent degradation: idle / loading / error all render nothing.
+	if (!isClineAgent || !isAuthenticated || !isReady) {
+		return null;
+	}
+
+	return (
+		<div style={{ padding: "0 12px 10px" }}>
+			<Button
+				fill
+				size="sm"
+				variant="ghost"
+				className="!border !border-border-bright bg-transparent text-text-secondary hover:bg-surface-2 hover:text-text-primary"
+				data-featurebase-feedback
+			>
+				Share Feedback
+			</Button>
 		</div>
 	);
 }

--- a/web-ui/src/hooks/use-featurebase-feedback-widget.test.tsx
+++ b/web-ui/src/hooks/use-featurebase-feedback-widget.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
+import type { FeaturebaseFeedbackState } from "@/hooks/use-featurebase-feedback-widget";
 import type { RuntimeClineProviderSettings } from "@/runtime/types";
 
 const defaultClineProviderSettings: RuntimeClineProviderSettings = {
@@ -16,16 +16,36 @@ const defaultClineProviderSettings: RuntimeClineProviderSettings = {
 	oauthExpiresAt: null,
 };
 
+const authenticatedClineSettings: RuntimeClineProviderSettings = {
+	...defaultClineProviderSettings,
+	oauthProvider: "cline",
+	oauthAccessTokenConfigured: true,
+	oauthRefreshTokenConfigured: true,
+	oauthAccountId: "acc-1",
+};
+
+const tokensOnlySettings: RuntimeClineProviderSettings = {
+	...defaultClineProviderSettings,
+	oauthProvider: null,
+	oauthAccessTokenConfigured: true,
+	oauthRefreshTokenConfigured: true,
+};
+
 async function importFeaturebaseModule() {
-	const fetchClineAccountProfileMock = vi.fn();
+	const fetchFeaturebaseTokenMock = vi.fn();
 	vi.resetModules();
 	vi.doMock("@/runtime/runtime-config-query", () => ({
-		fetchClineAccountProfile: fetchClineAccountProfileMock,
+		fetchFeaturebaseToken: fetchFeaturebaseTokenMock,
+	}));
+	const nativeAgent = await import("@/runtime/native-agent");
+	vi.doMock("@/runtime/native-agent", () => ({
+		...nativeAgent,
+		isClineOauthAuthenticated: nativeAgent.isClineOauthAuthenticated,
 	}));
 	const module = await import("@/hooks/use-featurebase-feedback-widget");
 	return {
 		module,
-		fetchClineAccountProfileMock,
+		fetchFeaturebaseTokenMock,
 	};
 }
 
@@ -62,11 +82,8 @@ describe("useFeaturebaseFeedbackWidget", () => {
 			previousActEnvironment;
 	});
 
-	it("initializes the feedback widget even if the SDK load event fires immediately", async () => {
-		const { module } = await importFeaturebaseModule();
-		const featurebaseMock = vi.fn();
+	function mockSdkLoad(featurebaseMock: ReturnType<typeof vi.fn>) {
 		const originalAppendChild = document.head.appendChild.bind(document.head);
-
 		vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
 			const result = originalAppendChild(node);
 			if (node instanceof HTMLScriptElement && node.id === "featurebase-sdk") {
@@ -75,6 +92,12 @@ describe("useFeaturebaseFeedbackWidget", () => {
 			}
 			return result;
 		});
+	}
+
+	it("initializes the feedback widget on mount", async () => {
+		const { module } = await importFeaturebaseModule();
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
 
 		function HookHarness(): null {
 			module.useFeaturebaseFeedbackWidget({
@@ -90,37 +113,27 @@ describe("useFeaturebaseFeedbackWidget", () => {
 			await Promise.resolve();
 		});
 
-		expect(featurebaseMock).toHaveBeenCalledWith(
-			"initialize_feedback_widget",
+		const initCall = featurebaseMock.mock.calls.find((call: unknown[]) => call[0] === "initialize_feedback_widget");
+		expect(initCall).toBeTruthy();
+		expect(initCall?.[1]).toEqual(
 			expect.objectContaining({
 				organization: "cline",
 				theme: "dark",
 				locale: "en",
 				metadata: { app: "kanban" },
 			}),
-			expect.any(Function),
 		);
 	});
 
-	it("replays an early open request after the widget reports ready", async () => {
-		vi.useFakeTimers();
-		const { module } = await importFeaturebaseModule();
+	it("returns idle state when unauthenticated", async () => {
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
 		const featurebaseMock = vi.fn();
-		const postMessageMock = vi.spyOn(window, "postMessage");
-		const originalAppendChild = document.head.appendChild.bind(document.head);
+		mockSdkLoad(featurebaseMock);
 
-		vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
-			const result = originalAppendChild(node);
-			if (node instanceof HTMLScriptElement && node.id === "featurebase-sdk") {
-				(window as Window & { Featurebase?: unknown }).Featurebase = featurebaseMock;
-				node.dispatchEvent(new Event("load"));
-			}
-			return result;
-		});
-
+		let hookResult: FeaturebaseFeedbackState | null = null;
 		function HookHarness(): null {
-			module.useFeaturebaseFeedbackWidget({
-				workspaceId: null,
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
 				clineProviderSettings: defaultClineProviderSettings,
 			});
 			return null;
@@ -132,68 +145,20 @@ describe("useFeaturebaseFeedbackWidget", () => {
 			await Promise.resolve();
 		});
 
-		await act(async () => {
-			module.openFeaturebaseFeedbackWidget();
-			await Promise.resolve();
-		});
-
-		expect(postMessageMock).not.toHaveBeenCalled();
-
-		const initializeCall = featurebaseMock.mock.calls.find(([action]) => action === "initialize_feedback_widget");
-		const readyCallback = initializeCall?.[2];
-		expect(typeof readyCallback).toBe("function");
-
-		await act(async () => {
-			(readyCallback as (error: unknown, callback?: { action?: string }) => void)(null, {
-				action: "widgetReady",
-			});
-			await Promise.resolve();
-		});
-
-		expect(postMessageMock).toHaveBeenCalledTimes(1);
-		expect(postMessageMock).toHaveBeenCalledWith(
-			{
-				target: "FeaturebaseWidget",
-				data: {
-					action: "openFeedbackWidget",
-				},
-			},
-			"*",
-		);
-
-		await act(async () => {
-			vi.advanceTimersByTime(50);
-			await Promise.resolve();
-		});
-
-		expect(postMessageMock).toHaveBeenCalledTimes(2);
+		expect(hookResult!.authState).toBe("idle");
+		expect(fetchFeaturebaseTokenMock).not.toHaveBeenCalled();
 	});
 
-	it("initializes immediately even while the managed Cline profile request is still pending", async () => {
-		const { module, fetchClineAccountProfileMock } = await importFeaturebaseModule();
+	it("requires oauthProvider=cline (tokens alone stay idle)", async () => {
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
 		const featurebaseMock = vi.fn();
-		const originalAppendChild = document.head.appendChild.bind(document.head);
+		mockSdkLoad(featurebaseMock);
 
-		fetchClineAccountProfileMock.mockReturnValue(new Promise(() => {}));
-
-		vi.spyOn(document.head, "appendChild").mockImplementation((node) => {
-			const result = originalAppendChild(node);
-			if (node instanceof HTMLScriptElement && node.id === "featurebase-sdk") {
-				(window as Window & { Featurebase?: unknown }).Featurebase = featurebaseMock;
-				node.dispatchEvent(new Event("load"));
-			}
-			return result;
-		});
-
+		let hookResult: FeaturebaseFeedbackState | null = null;
 		function HookHarness(): null {
-			module.useFeaturebaseFeedbackWidget({
+			hookResult = module.useFeaturebaseFeedbackWidget({
 				workspaceId: "workspace-1",
-				clineProviderSettings: {
-					...defaultClineProviderSettings,
-					oauthProvider: "cline",
-					oauthAccessTokenConfigured: true,
-					oauthAccountId: "account-123",
-				},
+				clineProviderSettings: tokensOnlySettings,
 			});
 			return null;
 		}
@@ -204,26 +169,310 @@ describe("useFeaturebaseFeedbackWidget", () => {
 			await Promise.resolve();
 		});
 
-		expect(fetchClineAccountProfileMock).toHaveBeenCalledWith("workspace-1");
-		expect(featurebaseMock).toHaveBeenCalledWith(
-			"identify",
-			expect.objectContaining({
-				organization: "cline",
-				userId: "account-123",
-			}),
-		);
-		expect(featurebaseMock).toHaveBeenCalledWith(
-			"initialize_feedback_widget",
-			expect.objectContaining({
-				organization: "cline",
-				theme: "dark",
-				locale: "en",
-				metadata: expect.objectContaining({
-					app: "kanban",
-					cline_account_id: "account-123",
-				}),
-			}),
-			expect.any(Function),
-		);
+		expect(hookResult!.authState).toBe("idle");
+		expect(fetchFeaturebaseTokenMock).not.toHaveBeenCalled();
+	});
+
+	it("transitions to ready on successful pre-identify (no retries scheduled)", async () => {
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		fetchFeaturebaseTokenMock.mockResolvedValue({ featurebaseJwt: "jwt-abc" });
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		const identifyCall = featurebaseMock.mock.calls.find((call: unknown[]) => call[0] === "identify");
+		expect(identifyCall).toBeTruthy();
+
+		await act(async () => {
+			(identifyCall?.[2] as (error: unknown) => void)?.(null);
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("ready");
+		// Only one token fetch — no retries needed
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("transitions to error on token fetch failure then auto-retries", async () => {
+		vi.useFakeTimers();
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		// All attempts fail
+		fetchFeaturebaseTokenMock.mockRejectedValue(new Error("Network error"));
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// Initial attempt failed
+		expect(hookResult!.authState).toBe("error");
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
+
+		// Advance past first retry delay (2s)
+		await act(async () => {
+			vi.advanceTimersByTime(2_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(2);
+		expect(hookResult!.authState).toBe("error");
+
+		// Advance past second retry delay (5s)
+		await act(async () => {
+			vi.advanceTimersByTime(5_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// 3 total attempts (initial + 2 retries), then stops
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(3);
+		expect(hookResult!.authState).toBe("error");
+
+		// No more retries after that
+		await act(async () => {
+			vi.advanceTimersByTime(30_000);
+			await Promise.resolve();
+		});
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("first attempt fails, auto-retry succeeds => becomes ready", async () => {
+		vi.useFakeTimers();
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		// First call fails, second succeeds
+		fetchFeaturebaseTokenMock
+			.mockRejectedValueOnce(new Error("Transient error"))
+			.mockResolvedValueOnce({ featurebaseJwt: "jwt-retry-ok" });
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("error");
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
+
+		// Advance past first retry delay (2s)
+		await act(async () => {
+			vi.advanceTimersByTime(2_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(2);
+
+		// Identify should have been called on the retry
+		const identifyCalls = featurebaseMock.mock.calls.filter((call: unknown[]) => call[0] === "identify");
+		expect(identifyCalls.length).toBeGreaterThanOrEqual(1);
+
+		// Simulate identify success
+		const latestIdentify = identifyCalls[identifyCalls.length - 1];
+		await act(async () => {
+			(latestIdentify?.[2] as (error: unknown) => void)?.(null);
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("ready");
+	});
+
+	it("transitions to error on identify callback error (silent degradation)", async () => {
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		fetchFeaturebaseTokenMock.mockResolvedValue({ featurebaseJwt: "jwt-abc" });
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		const identifyCall = featurebaseMock.mock.calls.find((call: unknown[]) => call[0] === "identify");
+		await act(async () => {
+			(identifyCall?.[2] as (error: unknown) => void)?.(new Error("Featurebase error"));
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("error");
+	});
+
+	it("auto-retries after identify callback error and transitions to ready on success", async () => {
+		vi.useFakeTimers();
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		// Both token fetches succeed
+		fetchFeaturebaseTokenMock
+			.mockResolvedValueOnce({ featurebaseJwt: "jwt-first" })
+			.mockResolvedValueOnce({ featurebaseJwt: "jwt-second" });
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// First identify call should have happened
+		const firstIdentifyCall = featurebaseMock.mock.calls.find((call: unknown[]) => call[0] === "identify");
+		expect(firstIdentifyCall).toBeTruthy();
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
+
+		// Invoke the first identify callback with an error
+		await act(async () => {
+			(firstIdentifyCall?.[2] as (error: unknown) => void)?.(new Error("identify failed"));
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("error");
+
+		// Advance timers by the first retry delay (2s)
+		await act(async () => {
+			vi.advanceTimersByTime(2_000);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// Token should be fetched again and a second identify call issued
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(2);
+		const identifyCalls = featurebaseMock.mock.calls.filter((call: unknown[]) => call[0] === "identify");
+		expect(identifyCalls.length).toBe(2);
+
+		// Invoke the second identify callback with null (success)
+		const secondIdentifyCall = identifyCalls[1];
+		await act(async () => {
+			(secondIdentifyCall?.[2] as (error: unknown) => void)?.(null);
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("ready");
+	});
+
+	it("does not pre-identify when workspaceId is null", async () => {
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		let hookResult: FeaturebaseFeedbackState | null = null;
+		function HookHarness(): null {
+			hookResult = module.useFeaturebaseFeedbackWidget({
+				workspaceId: null,
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(hookResult!.authState).toBe("idle");
+		expect(fetchFeaturebaseTokenMock).not.toHaveBeenCalled();
+	});
+
+	it("cancels retry timers on unmount", async () => {
+		vi.useFakeTimers();
+		const { module, fetchFeaturebaseTokenMock } = await importFeaturebaseModule();
+		fetchFeaturebaseTokenMock.mockRejectedValue(new Error("Network error"));
+		const featurebaseMock = vi.fn();
+		mockSdkLoad(featurebaseMock);
+
+		function HookHarness(): null {
+			module.useFeaturebaseFeedbackWidget({
+				workspaceId: "workspace-1",
+				clineProviderSettings: authenticatedClineSettings,
+			});
+			return null;
+		}
+
+		await act(async () => {
+			root.render(<HookHarness />);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
+
+		// Unmount before retry fires
+		await act(async () => {
+			root.render(<></>);
+			await Promise.resolve();
+		});
+
+		// Advance timers — retry should NOT fire
+		await act(async () => {
+			vi.advanceTimersByTime(10_000);
+			await Promise.resolve();
+		});
+
+		expect(fetchFeaturebaseTokenMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/web-ui/src/hooks/use-featurebase-feedback-widget.ts
+++ b/web-ui/src/hooks/use-featurebase-feedback-widget.ts
@@ -1,18 +1,34 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { fetchClineAccountProfile } from "@/runtime/runtime-config-query";
+import { isClineOauthAuthenticated } from "@/runtime/native-agent";
+import { fetchFeaturebaseToken } from "@/runtime/runtime-config-query";
 import type { RuntimeClineProviderSettings } from "@/runtime/types";
 
 const FEATUREBASE_SDK_ID = "featurebase-sdk";
 const FEATUREBASE_SDK_SRC = "https://do.featurebase.app/js/sdk.js";
 const FEATUREBASE_ORGANIZATION = "cline";
-const FEATUREBASE_OPEN_RETRY_DELAY_MS = 50;
-const FEATUREBASE_OPEN_WIDGET_MESSAGE = {
-	target: "FeaturebaseWidget",
-	data: {
-		action: "openFeedbackWidget",
-	},
-} as const;
+
+/**
+ * Bounded retry delays (ms) after the initial attempt.
+ * After these are exhausted the hook stays in "error".
+ */
+export const RETRY_DELAYS = [2_000, 5_000] as const;
+
+// ---------------------------------------------------------------------------
+// Featurebase auth readiness state machine
+// ---------------------------------------------------------------------------
+
+/** Tracks whether the Featurebase SDK has been successfully identified. */
+export type FeaturebaseAuthState = "idle" | "loading" | "ready" | "error";
+
+export interface FeaturebaseFeedbackState {
+	/** Current pre-identify readiness. */
+	authState: FeaturebaseAuthState;
+}
+
+// ---------------------------------------------------------------------------
+// Featurebase SDK internals
+// ---------------------------------------------------------------------------
 
 interface FeaturebaseCallbackPayload {
 	action?: string;
@@ -30,15 +46,7 @@ interface FeaturebaseWindow extends Window {
 	Featurebase?: FeaturebaseCommand;
 }
 
-interface ClineAccountProfile {
-	accountId: string | null;
-	email: string | null;
-	displayName: string | null;
-}
-
 let featurebaseSdkLoadPromise: Promise<void> | null = null;
-let isFeaturebaseFeedbackWidgetReady = false;
-let isFeaturebaseFeedbackWidgetOpenRequested = false;
 
 function ensureFeaturebaseCommand(win: FeaturebaseWindow): FeaturebaseCommand {
 	if (typeof win.Featurebase === "function") {
@@ -93,156 +101,143 @@ function ensureFeaturebaseSdkLoaded(): Promise<void> {
 	return featurebaseSdkLoadPromise;
 }
 
-function postOpenFeedbackWidgetMessage(): void {
-	window.postMessage(FEATUREBASE_OPEN_WIDGET_MESSAGE, "*");
-}
-
-function flushFeaturebaseFeedbackWidgetOpenRequest(): void {
-	if (!isFeaturebaseFeedbackWidgetOpenRequested || !isFeaturebaseFeedbackWidgetReady) {
-		return;
-	}
-	isFeaturebaseFeedbackWidgetOpenRequested = false;
-	postOpenFeedbackWidgetMessage();
-	window.setTimeout(() => {
-		postOpenFeedbackWidgetMessage();
-	}, FEATUREBASE_OPEN_RETRY_DELAY_MS);
-}
-
-export function openFeaturebaseFeedbackWidget(): void {
-	const win = window as FeaturebaseWindow;
-	ensureFeaturebaseCommand(win);
-	isFeaturebaseFeedbackWidgetOpenRequested = true;
-	void ensureFeaturebaseSdkLoaded()
-		.then(() => {
-			flushFeaturebaseFeedbackWidgetOpenRequest();
-		})
-		.catch(() => {
-			// Best effort only.
-		});
-}
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export function useFeaturebaseFeedbackWidget(input: {
 	workspaceId: string | null;
 	clineProviderSettings: RuntimeClineProviderSettings | null;
-}): void {
+}): FeaturebaseFeedbackState {
 	const { workspaceId, clineProviderSettings } = input;
-	const [clineProfile, setClineProfile] = useState<ClineAccountProfile | null>(null);
-	const [isClineProfileResolved, setIsClineProfileResolved] = useState(false);
-	const lastInitializedSignatureRef = useRef<string | null>(null);
-	const isManagedClineOauth =
-		clineProviderSettings?.oauthProvider === "cline" && clineProviderSettings.oauthAccessTokenConfigured;
+	const isAuthenticated = isClineOauthAuthenticated(clineProviderSettings);
 
-	useEffect(() => {
-		if (!isManagedClineOauth) {
-			setClineProfile(null);
-			setIsClineProfileResolved(true);
-			return;
-		}
-		let cancelled = false;
-		setIsClineProfileResolved(false);
-		void fetchClineAccountProfile(workspaceId)
-			.then((response) => {
-				if (cancelled) {
-					return;
-				}
-				setClineProfile(response.profile ?? null);
-			})
-			.catch(() => {
-				if (!cancelled) {
-					setClineProfile(null);
-				}
-			})
-			.finally(() => {
-				if (!cancelled) {
-					setIsClineProfileResolved(true);
-				}
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [isManagedClineOauth, workspaceId]);
+	const [authState, setAuthState] = useState<FeaturebaseAuthState>("idle");
 
-	const clineAccountId = clineProfile?.accountId ?? clineProviderSettings?.oauthAccountId ?? null;
-	const metadata = useMemo(() => {
-		const nextMetadata: Record<string, string> = {
-			app: "kanban",
-		};
-		if (clineAccountId) {
-			nextMetadata.cline_account_id = clineAccountId;
-		}
-		if (clineProfile?.displayName) {
-			nextMetadata.cline_display_name = clineProfile.displayName;
-		}
-		if (clineProfile?.email) {
-			nextMetadata.cline_email = clineProfile.email;
-		}
-		return nextMetadata;
-	}, [clineAccountId, clineProfile?.displayName, clineProfile?.email]);
+	// Track the latest attempt so we can cancel stale ones.
+	const attemptRef = useRef(0);
+	// Track the pending retry timer so we can cancel it on cleanup.
+	const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	const email = clineProfile?.email ?? undefined;
-	const displayName = clineProfile?.displayName ?? undefined;
-	const shouldIdentifyClineUser = isManagedClineOauth && Boolean(email || clineAccountId);
-	const signature = useMemo(
-		() =>
-			JSON.stringify({
-				email: email ?? null,
-				displayName: displayName ?? null,
-				shouldIdentifyClineUser,
-				metadata,
-			}),
-		[displayName, email, metadata, shouldIdentifyClineUser],
-	);
+	function clearRetryTimer() {
+		if (retryTimerRef.current !== null) {
+			clearTimeout(retryTimerRef.current);
+			retryTimerRef.current = null;
+		}
+	}
 
+	// Initialize the Featurebase feedback widget once on mount.
 	useEffect(() => {
 		const win = window as FeaturebaseWindow;
 		ensureFeaturebaseCommand(win);
 		let cancelled = false;
+
 		void ensureFeaturebaseSdkLoaded()
 			.then(() => {
-				if (cancelled || lastInitializedSignatureRef.current === signature) {
+				if (cancelled) {
 					return;
 				}
 				const featurebase = ensureFeaturebaseCommand(win);
-				lastInitializedSignatureRef.current = signature;
-				isFeaturebaseFeedbackWidgetReady = false;
-				if (shouldIdentifyClineUser) {
-					featurebase("identify", {
-						organization: FEATUREBASE_ORGANIZATION,
-						email,
-						name: displayName,
-						userId: clineAccountId ?? undefined,
-					});
-				}
-				featurebase(
-					"initialize_feedback_widget",
-					{
-						organization: FEATUREBASE_ORGANIZATION,
-						theme: "dark",
-						locale: "en",
-						email,
-						metadata,
-					},
-					(_error, callback) => {
-						if (callback?.action !== "widgetReady") {
-							return;
-						}
-						isFeaturebaseFeedbackWidgetReady = true;
-						flushFeaturebaseFeedbackWidgetOpenRequest();
-					},
-				);
+				featurebase("initialize_feedback_widget", {
+					organization: FEATUREBASE_ORGANIZATION,
+					theme: "dark",
+					locale: "en",
+					metadata: { app: "kanban" },
+				});
 			})
 			.catch(() => {});
+
 		return () => {
 			cancelled = true;
 		};
-	}, [
-		clineAccountId,
-		displayName,
-		email,
-		isClineProfileResolved,
-		isManagedClineOauth,
-		metadata,
-		shouldIdentifyClineUser,
-		signature,
-	]);
+	}, []);
+
+	// Core pre-identify routine with bounded automatic retries.
+	const runPreIdentify = useCallback(
+		(attempt: number, retryIndex: number) => {
+			if (!workspaceId || !isAuthenticated) {
+				return;
+			}
+
+			setAuthState("loading");
+			const win = window as FeaturebaseWindow;
+
+			const scheduleRetry = () => {
+				if (attemptRef.current !== attempt) {
+					return;
+				}
+				if (retryIndex < RETRY_DELAYS.length) {
+					const delay = RETRY_DELAYS[retryIndex];
+					retryTimerRef.current = setTimeout(() => {
+						if (attemptRef.current !== attempt) {
+							return;
+						}
+						runPreIdentify(attempt, retryIndex + 1);
+					}, delay);
+				}
+			};
+
+			void ensureFeaturebaseSdkLoaded()
+				.then(async () => {
+					if (attemptRef.current !== attempt) {
+						return;
+					}
+					const tokenResponse = await fetchFeaturebaseToken(workspaceId);
+					if (attemptRef.current !== attempt) {
+						return;
+					}
+					const featurebase = ensureFeaturebaseCommand(win);
+					featurebase(
+						"identify",
+						{
+							organization: FEATUREBASE_ORGANIZATION,
+							featurebaseJwt: tokenResponse.featurebaseJwt,
+						},
+						(error) => {
+							if (attemptRef.current !== attempt) {
+								return;
+							}
+							if (error) {
+								setAuthState("error");
+								scheduleRetry();
+								return;
+							}
+							clearRetryTimer();
+							setAuthState("ready");
+						},
+					);
+				})
+				.catch(() => {
+					if (attemptRef.current !== attempt) {
+						return;
+					}
+					setAuthState("error");
+					scheduleRetry();
+				});
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- retryTimerRef is a ref
+		[workspaceId, isAuthenticated],
+	);
+
+	// Pre-identify whenever auth state or workspace changes.
+	useEffect(() => {
+		clearRetryTimer();
+
+		if (!workspaceId || !isAuthenticated) {
+			// Reset to idle when the user signs out or workspace disappears.
+			setAuthState("idle");
+			return;
+		}
+
+		const attempt = ++attemptRef.current;
+		runPreIdentify(attempt, 0);
+
+		return () => {
+			// Cancel this attempt and any pending retries.
+			attemptRef.current++;
+			clearRetryTimer();
+		};
+	}, [workspaceId, isAuthenticated, runPreIdentify]);
+
+	return { authState };
 }

--- a/web-ui/src/runtime/native-agent.ts
+++ b/web-ui/src/runtime/native-agent.ts
@@ -42,6 +42,26 @@ export function isClineProviderAuthenticated(settings: RuntimeClineProviderSetti
 	return settings.apiKeyConfigured || settings.oauthAccessTokenConfigured;
 }
 
+/**
+ * Returns true only when the selected provider is the Cline managed OAuth
+ * provider **and** an access token is configured.  This is stricter than
+ * {@link isClineProviderAuthenticated} which accepts any configured provider
+ * (Claude API key, Codex, etc.).
+ *
+ * Use this for features that require a Cline-issued token (e.g. Featurebase
+ * JWT authentication).
+ */
+export function isClineOauthAuthenticated(settings: RuntimeClineProviderSettings | null | undefined): boolean {
+	if (!settings) {
+		return false;
+	}
+	return (
+		settings.oauthProvider === "cline" &&
+		settings.oauthAccessTokenConfigured === true &&
+		settings.oauthRefreshTokenConfigured === true
+	);
+}
+
 export function isTaskAgentSetupSatisfied(
 	config: Pick<RuntimeConfigResponse, "selectedAgentId" | "agents" | "clineProviderSettings"> | null | undefined,
 ): boolean | null {

--- a/web-ui/src/runtime/runtime-config-query.ts
+++ b/web-ui/src/runtime/runtime-config-query.ts
@@ -20,6 +20,7 @@ import type {
 	RuntimeClineReasoningEffort,
 	RuntimeConfigResponse,
 	RuntimeDebugResetAllStateResponse,
+	RuntimeFeaturebaseTokenResponse,
 	RuntimeProjectShortcut,
 } from "@/runtime/types";
 
@@ -95,6 +96,11 @@ export async function fetchClineAccountProfile(
 export async function fetchClineKanbanAccess(workspaceId: string | null): Promise<RuntimeClineKanbanAccessResponse> {
 	const trpcClient = getRuntimeTrpcClient(workspaceId);
 	return await trpcClient.runtime.getClineKanbanAccess.query();
+}
+
+export async function fetchFeaturebaseToken(workspaceId: string | null): Promise<RuntimeFeaturebaseTokenResponse> {
+	const trpcClient = getRuntimeTrpcClient(workspaceId);
+	return await trpcClient.runtime.getFeaturebaseToken.query();
 }
 
 export async function fetchClineProviderModels(


### PR DESCRIPTION
## Summary

Switches Featurebase feedback widget from client-side identity to backend-signed JWT authentication, and restores the Share Feedback button that was removed in f89668d.

## Changes

- **tRPC route**: `getFeaturebaseToken` in `app-router.ts` and `runtime-api.ts`
- **SDK boundary**: `fetchSdkFeaturebaseToken()` in `sdk-provider-boundary.ts`
- **Hook refactor** (`useFeaturebaseFeedbackWidget`):
  - Fetches a fresh JWT on each widget open (not on mount)
  - Calls `Featurebase("identify", { featurebaseJwt })` before opening the widget
  - Opens the widget only after the identify callback succeeds
  - Adds bounded auto-retry on identify callback failure
  - Fails closed on auth/token errors; surfaces toast instead of silent no-op
- **FeedbackCard**: gates Share Feedback on authenticated Cline OAuth session; hides entirely for non-Cline agents and when Featurebase auth is not ready
- **App wiring**: restores `useFeaturebaseFeedbackWidget` hook and passes state down to `ProjectNavigationPanel`

## Tests

- `test/runtime/trpc/runtime-api.test.ts` — 4 tests (JWT success, retry-after-refresh, non-Cline provider throws, no-settings fallback)
- `web-ui/src/components/project-navigation-panel.test.tsx` — 11 FeedbackCard tests (agent gate, auth gates, Featurebase state gates, regression)
- `web-ui/src/hooks/use-featurebase-feedback-widget.test.tsx` — 10 hook tests (identify flow, auto-retry, error states)

## Test plan

- [x] Unit/component tests passing locally
- [x] CI — all SDK dependencies published and resolved (`@clinebot/core@0.0.24`, `@clinebot/agents@0.0.24`, `@clinebot/llms@0.0.24`)
- [ ] Manual: verify Share Feedback button appears for authenticated Cline OAuth users and JWT identify flow completes

## Status

| Dependency | Status |
|---|---|
| `cline/core-platform#2259` — backend endpoint | ✅ Live on prod |
| `cline/sdk-wip#36` — `fetchFeaturebaseToken` in `@clinebot/core` | ✅ Published (`@clinebot/core@0.0.24`) |
| `cline/cline#10005` — `fetchFeaturebaseToken` in kanban's SDK boundary | ✅ Merged |

## Manual follow-up (post-merge)

- Provision `FEATUREBASE_JWT_SECRET`
- Enable Featurebase secure login
- Disable anonymous posting
- Configure board privacy as planned

Ref: ENG-1673