### PR TITLE
feat(cline-chat): show session usage totals near composer

### DIFF
--- a/src/cline-sdk/cline-message-repository.ts
+++ b/src/cline-sdk/cline-message-repository.ts
@@ -150,13 +150,48 @@ export function createTaskEntryFromPersistedSession(
 	for (const message of messages) {
 		hydratePersistedMessage(entry, taskId, message);
 	}
+	const usageTotals = accumulatePersistedUsageTotals(messages);
 	entry.summary = {
 		...entry.summary,
+		...usageTotals,
 		...summaryPatch,
 		taskId,
 		updatedAt: Date.now(),
 	};
 	return entry;
+}
+
+export function accumulatePersistedUsageTotals(
+	messages: ClineSdkPersistedMessage[],
+): Pick<RuntimeTaskSessionSummary, "totalInputTokens" | "totalOutputTokens" | "totalCost"> {
+	let inputTokenTotal: number | null = null;
+	let outputTokenTotal: number | null = null;
+	let costTotal: number | null = null;
+
+	for (const message of messages) {
+		const metrics = message.metrics;
+		if (!metrics || typeof metrics !== "object") {
+			continue;
+		}
+		const inputTokens = metrics.inputTokens;
+		if (typeof inputTokens === "number" && Number.isFinite(inputTokens)) {
+			inputTokenTotal = (inputTokenTotal ?? 0) + inputTokens;
+		}
+		const outputTokens = metrics.outputTokens;
+		if (typeof outputTokens === "number" && Number.isFinite(outputTokens)) {
+			outputTokenTotal = (outputTokenTotal ?? 0) + outputTokens;
+		}
+		const cost = metrics.cost;
+		if (typeof cost === "number" && Number.isFinite(cost)) {
+			costTotal = (costTotal ?? 0) + cost;
+		}
+	}
+
+	return {
+		totalInputTokens: inputTokenTotal,
+		totalOutputTokens: outputTokenTotal,
+		totalCost: costTotal,
+	};
 }
 
 function hydratePersistedSessionMessages(taskId: string, messages: ClineSdkPersistedMessage[]): ClineTaskMessage[] {

--- a/src/cline-sdk/cline-session-state.ts
+++ b/src/cline-sdk/cline-session-state.ts
@@ -69,6 +69,9 @@ export function createDefaultSummary(taskId: string): RuntimeTaskSessionSummary 
 		lastHookAt: null,
 		latestHookActivity: null,
 		warningMessage: null,
+		totalInputTokens: null,
+		totalOutputTokens: null,
+		totalCost: null,
 		latestTurnCheckpoint: null,
 		previousTurnCheckpoint: null,
 	};

--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -14,6 +14,7 @@ import { resolveHomeAgentAppendSystemPrompt } from "../prompts/append-system-pro
 import { captureTaskTurnCheckpoint, deleteTaskTurnCheckpointRef } from "../workspace/turn-checkpoints";
 import { applyClineSessionEvent } from "./cline-event-adapter";
 import {
+	accumulatePersistedUsageTotals,
 	type ClineMessageRepository,
 	createInMemoryClineMessageRepository,
 	createTaskEntryFromPersistedSession,
@@ -120,6 +121,35 @@ function formatStartWarnings(warnings: readonly string[] | undefined): string | 
 		return normalized[0] ?? null;
 	}
 	return `${normalized[0]} (+${normalized.length - 1} more MCP warning${normalized.length === 2 ? "" : "s"})`;
