### PR TITLE
Guard oversized workspace diffs in worker detail view

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -36,6 +36,9 @@ export const runtimeWorkspaceChangesResponseSchema = z.object({
 	repoRoot: z.string(),
 	generatedAt: z.number(),
 	files: z.array(runtimeWorkspaceFileChangeSchema),
+	totalFileCount: z.number().int().nonnegative().optional(),
+	truncated: z.boolean().optional(),
+	warning: z.string().nullable().optional(),
 });
 export type RuntimeWorkspaceChangesResponse = z.infer<typeof runtimeWorkspaceChangesResponseSchema>;
 

--- a/src/workspace/get-workspace-changes.ts
+++ b/src/workspace/get-workspace-changes.ts
@@ -9,6 +9,8 @@ import type {
 import { getGitStdout } from "./git-utils";
 
 const WORKSPACE_CHANGES_CACHE_MAX_ENTRIES = 128;
+const MAX_WORKSPACE_CHANGE_FILES = 250;
+const MAX_WORKSPACE_CHANGE_TEXT_BYTES = 5_000_000;
 
 interface WorkspaceChangesCacheEntry {
 	stateKey: string;
@@ -45,6 +47,13 @@ interface FileFingerprint {
 	size: number | null;
 	mtimeMs: number | null;
 	ctimeMs: number | null;
+}
+
+function estimateTextBytes(value: string | null): number {
+	if (!value) {
+		return 0;
+	}
+	return Buffer.byteLength(value, "utf8");
 }
 
 function mapNameStatus(code: string): RuntimeWorkspaceFileStatus {
@@ -351,16 +360,75 @@ async function buildFileChangeFromRef(
 	};
 }
 
+function createWorkspaceChangesResponse(input: {
+	repoRoot: string;
+	files: RuntimeWorkspaceChangesResponse["files"];
+	totalFileCount?: number;
+	truncated?: boolean;
+	warning?: string | null;
+}): RuntimeWorkspaceChangesResponse {
+	return {
+		repoRoot: input.repoRoot,
+		generatedAt: Date.now(),
+		files: input.files,
+		totalFileCount: input.totalFileCount ?? input.files.length,
+		truncated: input.truncated ?? false,
+		warning: input.warning ?? null,
+	};
+}
+
+function createTruncatedWorkspaceChangesResponse(input: {
+	repoRoot: string;
+	totalFileCount: number;
+	warning: string;
+}): RuntimeWorkspaceChangesResponse {
+	return createWorkspaceChangesResponse({
+		repoRoot: input.repoRoot,
+		files: [],
+		totalFileCount: input.totalFileCount,
+		truncated: true,
+		warning: input.warning,
+	});
+}
+
+async function buildWorkspaceChangesWithTextBudget(
+	builders: Array<() => Promise<RuntimeWorkspaceChangesResponse["files"][number]>>,
+	repoRoot: string,
+	totalFileCount: number,
+): Promise<RuntimeWorkspaceChangesResponse> {
+	const files: RuntimeWorkspaceChangesResponse["files"] = [];
+	let totalTextBytes = 0;
+	for (const build of builders) {
+		const file = await build();
+		totalTextBytes += estimateTextBytes(file.oldText) + estimateTextBytes(file.newText);
+		if (totalTextBytes > MAX_WORKSPACE_CHANGE_TEXT_BYTES) {
+			return createTruncatedWorkspaceChangesResponse({
+				repoRoot,
+				totalFileCount,
+				warning: `Too many changes to render safely. This view is limited to ${MAX_WORKSPACE_CHANGE_FILES} files or ${Math.floor(
+					MAX_WORKSPACE_CHANGE_TEXT_BYTES / 1_000_000,
+				)} MB of diff text.`,
+			});
+		}
+		files.push(file);
+	}
+	files.sort((left, right) => left.path.localeCompare(right.path));
+	return createWorkspaceChangesResponse({
+		repoRoot,
+		files,
+		totalFileCount,
+	});
+}
+
 export async function createEmptyWorkspaceChangesResponse(cwd: string): Promise<RuntimeWorkspaceChangesResponse> {
 	const repoRoot = (await getGitStdout(["rev-parse", "--show-toplevel"], cwd)).trim();
 	if (!repoRoot) {
 		throw new Error("Could not resolve git repository root.");
 	}
-	return {
+	return createWorkspaceChangesResponse({
 		repoRoot,
-		generatedAt: Date.now(),
 		files: [],
-	};
+	});
 }
 
 export async function getWorkspaceChanges(cwd: string): Promise<RuntimeWorkspaceChangesResponse> {
@@ -390,6 +458,15 @@ export async function getWorkspaceChanges(cwd: string): Promise<RuntimeWorkspace
 				status: "untracked" as const,
 			})),
 	];
