### PR TITLE
feat(sdk): align Cline provider/model fallbacks with SDK defaults

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -28,6 +28,8 @@ import {
 	loginManagedOauthProvider,
 	type ManagedClineOauthProviderId,
 	refreshManagedOauthCredentials,
+	SDK_DEFAULT_MODEL_ID,
+	SDK_DEFAULT_PROVIDER_ID,
 	type SdkCustomProviderCapability,
 	type SdkProviderModelRecord,
 	type SdkProviderSettings,
@@ -243,7 +245,31 @@ function toProviderSettingsSummary(settings: SdkProviderSettings | null): Runtim
 }
 
 function getSelectedProviderSettings(): SdkProviderSettings | null {
-	return getLastUsedSdkProviderSettings();
+	const lastUsedSettings = getLastUsedSdkProviderSettings();
+	const resolvedProviderId = lastUsedSettings?.provider?.trim().toLowerCase() || SDK_DEFAULT_PROVIDER_ID;
+	return (
+		getSdkProviderSettings(resolvedProviderId) ??
+		lastUsedSettings ?? {
+			provider: resolvedProviderId,
+		}
+	);
+}
+
+async function resolveDefaultModelIdForProvider(providerId: string): Promise<string | null> {
+	const normalizedProviderId = providerId.trim().toLowerCase();
+	if (!normalizedProviderId) {
+		return SDK_DEFAULT_MODEL_ID;
+	}
+	try {
+		const provider = (await listSdkProviderCatalog()).find((candidate) => candidate.id === normalizedProviderId);
+		const defaultModelId = provider?.defaultModelId?.trim();
+		if (defaultModelId) {
+			return defaultModelId;
+		}
+	} catch {
+		// Fall through to the stable built-in defaults.
+	}
+	return normalizedProviderId === SDK_DEFAULT_PROVIDER_ID ? SDK_DEFAULT_MODEL_ID : null;
 }
 
 function createRuntimeOauthCallbacks(providerId: ManagedClineOauthProviderId) {
@@ -458,7 +484,7 @@ export function createClineProviderService() {
 				: resolveVisibleApiKey(resolvedSettings);
 			return {
 				providerId: normalizedProviderId,
-				modelId: resolvedSettings.model?.trim() || null,
+				modelId: resolvedSettings.model?.trim() || (await resolveDefaultModelIdForProvider(normalizedProviderId)),
 				apiKey,
 				baseUrl: resolvedSettings.baseUrl?.trim() || null,
 				reasoningEffort: toRuntimeReasoningEffort(resolvedSettings.reasoning?.effort),

--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -36,6 +36,7 @@ import {
 	setOrCreateAssistantMessage,
 	updateSummary,
 } from "./cline-session-state";
+import { SDK_DEFAULT_MODEL_ID, SDK_DEFAULT_PROVIDER_ID } from "./sdk-provider-boundary";
 import { resolveClineSdkSystemPrompt } from "./sdk-runtime-boundary";
 
 export type { ClineTaskMessage } from "./cline-session-state";
@@ -225,8 +226,8 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			return cloneSummary(existing.summary);
 		}
 
-		const providerId = request.providerId?.trim() || "anthropic";
-		const modelId = request.modelId?.trim() || "claude-sonnet-4-6";
+		const providerId = request.providerId?.trim().toLowerCase() || SDK_DEFAULT_PROVIDER_ID;
+		const modelId = request.modelId?.trim() || SDK_DEFAULT_MODEL_ID;
 		const resolvedMode: RuntimeTaskSessionMode = request.mode ?? "act";
 		const persistedResumeSnapshot = request.resumeFromTrash
 			? await this.sessionRuntime.readPersistedTaskSession(request.taskId).catch(() => null)

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -29,6 +29,8 @@ import { LlmsProviders, LlmsModels as llmsModels } from "@clinebot/llms";
 
 export type ManagedClineOauthProviderId = "cline" | "oca" | "openai-codex";
 export type SdkReasoningEffort = NonNullable<NonNullable<LlmsProviders.ProviderSettings["reasoning"]>["effort"]>;
+export const SDK_DEFAULT_PROVIDER_ID = "cline";
+export const SDK_DEFAULT_MODEL_ID = llmsModels.CLINE_DEFAULT_MODEL;
 
 export interface ManagedOauthCredentials {
 	access: string;
@@ -255,7 +257,6 @@ export async function addSdkCustomProvider(input: AddSdkCustomProviderInput): Pr
 	});
 	await ensureCustomProvidersLoaded(providerManager);
 }
-
 export function getSdkProviderSettings(providerId: string): SdkProviderSettings | null {
 	return (providerManager.getProviderSettings(providerId) as SdkProviderSettings | undefined) ?? null;
 }