+}
+
+function eventShouldRefreshUsageTotals(event: unknown): boolean {
+	if (!event || typeof event !== "object") {
+		return false;
+	}
+	const record = event as {
+		type?: unknown;
+		payload?: {
+			event?: {
+				type?: unknown;
+			};
+		};
+	};
+	if (record.type !== "agent_event") {
+		return false;
+	}
+	return record.payload?.event?.type === "done";
+}
+
+function usageTotalsChanged(
+	summary: RuntimeTaskSessionSummary,
+	totals: Pick<RuntimeTaskSessionSummary, "totalInputTokens" | "totalOutputTokens" | "totalCost">,
+): boolean {
+	return (
+		summary.totalInputTokens !== totals.totalInputTokens ||
+		summary.totalOutputTokens !== totals.totalOutputTokens ||
+		summary.totalCost !== totals.totalCost
+	);
 }
 
 export class InMemoryClineTaskSessionService implements ClineTaskSessionService {
@@ -714,6 +744,25 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 		if (this.shouldCaptureReviewCheckpoint(previousSummary, latestSummary)) {
 			this.captureReviewCheckpoint(taskId, latestSummary);
 		}
+		if (eventShouldRefreshUsageTotals(event)) {
+			void this.refreshPersistedUsageTotals(taskId);
+		}
+	}
+
+	private async refreshPersistedUsageTotals(taskId: string): Promise<void> {
+		const entry = this.messageRepository.getTaskEntry(taskId);
+		if (!entry) {
+			return;
+		}
+		const snapshot = await this.sessionRuntime.readPersistedTaskSession(taskId).catch(() => null);
+		if (!snapshot) {
+			return;
+		}
+		const totals = accumulatePersistedUsageTotals(snapshot.messages);
+		if (!usageTotalsChanged(entry.summary, totals)) {
+			return;
+		}
+		this.emitSummary(updateSummary(entry, totals));
 	}
 }
 

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -225,6 +225,9 @@ export const runtimeTaskSessionSummarySchema = z.object({
 	lastHookAt: z.number().nullable().default(null),
 	latestHookActivity: runtimeTaskHookActivitySchema.nullable().default(null),
 	warningMessage: z.string().nullable().optional(),
+	totalInputTokens: z.number().nullable().optional(),
+	totalOutputTokens: z.number().nullable().optional(),
+	totalCost: z.number().nullable().optional(),
 	latestTurnCheckpoint: runtimeTaskTurnCheckpointSchema.nullable().optional(),
 	previousTurnCheckpoint: runtimeTaskTurnCheckpointSchema.nullable().optional(),
 });

--- a/test/runtime/cline-sdk/cline-message-repository.test.ts
+++ b/test/runtime/cline-sdk/cline-message-repository.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createInMemoryClineMessageRepository } from "../../../src/cline-sdk/cline-message-repository";
+import {
+	accumulatePersistedUsageTotals,
+	createInMemoryClineMessageRepository,
+	createTaskEntryFromPersistedSession,
+} from "../../../src/cline-sdk/cline-message-repository";
 import type { ClinePersistedTaskSessionSnapshot } from "../../../src/cline-sdk/cline-session-runtime";
 import {
 	type ClineTaskSessionEntry,
@@ -130,5 +134,61 @@ describe("InMemoryClineMessageRepository", () => {
 
 		expect(messages.map((message) => message.content)).toEqual(["Live response"]);
 		expect(loadPersistedSession).not.toHaveBeenCalled();
+	});
+
+	it("accumulates persisted metrics into session usage totals", () => {
+		const messages = [
+			{
+				role: "user",
+				content: "Investigate startup",
+				metrics: {
+					inputTokens: 200,
+				},
+			},
+			{
+				role: "assistant",
+				content: "I found the issue.",
+				metrics: {
+					outputTokens: 50,
+					cost: 0.003,
+				},
+			},
+			{
+				role: "assistant",
+				content: "Applying the fix.",
+				metrics: {
+					inputTokens: 20,
+					outputTokens: 100,
+					cost: 0.01,
+				},
+			},
+		] satisfies NonNullable<ClinePersistedTaskSessionSnapshot>["messages"];
+
+		const totals = accumulatePersistedUsageTotals(messages);
+		const entry = createTaskEntryFromPersistedSession("task-1", messages);
+
+		expect(totals.totalInputTokens).toBe(220);
+		expect(totals.totalOutputTokens).toBe(150);
+		expect(totals.totalCost).toBeCloseTo(0.013, 8);
+		expect(entry.summary.totalInputTokens).toBe(220);
+		expect(entry.summary.totalOutputTokens).toBe(150);
+		expect(entry.summary.totalCost).toBeCloseTo(0.013, 8);
+	});
+
+	it("keeps persisted usage totals null when no message metrics are available", () => {
+		const entry = createTaskEntryFromPersistedSession("task-1", [
+			{
+				role: "user",
+				content: "No metrics yet",
+			},
+			{
+				role: "assistant",
+				content: "Still no metrics",
+			},
+		]);
+
+		expect(entry.summary.totalInputTokens).toBeNull();
+		expect(entry.summary.totalOutputTokens).toBeNull();
+		expect(entry.summary.totalCost).toBeNull();
 	});
 });

