### PR TITLE
Fix: Use Correct Agent On Restore from Trash

### DIFF
--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -156,13 +156,9 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						});
 				const shouldCaptureTurnCheckpoint = !body.resumeFromTrash && !isHomeAgentSessionId(body.taskId);
 
-				// When restoring from trash, use the agent that originally ran the task
-				// so the correct session type (Cline SDK vs terminal PTY) is used and
-				// the existing conversation history can be resumed.  For Cline we also
-				// probe persisted SDK sessions as a fallback; for terminal agents the
-				// browser passes the original agentId via resumeAgentId.
-				// Check if the terminal manager has a preserved agentId from a
-				// previous session for this task (hydrated from workspace state).
+				// When restoring from trash, resume with the original agent so conversation
+				// history is preserved. Terminal agents have their agentId preserved in the
+				// hydrated session summary; Cline tasks are detected via persisted SDK sessions.
 				const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
 				const previousTerminalAgentId = body.resumeFromTrash
 					? (terminalManager.getSummary(body.taskId)?.agentId ?? null)

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -80,10 +80,8 @@ describe("TerminalSessionManager", () => {
 
 		expect(recovered?.state).toBe("idle");
 		expect(recovered?.pid).toBeNull();
-			// agentId is preserved so the server can route to the correct agent
-			// when a task is restored from trash.
-			expect(recovered?.agentId).toBe("claude");
-			expect(recovered?.workspacePath).toBeNull();
+		expect(recovered?.agentId).toBe("claude");
+		expect(recovered?.workspacePath).toBeNull();
 		expect(recovered?.reviewReason).toBeNull();
 	});
 

--- a/web-ui/src/hooks/use-task-sessions.ts
+++ b/web-ui/src/hooks/use-task-sessions.ts
@@ -166,7 +166,7 @@ export function useTaskSessions({
 					images: options?.resumeFromTrash ? undefined : task.images,
 					startInPlanMode: options?.resumeFromTrash ? undefined : task.startInPlanMode,
 					resumeFromTrash: options?.resumeFromTrash,
-				baseRef: task.baseRef,
+					baseRef: task.baseRef,
 					cols: geometry.cols,
 					rows: geometry.rows,
 				});


### PR DESCRIPTION
Preserve the original `agentId` in `recoverStaleSession` so the server can route restore-from-trash to the correct agent. Also probes for persisted Cline sessions as a fallback.

https://github.com/user-attachments/assets/d32392b4-c796-45a7-974d-8be1a8252586