--- a/test/runtime/cline-sdk/cline-task-session-service.test.ts
+++ b/test/runtime/cline-sdk/cline-task-session-service.test.ts
@@ -206,8 +206,8 @@ function createFakeClineSessionRuntime(): FakeClineSessionRuntimeController {
 						lastStartRequestByTaskId.set(taskId, {
 							taskId,
 							cwd: persistedCwd || persistedWorkspaceRoot,
-							providerId: typeof record?.provider === "string" ? record.provider : "anthropic",
-							modelId: typeof record?.model === "string" ? record.model : "claude-sonnet-4-6",
+							providerId: typeof record?.provider === "string" ? record.provider : "cline",
+							modelId: typeof record?.model === "string" ? record.model : "anthropic/claude-sonnet-4.6",
 							mode: undefined,
 							apiKey: undefined,
 							baseUrl: undefined,
@@ -481,7 +481,7 @@ describe("InMemoryClineTaskSessionService", () => {
 		});
 	});
 
-	it("defaults to anthropic provider when provider is not explicitly configured", async () => {
+	it("defaults to the SDK cline provider when provider is not explicitly configured", async () => {
 		const { service, runtime } = createTrackedService();
 
 		await service.startTaskSession({
@@ -495,7 +495,7 @@ describe("InMemoryClineTaskSessionService", () => {
 
 		expect(runtime.startTaskSessionMock).toHaveBeenCalledWith(
 			expect.objectContaining({
-				providerId: "anthropic",
+				providerId: "cline",
 				systemPrompt: expect.stringContaining("You are Cline, an AI coding agent."),
 			}),
 		);
@@ -864,6 +864,9 @@ describe("InMemoryClineTaskSessionService", () => {
 			taskId: "task-1",
 			cwd: "/tmp/worktree",
 			prompt: "Initial prompt",
+		});
+		await vi.waitFor(() => {
+			expect(runtime.startTaskSessionMock).toHaveBeenCalledTimes(1);
 		});
 
 		runtimeSetup.resolvePromptMock.mockImplementation((prompt: string) => `workflow:${prompt}`);

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -89,8 +89,9 @@ vi.mock("@clinebot/core/node", () => ({
 	},
 }));
 
-vi.mock("@clinebot/llms/node", () => ({
-	models: {
+vi.mock("@clinebot/llms", () => ({
+	LlmsModels: {
+		CLINE_DEFAULT_MODEL: "anthropic/claude-sonnet-4.6",
 		getAllProviders: llmsModelMocks.getAllProviders,
 		getModelsForProvider: llmsModelMocks.getModelsForProvider,
 	},
@@ -510,6 +511,61 @@ describe("createRuntimeApi startTaskSession", () => {
 			}),
 		);
 		expect(terminalManager.startTaskSession).not.toHaveBeenCalled();
+	});
+
+	it("uses saved cline settings even when no last-used provider is recorded", async () => {
+		taskWorktreeMocks.resolveTaskCwd.mockResolvedValue("/tmp/existing-worktree");
+		agentRegistryMocks.resolveAgentCommand.mockReturnValue(null);
+		oauthMocks.getLastUsedProviderSettings.mockReturnValue(undefined);
+		oauthMocks.getProviderSettings.mockImplementation((providerId: string) =>
+			providerId === "cline"
+				? {
+						provider: "cline",
+						model: "anthropic/claude-opus-4.6",
+						apiKey: "saved-cline-api-key",
+					}
+				: undefined,
+		);
+
+		const clineTaskSessionService = createClineTaskSessionServiceMock();
+		clineTaskSessionService.startTaskSession.mockResolvedValue(createSummary({ agentId: "cline", pid: null }));
+
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => {
+				const runtimeConfigState = createRuntimeConfigState();
+				runtimeConfigState.selectedAgentId = "cline";
+				return runtimeConfigState;
+			}),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(
+				async () => ({ startTaskSession: vi.fn(), applyTurnCheckpoint: vi.fn() }) as never,
+			),
+			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.startTaskSession(
+			{
+				workspaceId: "workspace-1",
+				workspacePath: "/tmp/repo",
+			},
+			{
+				taskId: "task-1",
+				baseRef: "main",
+				prompt: "Continue task",
+			},
+		);
+
+		expect(response.ok).toBe(true);
+		expect(clineTaskSessionService.startTaskSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerId: "cline",
+				modelId: "anthropic/claude-opus-4.6",
+				apiKey: "saved-cline-api-key",
+			}),
+		);
 	});
 
 	it("fails early when the cline provider is selected without cline credentials", async () => {


### PR DESCRIPTION
## Summary
This is PR 3 of 3 splitting the original `#93` into focused changes.

This PR moves provider/model fallback behavior to SDK-defined defaults and improves provider settings resolution when no explicit last-used provider record exists.

## Problem
Kanban had hardcoded fallback values for provider/model in task session startup paths. That can drift from SDK behavior and makes it easier for launch behavior to become inconsistent.

## Technical approach
- Added exported SDK default constants in the provider boundary:
  - `SDK_DEFAULT_PROVIDER_ID`
  - `SDK_DEFAULT_MODEL_ID`
- Updated task-session startup to use those constants instead of hardcoded literals.
- Updated provider service launch config resolution so that when last-used is missing, it still resolves provider settings via SDK defaults.
- Added provider launch fallback for model resolution to SDK/default-provider model when model is omitted.
- Added runtime tests validating:
  - startup behavior when last-used provider is missing
  - default provider expectation updates
- Updated test mocking from `@clinebot/llms/node` to `@clinebot/llms` where needed for the new constant usage path.

## Notes from split/debug process
- This PR intentionally excludes usage-summary UI/event work and provider setup UX metadata work.
- One small existing test needed an explicit wait for startup call stability in this branch.

## How to test
1. Configure provider settings with provider saved but no last-used entry, then start a Cline task.
2. Confirm launch uses the saved/default provider and model fallback correctly.
3. Run tests:
   - `npx vitest run test/runtime/trpc/runtime-api.test.ts test/runtime/cline-sdk/cline-task-session-service.test.ts`
4. Optional full gate (already run via pre-commit):
   - `npm run typecheck`
   - `npm run test`

## Follow-ups
- PR 1: usage summaries in chat
- PR 2: provider setup metadata and UX