+	if (allChanges.length > MAX_WORKSPACE_CHANGE_FILES) {
+		return createTruncatedWorkspaceChangesResponse({
+			repoRoot,
+			totalFileCount: allChanges.length,
+			warning: `Too many changes to render safely. This view is limited to ${MAX_WORKSPACE_CHANGE_FILES} files or ${Math.floor(
+				MAX_WORKSPACE_CHANGE_TEXT_BYTES / 1_000_000,
+			)} MB of diff text.`,
+		});
+	}
 	const fingerprintPaths = allChanges.flatMap((entry) => [entry.path, entry.previousPath].filter(Boolean) as string[]);
 	const fingerprints = await buildFileFingerprints(repoRoot, fingerprintPaths);
 	const stateKey = buildWorkspaceChangesStateKey({
@@ -405,13 +482,11 @@ export async function getWorkspaceChanges(cwd: string): Promise<RuntimeWorkspace
 		return existing.response;
 	}
 
-	const files = await Promise.all(allChanges.map((entry) => buildFileChange(repoRoot, entry)));
-	files.sort((left, right) => left.path.localeCompare(right.path));
-	const response: RuntimeWorkspaceChangesResponse = {
+	const response = await buildWorkspaceChangesWithTextBudget(
+		allChanges.map((entry) => () => buildFileChange(repoRoot, entry)),
 		repoRoot,
-		generatedAt: Date.now(),
-		files,
-	};
+		allChanges.length,
+	);
 	workspaceChangesCacheByRepoRoot.set(repoRoot, {
 		stateKey,
 		response,
@@ -435,23 +510,26 @@ export async function getWorkspaceChangesBetweenRefs(
 	);
 	const trackedChanges = parseTrackedChanges(trackedChangesOutput);
 	if (trackedChanges.length === 0) {
-		return {
+		return createWorkspaceChangesResponse({
 			repoRoot,
-			generatedAt: Date.now(),
 			files: [],
-		};
+		});
+	}
+	if (trackedChanges.length > MAX_WORKSPACE_CHANGE_FILES) {
+		return createTruncatedWorkspaceChangesResponse({
+			repoRoot,
+			totalFileCount: trackedChanges.length,
+			warning: `Too many changes to render safely. This view is limited to ${MAX_WORKSPACE_CHANGE_FILES} files or ${Math.floor(
+				MAX_WORKSPACE_CHANGE_TEXT_BYTES / 1_000_000,
+			)} MB of diff text.`,
+		});
 	}
 
-	const files = await Promise.all(
-		trackedChanges.map((entry) => buildFileChangeBetweenRefs(repoRoot, entry, input.fromRef, input.toRef)),
-	);
-	files.sort((left, right) => left.path.localeCompare(right.path));
-
-	return {
+	return await buildWorkspaceChangesWithTextBudget(
+		trackedChanges.map((entry) => () => buildFileChangeBetweenRefs(repoRoot, entry, input.fromRef, input.toRef)),
 		repoRoot,
-		generatedAt: Date.now(),
-		files,
-	};
+		trackedChanges.length,
+	);
 }
 
 export async function getWorkspaceChangesFromRef(input: ChangesFromRefInput): Promise<RuntimeWorkspaceChangesResponse> {
@@ -481,18 +559,23 @@ export async function getWorkspaceChangesFromRef(input: ChangesFromRefInput): Pr
 	];
 
 	if (allChanges.length === 0) {
-		return {
+		return createWorkspaceChangesResponse({
 			repoRoot,
-			generatedAt: Date.now(),
 			files: [],
-		};
+		});
 	}
-
-	const files = await Promise.all(allChanges.map((entry) => buildFileChangeFromRef(repoRoot, entry, input.fromRef)));
-	files.sort((left, right) => left.path.localeCompare(right.path));
-	return {
+	if (allChanges.length > MAX_WORKSPACE_CHANGE_FILES) {
+		return createTruncatedWorkspaceChangesResponse({
+			repoRoot,
+			totalFileCount: allChanges.length,
+			warning: `Too many changes to render safely. This view is limited to ${MAX_WORKSPACE_CHANGE_FILES} files or ${Math.floor(
+				MAX_WORKSPACE_CHANGE_TEXT_BYTES / 1_000_000,
+			)} MB of diff text.`,
+		});
+	}
+	return await buildWorkspaceChangesWithTextBudget(
+		allChanges.map((entry) => () => buildFileChangeFromRef(repoRoot, entry, input.fromRef)),
 		repoRoot,
-		generatedAt: Date.now(),
-		files,
-	};
+		allChanges.length,
+	);
 }

--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -141,6 +141,8 @@ describe("CardDetailView", () => {
 		mockClineSendText.mockClear();
 		mockUseRuntimeWorkspaceChanges.mockReturnValue({
 			changes: {
+				repoRoot: "/tmp/project",
+				generatedAt: Date.now(),
 				files: [
 					{
 						path: "src/example.ts",
@@ -257,6 +259,43 @@ describe("CardDetailView", () => {
 		const lastCall = mockUseRuntimeWorkspaceChanges.mock.calls.at(-1);
 		expect(lastCall?.[3]).toBe("last_turn");
 		expect(lastCall?.[7]).toBe(true);
+	});
+
+	it("shows a safety panel instead of mounting the diff viewer when changes are truncated", async () => {
+		mockUseRuntimeWorkspaceChanges.mockReturnValue({
+			changes: {
+				repoRoot: "/tmp/project",
+				generatedAt: Date.now(),
+				files: [],
+				totalFileCount: 1000000,
+				truncated: true,
+				warning: "Too many changes to render safely.",
+			},
+			isRuntimeAvailable: true,
+		});
+
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		expect(container.textContent).toContain("Too many changes to render");
+		expect(container.textContent).toContain("Too many changes to render safely.");
+		expect(mockDiffViewerPanel).not.toHaveBeenCalled();
 	});
 
 	it("closes git history before handling other Escape behavior", async () => {

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -118,6 +118,28 @@ function WorkspaceChangesEmptyPanel({ title }: { title: string }): React.ReactEl
 	);
 }
 
+function WorkspaceChangesTruncatedPanel({
+	title,
+	description,
+}: {
+	title: string;
+	description: string;
+}): React.ReactElement {
+	return (
+		<div
+			style={{ display: "flex", flex: "1.6 1 0", minWidth: 0, minHeight: 0, background: "var(--color-surface-0)" }}
+		>
+			<div className="kb-empty-state-center" style={{ flex: 1 }}>
+				<div className="flex flex-col items-center justify-center gap-3 px-8 py-12 text-center text-text-tertiary">
+					<GitCompareArrows size={40} />
+					<h3 className="font-semibold text-text-secondary">{title}</h3>
+					<p className="max-w-xl text-sm leading-6 text-text-tertiary m-0">{description}</p>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 function DiffToolbar({
 	mode,
 	onModeChange,
@@ -397,7 +419,15 @@ export function CardDetailView({
 	const isWorkspaceChangesPending = isRuntimeAvailable && workspaceChanges === null;
 	const hasNoWorkspaceFileChanges =
 		isRuntimeAvailable && workspaceChanges !== null && runtimeFiles !== null && runtimeFiles.length === 0;
+	const isWorkspaceChangesTruncated = Boolean(workspaceChanges?.truncated);
 	const emptyDiffTitle = diffMode === "last_turn" ? "No changes since last turn" : "No working changes";
+	const truncatedDiffTitle =
+		diffMode === "last_turn" ? "Too many last-turn changes to render" : "Too many changes to render";
+	const truncatedDiffDescription =
+		workspaceChanges?.warning ??
+		(workspaceChanges?.totalFileCount && workspaceChanges.totalFileCount > 0
+			? `This workspace has ${workspaceChanges.totalFileCount} changed files, which is above the safe rendering limit.`
+			: "This workspace is above the safe rendering limit.");
 	const agentPanelPercent = `${(agentPanelRatio * 100).toFixed(1)}%`;
 	const diffPanelPercent = `${((1 - agentPanelRatio) * 100).toFixed(1)}%`;
 	const fileTreePanelFlex = `0 0 ${isDiffExpanded ? EXPANDED_FILE_TREE_PANEL_BASIS : COLLAPSED_FILE_TREE_PANEL_BASIS}`;
@@ -690,6 +720,11 @@ export function CardDetailView({
 								<div style={{ display: "flex", flex: "1 1 0", minHeight: 0 }}>
 									{isWorkspaceChangesPending ? (
 										<WorkspaceChangesLoadingPanel panelFlex={fileTreePanelFlex} />
+									) : isWorkspaceChangesTruncated ? (
+										<WorkspaceChangesTruncatedPanel
+											title={truncatedDiffTitle}
+											description={truncatedDiffDescription}
+										/>
 									) : hasNoWorkspaceFileChanges ? (
 										<WorkspaceChangesEmptyPanel title={emptyDiffTitle} />
 									) : (


### PR DESCRIPTION
## Summary
- add a hard server-side guard for oversized workspace diff payloads
- return a truncated workspace-changes response instead of materializing unbounded diff text
- show a clear "too many changes to render" state in the worker detail UI

## Problem
Opening a worker detail view on a very dirty worktree could force Kanban to build and poll a massive working-copy diff. That could destabilize or crash the server instead of degrading gracefully.

## Changes
- extend the workspace-changes response contract with truncation metadata
- stop building full diff payloads when the change set exceeds file-count or text-size safety limits
- render a non-crashing fallback panel when the diff is intentionally truncated
- add UI coverage for the truncated-diff state

## Verification
- `npm --prefix /var/home/ut93/ai_test/public_repos/kanban run test -- web-ui/src/components/card-detail-view.test.tsx test/runtime/trpc/workspace-api.test.ts`
- `npm --prefix /var/home/ut93/ai_test/public_repos/kanban run web:test -- card-detail-view`
- `npm --prefix /var/home/ut93/ai_test/public_repos/kanban run build`

Fixes cline/kanban#121