### PR TITLE
feat(cline-sdk): surface per-turn usage summaries in Cline chat

### DIFF
--- a/src/cline-sdk/cline-event-adapter.ts
+++ b/src/cline-sdk/cline-event-adapter.ts
@@ -24,6 +24,13 @@ import {
 import { formatClineToolCallLabel, getClineToolCallDisplay } from "./cline-tool-call-display";
 import type { ClineSdkAgentEvent, ClineSdkSessionEvent } from "./sdk-runtime-boundary";
 
+interface UsageSummaryUI {
+	status: "done" | "failed";
+	iterations: number;
+	token: { input: number; output: number };
+	cache: { input: number; output: number };
+}
+
 function normalizePreviewText(value: string | null | undefined): string | null {
 	if (typeof value !== "string") {
 		return null;
@@ -159,6 +166,37 @@ function extractAgentErrorMessage(error: unknown): string | null {
 	return null;
 }
 
+function buildUsageSummaryPayload(
+	status: "done" | "failed",
+	iterations: number,
+	usage:
+		| {
+				inputTokens: number;
+				outputTokens: number;
+				cacheReadTokens?: number;
+				cacheWriteTokens?: number;
+				cost?: number;
+		  }
+		| null
+		| undefined,
+): string | null {
+	if (!usage) {
+		return null;
+	}
+	return JSON.stringify({
+		status,
+		iterations,
+		token: {
+			input: usage.inputTokens ?? 0,
+			output: usage.outputTokens ?? 0,
+		},
+		cache: {
+			input: usage.cacheReadTokens ?? 0,
+			output: usage.cacheWriteTokens ?? 0,
+		},
+	} satisfies UsageSummaryUI);
+}
+
 export function extractClineSessionId(event: unknown): string | null {
 	const record = asRecord(event);
 	if (!record) {
@@ -265,8 +303,34 @@ export function applyClineSessionEvent(input: ApplyClineSessionEventInput): void
 		return;
 	}
 
+	if (agentEvent?.type === "usage") {
+		entry.turnUsageSummary = buildUsageSummaryPayload("done", 0, {
+			inputTokens: agentEvent.inputTokens,
+			outputTokens: agentEvent.outputTokens,
+			cacheReadTokens: agentEvent.cacheReadTokens,
+			cacheWriteTokens: agentEvent.cacheWriteTokens,
+			cost: agentEvent.cost,
+		});
+		return;
+	}
+
 	if (agentEvent?.type === "done") {
 		const finalText = typeof agentEvent.text === "string" ? agentEvent.text.trim() : "";
+		const iterations =
+			typeof agentEvent.iterations === "number" && Number.isFinite(agentEvent.iterations)
+				? agentEvent.iterations
+				: 0;
+		const doneReason = typeof agentEvent.reason === "string" ? agentEvent.reason : "completed";
+		const usageStatus: "done" | "failed" = doneReason === "error" ? "failed" : "done";
+		const usageSummary =
+			buildUsageSummaryPayload(usageStatus, iterations, agentEvent.usage) ??
+			(entry.turnUsageSummary
+				? JSON.stringify({
+						...(JSON.parse(entry.turnUsageSummary) as UsageSummaryUI),
+						status: usageStatus,
+						iterations,
+					} satisfies UsageSummaryUI)
+				: null);
 		if (finalText) {
 			const message = setOrCreateAssistantMessage(entry, taskId, finalText);
 			if (message) {
@@ -277,9 +341,27 @@ export function applyClineSessionEvent(input: ApplyClineSessionEventInput): void
 				input.emitMessage(taskId, assistantMessage);
 			}
 		}
+		if (iterations > 0 || usageSummary) {
+			const statusMessage = createMessage(
+				taskId,
+				"status",
+				usageSummary ??
+					JSON.stringify({
+						status: usageStatus,
+						iterations,
+						token: { input: 0, output: 0 },
+						cache: { input: 0, output: 0 },
+					} satisfies UsageSummaryUI),
+			);
+			statusMessage.meta = {
+				messageKind: "usage_summary",
+			};
+			entry.messages.push(statusMessage);
+			input.emitMessage(taskId, statusMessage);
+		}
 
-		const doneReason = typeof agentEvent.reason === "string" ? agentEvent.reason : "completed";
 		if (doneReason === "aborted" && input.pendingTurnCancelTaskIds.has(taskId)) {
+			entry.turnUsageSummary = null;
 			emitTurnCanceled(input);
 			return;
 		}
@@ -310,6 +392,7 @@ export function applyClineSessionEvent(input: ApplyClineSessionEventInput): void
 		}
 
 		clearActiveTurnState(entry);
+		entry.turnUsageSummary = null;
 		emitSummary(input, summaryPatch);
 		return;
 	}

--- a/src/cline-sdk/cline-message-repository.ts
+++ b/src/cline-sdk/cline-message-repository.ts
@@ -175,6 +175,7 @@ function createHydrationEntry(taskId: string): ClineTaskSessionEntry {
 		activeReasoningMessageId: null,
 		toolMessageIdByToolCallId: new Map<string, string>(),
 		toolInputByToolCallId: new Map<string, unknown>(),
+		turnUsageSummary: null,
 	};
 }
 

--- a/src/cline-sdk/cline-session-state.ts
+++ b/src/cline-sdk/cline-session-state.ts
@@ -13,6 +13,7 @@ export interface ClineTaskSessionEntry {
 	activeReasoningMessageId: string | null;
 	toolMessageIdByToolCallId: Map<string, string>;
 	toolInputByToolCallId: Map<string, unknown>;
+	turnUsageSummary: string | null;
 }
 
 export interface ClineTaskMessage {

--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -257,6 +257,7 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 						activeReasoningMessageId: null,
 						toolMessageIdByToolCallId: new Map<string, string>(),
 						toolInputByToolCallId: new Map<string, unknown>(),
+						turnUsageSummary: null,
 					} satisfies ClineTaskSessionEntry);
 		this.messageRepository.setTaskEntry(request.taskId, entry);
 		this.pendingTurnCancelTaskIds.delete(request.taskId);
@@ -268,6 +269,7 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			const message = createMessage(request.taskId, "user", normalizedPrompt, request.images);
 			entry.messages.push(message);
 			this.emitMessage(request.taskId, message);
+			entry.turnUsageSummary = null;
 			const runningSummary = updateSummary(entry, {
 				state: "running",
 				reviewReason: null,
@@ -453,6 +455,7 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			entry.messages.push(message);
 			this.emitMessage(taskId, message);
 			clearActiveTurnState(entry);
+			entry.turnUsageSummary = null;
 			const queueDelivery = entry.summary.state === "running";
 			const waitingSummary = updateSummary(entry, {
 				state: "running",

--- a/test/runtime/cline-sdk/cline-event-adapter.test.ts
+++ b/test/runtime/cline-sdk/cline-event-adapter.test.ts
@@ -15,6 +15,7 @@ function createEntry(taskId: string): ClineTaskSessionEntry {
 		activeReasoningMessageId: null,
 		toolMessageIdByToolCallId: new Map<string, string>(),
 		toolInputByToolCallId: new Map<string, unknown>(),
+		turnUsageSummary: null,
 	};
 }
 
@@ -293,6 +294,63 @@ describe("applyClineSessionEvent", () => {
 		expect(result.entry.summary.latestHookActivity?.finalMessage).toBe("Done. Added the comment.");
 		expect(result.messages[0]?.role).toBe("assistant");
 		expect(result.messages[0]?.content).toBe("Done. Added the comment.");
+	});
+
+	it("adds a turn usage status message when usage arrives before the done event", () => {
+		const entry = createEntry("task-1");
+		entry.summary.state = "running";
+
+		applyEvent({
+			entry,
+			event: {
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "usage",
+						inputTokens: 120,
+						outputTokens: 45,
+						cacheReadTokens: 20,
+						cacheWriteTokens: 10,
+						cost: 0.0123,
+						totalInputTokens: 120,
+						totalOutputTokens: 45,
+					},
+				},
+			},
+		});
+
+		const result = applyEvent({
+			entry,
+			event: {
+				type: "agent_event",
+				payload: {
+					sessionId: "session-1",
+					event: {
+						type: "done",
+						reason: "completed",
+						text: "Applied the change.",
+						iterations: 3,
+					},
+				},
+			},
+		});
+
+		expect(result.messages).toHaveLength(2);
+		expect(result.messages[1]?.role).toBe("status");
+		expect(result.messages[1]?.meta?.messageKind).toBe("usage_summary");
+		expect(JSON.parse(result.messages[1]?.content ?? "")).toEqual({
+			status: "done",
+			iterations: 3,
+			token: {
+				input: 120,
+				output: 45,
+			},
+			cache: {
+				input: 20,
+				output: 10,
+			},
+		});
 	});
 
 	it("keeps the previous preview when done events have no final text", () => {

--- a/test/runtime/cline-sdk/cline-message-repository.test.ts
+++ b/test/runtime/cline-sdk/cline-message-repository.test.ts
@@ -40,6 +40,7 @@ function createEntry(taskId: string): ClineTaskSessionEntry {
 		activeReasoningMessageId: null,
 		toolMessageIdByToolCallId: new Map<string, string>(),
 		toolInputByToolCallId: new Map<string, unknown>(),
+		turnUsageSummary: null,
 	};
 }
 

--- a/web-ui/src/components/detail-panels/cline-chat-message-item.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-message-item.tsx
@@ -13,6 +13,53 @@ import { cn } from "@/components/ui/cn";
 import { Spinner } from "@/components/ui/spinner";
 import type { ClineChatMessage } from "@/hooks/use-cline-chat-session";
 
+interface UsageSummaryUI {
+	status: "done" | "failed";
+	iterations: number;
+	token: { input: number; output: number };
+	cache: { input: number; output: number };
+}
+
+function parseUsageSummary(message: ClineChatMessage): UsageSummaryUI | null {
+	if (message.role !== "status" || message.meta?.messageKind !== "usage_summary") {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(message.content) as UsageSummaryUI;
+		if (
+			(parsed.status === "done" || parsed.status === "failed") &&
+			typeof parsed.iterations === "number" &&
+			typeof parsed.token?.input === "number" &&
+			typeof parsed.token?.output === "number" &&
+			typeof parsed.cache?.input === "number" &&
+			typeof parsed.cache?.output === "number"
+		) {
+			return parsed;
+		}
+	} catch {
+		// Fall back to plain status rendering.
+	}
+	return null;
+}
+
+function UsageSummaryBlock({ summary }: { summary: UsageSummaryUI }): ReactElement {
+	return (
+		<div className={cn("w-full p-1", summary.status === "failed" ? "border-red-500/70 bg-red-500/10" : "")}>
+			<div id={`usage-summary-${summary.iterations}`} className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+				<span className="text-text-secondary">
+					In <span className="text-text-primary">{summary.token.input}</span>
+				</span>
+				<span className="text-text-secondary">
+					Out <span className="text-text-primary">{summary.token.output}</span>
+				</span>
+				<span className="text-text-secondary">
+					Cache <span className="text-text-primary">{summary.cache.input + summary.cache.output}</span>
+				</span>
+			</div>
+		</div>
+	);
+}
+
 function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElement {
 	const parsed = useMemo(() => parseToolMessageContent(message.content), [message.content]);
 	const isRunning = message.meta?.hookEventName === "tool_call_start";
@@ -141,6 +188,10 @@ function ReasoningMessageBlock({ message }: { message: ClineChatMessage }): Reac
 }
 
 export function ClineChatMessageItem({ message }: { message: ClineChatMessage }): ReactElement {
+	const usageSummary = parseUsageSummary(message);
+	if (usageSummary) {
+		return <UsageSummaryBlock summary={usageSummary} />;
+	}
 	if (message.role === "tool") {
 		return <ToolMessageBlock message={message} />;
 	}


### PR DESCRIPTION
## Summary
This is PR 1 of 3 splitting the original `#93` into focused changes.

This PR adds end-of-turn usage summaries to Cline task chat. When the SDK emits usage data and a turn completes, Kanban now stores the usage data for the active turn and emits a structured status message that the UI renders as a compact token/cache usage row.

## Problem
Before this change, usage details were either unavailable in chat or mixed into other status text. It was hard to inspect turn cost/usage from the main interaction surface.

## Technical approach
- Added a structured usage summary payload path in the event adapter.
- Introduced a transient `turnUsageSummary` field in task session state so `usage` and `done` events can be correlated safely.
- On `done`, emit a `status` message with `meta.messageKind = "usage_summary"` and JSON payload.
- Added UI parsing/rendering for that status message in chat message items.
- Added focused runtime tests for state/message behavior.

## Notes from split/debug process
- The original PR mixed usage summary work with provider defaults and provider setup UX.
- During split, I intentionally kept this PR limited to usage summary behavior and excluded provider/default logic.

## How to test
1. Start a Cline task and let a turn complete.
2. Confirm chat shows a compact usage row (input/output/cache) after completion.
3. Run tests:
   - `npx vitest run test/runtime/cline-sdk/cline-event-adapter.test.ts test/runtime/cline-sdk/cline-message-repository.test.ts`
4. Optional full gate (already run via pre-commit):
   - `npm run typecheck`
   - `npm run test`

## Follow-ups
- PR 2 will contain provider catalog/settings UX improvements.
- PR 3 will contain SDK-default provider/model fallback behavior.