--- a/test/runtime/cline-sdk/cline-task-session-service.test.ts
+++ b/test/runtime/cline-sdk/cline-task-session-service.test.ts
@@ -437,10 +437,17 @@ describe("InMemoryClineTaskSessionService", () => {
 				{
 					role: "user",
 					content: "Recovered prompt",
+					metrics: {
+						inputTokens: 120,
+					},
 				},
 				{
 					role: "assistant",
 					content: "Recovered answer",
+					metrics: {
+						outputTokens: 80,
+						cost: 0.0095,
+					},
 				},
 			],
 		});
@@ -470,10 +477,17 @@ describe("InMemoryClineTaskSessionService", () => {
 						{
 							role: "user",
 							content: "Recovered prompt",
+							metrics: {
+								inputTokens: 120,
+							},
 						},
 						{
 							role: "assistant",
 							content: "Recovered answer",
+							metrics: {
+								outputTokens: 80,
+								cost: 0.0095,
+							},
 						},
 					],
 				}),
@@ -820,10 +834,17 @@ describe("InMemoryClineTaskSessionService", () => {
 				{
 					role: "user",
 					content: "Recovered prompt",
+					metrics: {
+						inputTokens: 120,
+					},
 				},
 				{
 					role: "assistant",
 					content: "Recovered answer",
+					metrics: {
+						outputTokens: 80,
+						cost: 0.0095,
+					},
 				},
 			],
 		});
@@ -833,6 +854,9 @@ describe("InMemoryClineTaskSessionService", () => {
 		expect(reboundSummary?.state).toBe("awaiting_review");
 		expect(reboundSummary?.reviewReason).toBe("attention");
 		expect(reboundSummary?.workspacePath).toBe("task-1-persisted-cwd");
+		expect(reboundSummary?.totalInputTokens).toBe(120);
+		expect(reboundSummary?.totalOutputTokens).toBe(80);
+		expect(reboundSummary?.totalCost).toBeCloseTo(0.0095, 8);
 		expect(service.listMessages("task-1").map((message) => message.content)).toEqual([
 			"Recovered prompt",
 			"Recovered answer",
@@ -847,6 +871,65 @@ describe("InMemoryClineTaskSessionService", () => {
 				"Recovered answer",
 				"Continue",
 			]);
+		});
+	});
+
+	it("refreshes totals from persisted message metrics when a turn completes", async () => {
+		const { service, runtime } = createTrackedService();
+		runtime.readPersistedTaskSessionMock.mockResolvedValue({
+			record: {
+				sessionId: "task-1-persisted",
+				source: "core" as ClinePersistedTaskSessionSnapshot["record"]["source"],
+				status: "completed",
+				startedAt: "2026-03-17T10:00:00.000Z",
+				updatedAt: "2026-03-17T10:05:00.000Z",
+				interactive: true,
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
+				cwd: "/tmp/worktree",
+				workspaceRoot: "/tmp/workspace-root",
+				enableTools: true,
+				enableSpawn: false,
+				enableTeams: false,
+				isSubagent: false,
+			},
+			messages: [
+				{
+					role: "user",
+					content: "Recovered prompt",
+					metrics: {
+						inputTokens: 240,
+					},
+				},
+				{
+					role: "assistant",
+					content: "Recovered answer",
+					metrics: {
+						outputTokens: 160,
+						cost: 0.021,
+					},
+				},
+			],
+		});
+
+		await service.startTaskSession({
+			taskId: "task-1",
+			cwd: "/tmp/worktree",
+			prompt: "Initial prompt",
+		});
+		const sessionId = await waitForTaskSessionId(runtime, "task-1");
+
+		runtime.emitAgentEvent(sessionId, {
+			type: "done",
+			reason: "completed",
+			text: "Done",
+		});
+
+		await vi.waitFor(() => {
+			const summary = service.getSummary("task-1");
+			expect(summary?.totalInputTokens).toBe(240);
+			expect(summary?.totalOutputTokens).toBe(160);
+			expect(summary?.totalCost).toBeCloseTo(0.021, 8);
 		});
 	});
 

