### PR TITLE
feat: support custom project display name via config

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -23,6 +23,7 @@ interface RuntimeGlobalConfigFileShape {
 }
 
 interface RuntimeProjectConfigFileShape {
+	name?: string;
 	shortcuts?: RuntimeProjectShortcut[];
 }
 
@@ -391,7 +392,9 @@ async function writeRuntimeProjectConfigFile(
 		}
 		return;
 	}
-	if (normalizedShortcuts.length === 0) {
+	const existing = await readRuntimeConfigFile<RuntimeProjectConfigFileShape>(configPath);
+	const existingName = typeof existing?.name === "string" && existing.name.trim() ? existing.name.trim() : null;
+	if (normalizedShortcuts.length === 0 && existingName === null) {
 		await rm(configPath, { force: true });
 		try {
 			await rm(dirname(configPath));
@@ -400,15 +403,16 @@ async function writeRuntimeProjectConfigFile(
 		}
 		return;
 	}
-	await lockedFileSystem.writeJsonFileAtomic(
-		configPath,
-		{
-			shortcuts: normalizedShortcuts,
-		} satisfies RuntimeProjectConfigFileShape,
-		{
-			lock: null,
-		},
-	);
+	const payload: RuntimeProjectConfigFileShape = {};
+	if (existingName !== null) {
+		payload.name = existingName;
+	}
+	if (normalizedShortcuts.length > 0) {
+		payload.shortcuts = normalizedShortcuts;
+	}
+	await lockedFileSystem.writeJsonFileAtomic(configPath, payload, {
+		lock: null,
+	});
 }
 
 interface RuntimeConfigFiles {

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -1,4 +1,9 @@
-import { toGlobalRuntimeConfigState, type RuntimeConfigState } from "../config/runtime-config.js";
+import { readFile } from "node:fs/promises";
+import {
+	getRuntimeProjectConfigPath,
+	toGlobalRuntimeConfigState,
+	type RuntimeConfigState,
+} from "../config/runtime-config.js";
 import type {
 	RuntimeBoardColumnId,
 	RuntimeBoardData,
@@ -170,10 +175,11 @@ function toProjectSummary(project: {
 	workspaceId: string;
 	repoPath: string;
 	taskCounts: RuntimeProjectTaskCounts;
+	customName?: string | null;
 }): RuntimeProjectSummary {
 	const normalized = project.repoPath.replaceAll("\\", "/").replace(/\/+$/g, "");
 	const segments = normalized.split("/").filter((segment) => segment.length > 0);
-	const name = segments[segments.length - 1] ?? normalized;
+	const name = project.customName || segments[segments.length - 1] || normalized;
 	return {
 		id: project.workspaceId,
 		path: project.repoPath,
@@ -339,10 +345,21 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 		const projectSummaries = await Promise.all(
 			projects.map(async (project) => {
 				const taskCounts = await summarizeProjectTaskCounts(project.workspaceId, project.repoPath);
+				let customName: string | null = null;
+				try {
+					const configPath = getRuntimeProjectConfigPath(project.repoPath);
+					const raw = JSON.parse(await readFile(configPath, "utf8"));
+					if (typeof raw.name === "string" && raw.name.trim()) {
+						customName = raw.name.trim();
+					}
+				} catch {
+					// No project config file or invalid JSON — use default folder name.
+				}
 				return toProjectSummary({
 					workspaceId: project.workspaceId,
 					repoPath: project.repoPath,
 					taskCounts,
+					customName,
 				});
 			}),
 		);


### PR DESCRIPTION
## Summary

Adds support for an optional `name` field in the per-project config file (`.cline/kanban/config.json`) that overrides the folder-based project display name on the Kanban board.

This solves the problem where multiple projects with the same folder name (e.g. `App`) are indistinguishable in the project sidebar.

### Usage

Add a `name` field to `.cline/kanban/config.json` in your project:

```json
{
  "name": "Maven"
}
```

### Changes

- **`src/config/runtime-config.ts`**: Added `name` to `RuntimeProjectConfigFileShape`. Updated `writeRuntimeProjectConfigFile` to preserve the `name` field when writing shortcuts so it isn't accidentally deleted.
- **`src/server/workspace-registry.ts`**: `toProjectSummary` now accepts an optional `customName` that takes priority over the folder name. `buildProjectsPayload` reads the project config to pass the custom name.

### Related

- Feature request: https://github.com/cline/cline/discussions/10017