### PR TITLE
fix: detect Codex task completion via PTY prompt after work output

### DIFF
--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -715,21 +715,55 @@ const claudeAdapter: AgentSessionAdapter = {
 	},
 };
 
-function codexPromptDetector(data: string, summary: RuntimeTaskSessionSummary): SessionTransitionEvent | null {
-	if (summary.state !== "awaiting_review") {
+function codexChunkHasPrompt(strippedChunk: string): boolean {
+	return /(?:^|\n)\s*›/.test(strippedChunk);
+}
+
+function codexChunkHasNonPromptOutput(strippedChunk: string): boolean {
+	const withoutPromptLines = strippedChunk.replace(/(?:^|\n)\s*›[^\n]*/g, "\n");
+	return /\S/.test(withoutPromptLines);
+}
+
+function createCodexPromptDetector(): AgentOutputTransitionDetector {
+	let hasSeenWorkOutputSincePrompt = false;
+
+	return (data: string, summary: RuntimeTaskSessionSummary): SessionTransitionEvent | null => {
+		const stripped = stripAnsi(data);
+		if (!stripped) {
+			return null;
+		}
+
+		const hasPrompt = codexChunkHasPrompt(stripped);
+		const hasNonPromptOutput = codexChunkHasNonPromptOutput(stripped);
+
+		if (summary.state === "running") {
+			if (hasPrompt && hasSeenWorkOutputSincePrompt) {
+				hasSeenWorkOutputSincePrompt = false;
+				return { type: "hook.to_review" };
+			}
+			if (hasNonPromptOutput) {
+				hasSeenWorkOutputSincePrompt = true;
+			}
+			return null;
+		}
+
+		if (
+			summary.state === "awaiting_review" &&
+			(summary.reviewReason === "attention" || summary.reviewReason === "hook")
+		) {
+			if (hasPrompt) {
+				return { type: "agent.prompt-ready" };
+			}
+		}
+
 		return null;
-	}
-	if (summary.reviewReason !== "attention" && summary.reviewReason !== "hook") {
-		return null;
-	}
-	const stripped = stripAnsi(data);
-	if (/(?:^|\n)\s*›/.test(stripped)) {
-		return { type: "agent.prompt-ready" };
-	}
-	return null;
+	};
 }
 
 function shouldInspectCodexOutputForTransition(summary: RuntimeTaskSessionSummary): boolean {
+	if (summary.state === "running") {
+		return true;
+	}
 	return (
 		summary.state === "awaiting_review" &&
 		(summary.reviewReason === "attention" || summary.reviewReason === "hook" || summary.reviewReason === "error")
@@ -741,6 +775,7 @@ const codexAdapter: AgentSessionAdapter = {
 		const codexArgs = [...input.args];
 		const env: Record<string, string | undefined> = {};
 		let binary = input.binary;
+		const detectOutputTransition = createCodexPromptDetector();
 		const appendedSystemPrompt = resolveHomeAgentAppendSystemPrompt(input.taskId);
 
 		if (input.autonomousModeEnabled && !hasCliOption(codexArgs, "--dangerously-bypass-approvals-and-sandbox")) {
@@ -791,7 +826,7 @@ const codexAdapter: AgentSessionAdapter = {
 				binary,
 				args,
 				env,
-				detectOutputTransition: codexPromptDetector,
+				detectOutputTransition,
 				shouldInspectOutputForTransition: shouldInspectCodexOutputForTransition,
 			};
 		}
@@ -800,7 +835,7 @@ const codexAdapter: AgentSessionAdapter = {
 			binary,
 			args: codexArgs,
 			env,
-			detectOutputTransition: codexPromptDetector,
+			detectOutputTransition,
 			shouldInspectOutputForTransition: shouldInspectCodexOutputForTransition,
 		};
 	},

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { RuntimeTaskSessionSummary } from "../../../src/core/api-contract";
 import { prepareAgentLaunch } from "../../../src/terminal/agent-session-adapters";
 
 const originalHome = process.env.HOME;
@@ -27,6 +28,29 @@ function setKanbanProcessContext(): void {
 		configurable: true,
 		value: "/usr/local/bin/node",
 	});
+}
+
+function createCodexSummary(
+	state: RuntimeTaskSessionSummary["state"],
+	reviewReason: RuntimeTaskSessionSummary["reviewReason"],
+): RuntimeTaskSessionSummary {
+	return {
+		taskId: "task-codex",
+		state,
+		agentId: "codex",
+		workspacePath: "/tmp",
+		pid: 123,
+		startedAt: Date.now(),
+		updatedAt: Date.now(),
+		lastOutputAt: Date.now(),
+		reviewReason,
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+		warningMessage: null,
+		latestTurnCheckpoint: null,
+		previousTurnCheckpoint: null,
+	};
 }
 
 afterEach(() => {
@@ -458,6 +482,72 @@ describe("prepareAgentLaunch hook strategies", () => {
 			resumeFromTrash: true,
 		});
 		expect(clineLaunch.args).toContain("--continue");
+	});
+
+	it("maps codex running prompt back to review after activity", async () => {
+		setupTempHome();
+		const launch = await prepareAgentLaunch({
+			taskId: "task-codex-detector",
+			agentId: "codex",
+			binary: "codex",
+			args: [],
+			cwd: "/tmp",
+			prompt: "",
+		});
+
+		const detect = launch.detectOutputTransition;
+		expect(detect).toBeDefined();
+		if (!detect) {
+			return;
+		}
+
+		const running = createCodexSummary("running", null);
+
+		expect(detect("› ", running)).toBeNull();
+		expect(detect("Running command: npm run test\n", running)).toBeNull();
+		expect(detect("\u001b[32m›\u001b[0m ", running)).toEqual({ type: "hook.to_review" });
+	});
+
+	it("keeps codex awaiting-review prompt-ready transition", async () => {
+		setupTempHome();
+		const launch = await prepareAgentLaunch({
+			taskId: "task-codex-awaiting-review",
+			agentId: "codex",
+			binary: "codex",
+			args: [],
+			cwd: "/tmp",
+			prompt: "",
+		});
+
+		const detect = launch.detectOutputTransition;
+		expect(detect).toBeDefined();
+		if (!detect) {
+			return;
+		}
+
+		const awaitingReview = createCodexSummary("awaiting_review", "hook");
+		expect(detect("\u001b[36m›\u001b[0m", awaitingReview)).toEqual({ type: "agent.prompt-ready" });
+	});
+
+	it("inspects codex output while running", async () => {
+		setupTempHome();
+		const launch = await prepareAgentLaunch({
+			taskId: "task-codex-inspect-running",
+			agentId: "codex",
+			binary: "codex",
+			args: [],
+			cwd: "/tmp",
+			prompt: "",
+		});
+
+		const shouldInspect = launch.shouldInspectOutputForTransition;
+		expect(shouldInspect).toBeDefined();
+		if (!shouldInspect) {
+			return;
+		}
+
+		expect(shouldInspect(createCodexSummary("running", null))).toBe(true);
+		expect(shouldInspect(createCodexSummary("idle", null))).toBe(false);
 	});
 
 	it("applies autonomous mode flags in adapters for non-droid CLIs", async () => {


### PR DESCRIPTION
## Problem

Codex tasks get stuck in `in_progress` forever because kanban's `codex-wrapper` session log watcher expects `{ type: "task_complete" }` events, but Codex writes a completely different JSONL schema (`{ ts, dir, kind, variant }`). Verified across 12 session log files — zero `task_complete` events exist.

Additionally, Codex doesn't exit after completing a task — it returns to an idle `›` prompt waiting for new input. The existing `codexPromptDetector` only fires in `awaiting_review` state (emitting `agent.prompt-ready`), so it never triggers completion detection while the task is `running`.

## Root Cause

1. **Session log schema mismatch**: Codex JSONL uses `kind`/`variant` fields, not `type`. No `task_complete` event exists in Codex's vocabulary.
2. **`codexPromptDetector` only active in `awaiting_review`**: When Codex finishes work and shows `›` prompt while task is `running`, no transition is detected.

## Fix

Convert `codexPromptDetector` from a stateless function to a stateful closure factory `createCodexPromptDetector()` that tracks whether Codex has produced work output:

- **`running` state**: After seeing non-prompt work output, detecting `›` prompt triggers `hook.to_review` (task moves to review)
- **Startup debounce**: The initial `›` prompt before any work output is ignored (prevents false completion on session start)
- **`awaiting_review` state**: Preserves existing `agent.prompt-ready` behavior (backward compatible)
- **`shouldInspectCodexOutputForTransition`**: Now returns `true` for `running` state so the detector is active

## Backward Compatibility

- No changes to Claude Code, Gemini, Droid, or any other agent adapter
- Existing `awaiting_review → prompt-ready` flow unchanged
- Only Codex adapter affected

## Testing

Added 3 tests:
- `running` → `to_review` after work output + prompt detection
- `awaiting_review` → `prompt-ready` preserved
- `shouldInspect` returns `true` for `running` state