--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.test.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.test.tsx
@@ -206,6 +206,28 @@ describe("ClineAgentChatPanel", () => {
 		expect(container.textContent).toContain('Failed to load MCP server "linear"');
 	});
 
+	it("shows session totals below the composer when usage metrics are available", async () => {
+		await act(async () => {
+			renderPanel(
+				root,
+				<ClineAgentChatPanel
+					taskId="task-1"
+					summary={{
+						...createSummary("awaiting_review"),
+						totalInputTokens: 1200,
+						totalOutputTokens: 345,
+						totalCost: 0.0142,
+					}}
+					onLoadMessages={async () => []}
+				/>,
+			);
+			await Promise.resolve();
+		});
+
+		expect(container.textContent).toContain("Total cost $0.0142");
+		expect(container.textContent).toContain("Total tokens 1,545");
+	});
+
 	it("renders user message images inline without a task header", async () => {
 		await act(async () => {
 			renderPanel(

--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
@@ -34,6 +34,41 @@ import type {
 import type { TaskImage } from "@/types";
 
 const BOTTOM_LOCK_THRESHOLD_PX = 24;
+const NUMBER_FORMATTER = new Intl.NumberFormat("en-US");
+
+function formatSessionCost(cost: number): string {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 4,
+	}).format(cost);
+}
+
+function buildUsageSummaryLine(summary: RuntimeTaskSessionSummary | null): string | null {
+	if (!summary) {
+		return null;
+	}
+	const usageParts: string[] = [];
+	const totalCost =
+		typeof summary.totalCost === "number" && Number.isFinite(summary.totalCost) ? summary.totalCost : null;
+	if (totalCost !== null) {
+		usageParts.push(`Total cost ${formatSessionCost(totalCost)}`);
+	}
+	const inputTokens =
+		typeof summary.totalInputTokens === "number" && Number.isFinite(summary.totalInputTokens)
+			? summary.totalInputTokens
+			: null;
+	const outputTokens =
+		typeof summary.totalOutputTokens === "number" && Number.isFinite(summary.totalOutputTokens)
+			? summary.totalOutputTokens
+			: null;
+	if (inputTokens !== null || outputTokens !== null) {
+		const totalTokens = (inputTokens ?? 0) + (outputTokens ?? 0);
+		usageParts.push(`Total tokens ${NUMBER_FORMATTER.format(totalTokens)}`);
+	}
+	return usageParts.length > 0 ? usageParts.join(" . ") : null;
+}
 
 const ThinkingShimmer = React.memo(function ThinkingShimmer() {
 	return (
@@ -210,6 +245,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 			draftImages.length > 0 && selectedModel?.supportsVision === false
 				? "The selected Cline model may not accept image input. Choose a vision-capable model to use these images."
 				: null;
+		const usageSummaryLine = buildUsageSummaryLine(summary);
 
 		const isPinnedToBottom = useCallback((container: HTMLDivElement): boolean => {
 			const remainingDistance = container.scrollHeight - container.scrollTop - container.clientHeight;
@@ -408,6 +444,9 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 					<div className="border-t border-status-red/30 bg-status-red/10 px-2 py-2 text-xs text-status-red">
 						{panelError}
 					</div>
+				) : null}
+				{usageSummaryLine ? (
+					<div className="px-2 pt-1 text-[11px] text-text-tertiary">{usageSummaryLine}</div>
 				) : null}
 				<div className="px-2 py-3">
 					<ClineChatComposer

--- a/web-ui/src/hooks/app-utils.tsx
+++ b/web-ui/src/hooks/app-utils.tsx
@@ -86,6 +86,9 @@ export function createIdleTaskSession(taskId: string): RuntimeTaskSessionSummary
 		lastHookAt: null,
 		latestHookActivity: null,
 		warningMessage: null,
+		totalInputTokens: null,
+		totalOutputTokens: null,
+		totalCost: null,
 	};
 }
 


### PR DESCRIPTION
## Summary
This PR moves Cline usage visibility to a single session-level summary near the chat composer and removes the need to scan per-message usage rows.

The UI now shows:
- Total cost of the currently tracked session window
- Total token usage of the currently tracked session window

This is intentionally conservative for resumed chats because of current SDK data constraints described below.

## Why we are doing it this way
The goal from product was simple and pragmatic: show one running total in the composer area, not per-turn usage rows in the message stream.

To do that reliably, this implementation uses persisted per-message `metrics` (when present) as the source of truth and accumulates totals in Kanban session summary state.

This keeps the behavior deterministic and easy to reason about:
- Resume/hydration computes totals from persisted message metrics
- After a turn completes, totals are refreshed from persisted messages
- The composer renders a compact total line

## SDK limitation for resumed older sessions
For many older resumed sessions, historical messages do not include usage `metrics` for earlier turns.

When those fields are absent, there is nothing in persisted history to sum for that older portion of the conversation. As a result, the displayed total only reflects the part of the session where metrics are actually available (often from newer turns).

So if a user resumes an old session and sends a new message, they may only see totals from the newly tracked segment, not a full lifetime total for that entire historical conversation.

Until the SDK persists and exposes complete historical usage for resumed sessions, Kanban cannot reconstruct a true full-session total for those old conversations.

## Why not the approach from PR #133
PR #133 focused on per-turn usage summaries emitted into chat messages from usage events.

This PR intentionally takes a different direction:
- Scope is session-level totals near composer, not per-turn message rows
- Data source is persisted message metrics accumulation, not rendering usage events as chat items
- UX is lower-noise and aligned with the current request for one running total indicator

Tradeoff:
- Per-turn rows provide granular turn-level visibility
- Composer totals provide a cleaner high-level signal and match the requested UX

Given the current SDK limitation for older resumed history, both approaches still face missing historical usage for some old sessions. This PR just presents the available data in the requested place and format.

## Technical approach
- Extended `RuntimeTaskSessionSummary` with total usage fields (`totalInputTokens`, `totalOutputTokens`, `totalCost`)
- Added persisted metric accumulation in Cline message repository hydration path
- Updated task session service to refresh totals from persisted messages on completed turns
- Rendered compact totals line above composer in Cline chat panel
- Added backend and UI tests for resume totals, turn refresh behavior, and composer rendering

## Debugging and decisions
During debugging we validated that:
- Resume paths can restore chat content correctly
- Older resumed transcripts frequently lack historical `metrics` on earlier messages
- Totals looked correct only after newer turns because those turns had metrics

I considered adding broader fallback logic that inferred or merged usage from non-persisted runtime channels, but that would have introduced higher complexity and less predictable behavior for this PR. We kept the implementation straightforward and based on persisted data.

## Testing
- `pnpm typecheck`
- `pnpm test`
- Additional targeted checks during development:
  - runtime Cline session/task tests
  - runtime API tests
  - web-ui chat panel and runtime actions tests

## Known limitation
If resumed historical messages do not include usage metrics, the displayed totals cannot represent the full historical lifetime of that conversation. They only represent the portion for which metrics exist.
