### PR TITLE
Move auto-review automation into the runtime

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,6 +334,9 @@ async function runScopedCommand(command: string, cwd: string): Promise<RuntimeCo
 	});
 }
 
+/**
+ * Boots the local Kanban runtime server and returns lifecycle helpers for shutdown flows.
+ */
 async function startServer(): Promise<{
 	url: string;
 	close: () => Promise<void>;
@@ -352,6 +355,7 @@ async function startServer(): Promise<{
 	*/
 	const [
 		{ resolveProjectInputPath },
+		{ createRuntimeTaskAutomation },
 		{ pickDirectoryPathFromSystemDialog },
 		{ createRuntimeServer },
 		{ createRuntimeStateHub },
@@ -360,6 +364,7 @@ async function startServer(): Promise<{
 		{ collectProjectWorktreeTaskIdsForRemoval, createWorkspaceRegistry },
 	] = await Promise.all([
 		import("./projects/project-path.js"),
+		import("./server/runtime-task-automation.js"),
 		import("./server/directory-picker.js"),
 		import("./server/runtime-server.js"),
 		import("./server/runtime-state-hub.js"),
@@ -368,6 +373,7 @@ async function startServer(): Promise<{
 		import("./server/workspace-registry.js"),
 	]);
 	let runtimeStateHub: RuntimeStateHub | undefined;
+	let runtimeTaskAutomation: ReturnType<typeof createRuntimeTaskAutomation> | undefined;
 	const workspaceRegistry = await createWorkspaceRegistry({
 		cwd: process.cwd(),
 		loadGlobalRuntimeConfig,
@@ -376,6 +382,7 @@ async function startServer(): Promise<{
 		pathIsDirectory,
 		onTerminalManagerReady: (workspaceId, manager) => {
 			runtimeStateHub?.trackTerminalManager(workspaceId, manager);
+			runtimeTaskAutomation?.trackTerminalManager(workspaceId, manager);
 		},
 	});
 	runtimeStateHub = createRuntimeStateHub({
@@ -396,12 +403,16 @@ async function startServer(): Promise<{
 			stopTerminalSessions: options?.stopTerminalSessions,
 		});
 		runtimeHub.disposeWorkspace(workspaceId);
+		runtimeTaskAutomation?.disposeWorkspace(workspaceId);
 		return disposed;
 	};
 
 	const runtimeServer = await createRuntimeServer({
 		workspaceRegistry,
 		runtimeStateHub: runtimeHub,
+		onClineTaskSessionServiceReady: (workspaceId, service) => {
+			runtimeTaskAutomation?.trackClineTaskSessionService(workspaceId, service);
+		},
 		warn: (message) => {
 			console.warn(`[kanban] ${message}`);
 		},
@@ -415,8 +426,15 @@ async function startServer(): Promise<{
 		collectProjectWorktreeTaskIdsForRemoval,
 		pickDirectoryPathFromSystemDialog,
 	});
+	runtimeTaskAutomation = createRuntimeTaskAutomation({
+		getWorkspacePathById: workspaceRegistry.getWorkspacePathById,
+	});
+	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
+		runtimeTaskAutomation.trackTerminalManager(workspaceId, terminalManager);
+	}
 
 	const close = async () => {
+		runtimeTaskAutomation?.close();
 		await runtimeServer.close();
 	};
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -439,12 +439,18 @@ async function startServer(): Promise<{
 		getWorkspacePathById: workspaceRegistry.getWorkspacePathById,
 		taskGitActionCoordinator,
 	});
-	for (const { workspaceId, repoPath } of await listWorkspaceIndexEntries()) {
+	const rememberedWorkspaces = await listWorkspaceIndexEntries();
+	for (const { workspaceId, repoPath } of rememberedWorkspaces) {
 		workspaceRegistry.rememberWorkspace(workspaceId, repoPath);
 	}
 	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
 		runtimeTaskAutomation.trackTerminalManager(workspaceId, terminalManager);
 	}
+	await Promise.all(
+		rememberedWorkspaces.map(async ({ workspaceId, repoPath }) => {
+			await runtimeServer.ensureClineTaskSessionService(workspaceId, repoPath);
+		}),
+	);
 
 	const close = async () => {
 		runtimeTaskAutomation?.close();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -356,24 +356,29 @@ async function startServer(): Promise<{
 	const [
 		{ resolveProjectInputPath },
 		{ createRuntimeTaskAutomation },
+		{ createRuntimeTaskGitActionCoordinator },
 		{ pickDirectoryPathFromSystemDialog },
 		{ createRuntimeServer },
 		{ createRuntimeStateHub },
 		{ resolveInteractiveShellCommand },
 		{ shutdownRuntimeServer },
 		{ collectProjectWorktreeTaskIdsForRemoval, createWorkspaceRegistry },
+		{ listWorkspaceIndexEntries },
 	] = await Promise.all([
 		import("./projects/project-path.js"),
 		import("./server/runtime-task-automation.js"),
+		import("./server/runtime-task-git-actions.js"),
 		import("./server/directory-picker.js"),
 		import("./server/runtime-server.js"),
 		import("./server/runtime-state-hub.js"),
 		import("./server/shell.js"),
 		import("./server/shutdown-coordinator.js"),
 		import("./server/workspace-registry.js"),
+		import("./state/workspace-state.js"),
 	]);
 	let runtimeStateHub: RuntimeStateHub | undefined;
 	let runtimeTaskAutomation: ReturnType<typeof createRuntimeTaskAutomation> | undefined;
+	const taskGitActionCoordinator = createRuntimeTaskGitActionCoordinator();
 	const workspaceRegistry = await createWorkspaceRegistry({
 		cwd: process.cwd(),
 		loadGlobalRuntimeConfig,
@@ -410,6 +415,7 @@ async function startServer(): Promise<{
 	const runtimeServer = await createRuntimeServer({
 		workspaceRegistry,
 		runtimeStateHub: runtimeHub,
+		taskGitActionCoordinator,
 		onClineTaskSessionServiceReady: (workspaceId, service) => {
 			runtimeTaskAutomation?.trackClineTaskSessionService(workspaceId, service);
 		},
@@ -428,13 +434,19 @@ async function startServer(): Promise<{
 	});
 	runtimeTaskAutomation = createRuntimeTaskAutomation({
 		getWorkspacePathById: workspaceRegistry.getWorkspacePathById,
+		taskGitActionCoordinator,
 	});
+	for (const { workspaceId, repoPath } of await listWorkspaceIndexEntries()) {
+		workspaceRegistry.rememberWorkspace(workspaceId, repoPath);
+		runtimeTaskAutomation.trackWorkspace(workspaceId);
+	}
 	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
 		runtimeTaskAutomation.trackTerminalManager(workspaceId, terminalManager);
 	}
 
 	const close = async () => {
 		runtimeTaskAutomation?.close();
+		taskGitActionCoordinator.close();
 		await runtimeServer.close();
 	};
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -385,6 +385,9 @@ async function startServer(): Promise<{
 		loadRuntimeConfig,
 		hasGitRepository,
 		pathIsDirectory,
+		onWorkspaceRemembered: (workspaceId) => {
+			runtimeTaskAutomation?.trackWorkspace(workspaceId);
+		},
 		onTerminalManagerReady: (workspaceId, manager) => {
 			runtimeStateHub?.trackTerminalManager(workspaceId, manager);
 			runtimeTaskAutomation?.trackTerminalManager(workspaceId, manager);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,7 +363,6 @@ async function startServer(): Promise<{
 		{ resolveInteractiveShellCommand },
 		{ shutdownRuntimeServer },
 		{ collectProjectWorktreeTaskIdsForRemoval, createWorkspaceRegistry },
-		{ listWorkspaceIndexEntries },
 	] = await Promise.all([
 		import("./projects/project-path.js"),
 		import("./server/runtime-task-automation.js"),
@@ -374,7 +373,6 @@ async function startServer(): Promise<{
 		import("./server/shell.js"),
 		import("./server/shutdown-coordinator.js"),
 		import("./server/workspace-registry.js"),
-		import("./state/workspace-state.js"),
 	]);
 	let runtimeStateHub: RuntimeStateHub | undefined;
 	let runtimeTaskAutomation: ReturnType<typeof createRuntimeTaskAutomation> | undefined;
@@ -439,9 +437,9 @@ async function startServer(): Promise<{
 		getWorkspacePathById: workspaceRegistry.getWorkspacePathById,
 		taskGitActionCoordinator,
 	});
-	for (const { workspaceId, repoPath } of await listWorkspaceIndexEntries()) {
-		workspaceRegistry.rememberWorkspace(workspaceId, repoPath);
-		runtimeTaskAutomation.trackWorkspace(workspaceId);
+	const activeWorkspaceId = workspaceRegistry.getActiveWorkspaceId();
+	if (activeWorkspaceId) {
+		runtimeTaskAutomation.trackWorkspace(activeWorkspaceId);
 	}
 	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
 		runtimeTaskAutomation.trackTerminalManager(workspaceId, terminalManager);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,6 +363,7 @@ async function startServer(): Promise<{
 		{ resolveInteractiveShellCommand },
 		{ shutdownRuntimeServer },
 		{ collectProjectWorktreeTaskIdsForRemoval, createWorkspaceRegistry },
+		{ listWorkspaceIndexEntries },
 	] = await Promise.all([
 		import("./projects/project-path.js"),
 		import("./server/runtime-task-automation.js"),
@@ -373,6 +374,7 @@ async function startServer(): Promise<{
 		import("./server/shell.js"),
 		import("./server/shutdown-coordinator.js"),
 		import("./server/workspace-registry.js"),
+		import("./state/workspace-state.js"),
 	]);
 	let runtimeStateHub: RuntimeStateHub | undefined;
 	let runtimeTaskAutomation: ReturnType<typeof createRuntimeTaskAutomation> | undefined;
@@ -437,9 +439,8 @@ async function startServer(): Promise<{
 		getWorkspacePathById: workspaceRegistry.getWorkspacePathById,
 		taskGitActionCoordinator,
 	});
-	const activeWorkspaceId = workspaceRegistry.getActiveWorkspaceId();
-	if (activeWorkspaceId) {
-		runtimeTaskAutomation.trackWorkspace(activeWorkspaceId);
+	for (const { workspaceId, repoPath } of await listWorkspaceIndexEntries()) {
+		workspaceRegistry.rememberWorkspace(workspaceId, repoPath);
 	}
 	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
 		runtimeTaskAutomation.trackTerminalManager(workspaceId, terminalManager);

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -807,6 +807,23 @@ export const runtimeTaskSessionInputResponseSchema = z.object({
 });
 export type RuntimeTaskSessionInputResponse = z.infer<typeof runtimeTaskSessionInputResponseSchema>;
 
+export const runtimeTaskGitActionSchema = z.enum(["commit", "pr"]);
+export type RuntimeTaskGitAction = z.infer<typeof runtimeTaskGitActionSchema>;
+
+export const runtimeTaskGitActionRequestSchema = z.object({
+	taskId: z.string(),
+	baseRef: z.string(),
+	action: runtimeTaskGitActionSchema,
+});
+export type RuntimeTaskGitActionRequest = z.infer<typeof runtimeTaskGitActionRequestSchema>;
+
+export const runtimeTaskGitActionResponseSchema = z.object({
+	ok: z.boolean(),
+	summary: runtimeTaskSessionSummarySchema.nullable(),
+	error: z.string().optional(),
+});
+export type RuntimeTaskGitActionResponse = z.infer<typeof runtimeTaskGitActionResponseSchema>;
+
 export const runtimeTaskChatMessageSchema = z.object({
 	id: z.string(),
 	role: z.enum(["user", "assistant", "system", "tool", "reasoning", "status"]),

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -810,10 +810,14 @@ export type RuntimeTaskSessionInputResponse = z.infer<typeof runtimeTaskSessionI
 export const runtimeTaskGitActionSchema = z.enum(["commit", "pr"]);
 export type RuntimeTaskGitAction = z.infer<typeof runtimeTaskGitActionSchema>;
 
+export const runtimeTaskGitActionSourceSchema = z.enum(["manual", "auto"]);
+export type RuntimeTaskGitActionSource = z.infer<typeof runtimeTaskGitActionSourceSchema>;
+
 export const runtimeTaskGitActionRequestSchema = z.object({
 	taskId: z.string(),
 	baseRef: z.string(),
 	action: runtimeTaskGitActionSchema,
+	source: runtimeTaskGitActionSourceSchema,
 });
 export type RuntimeTaskGitActionRequest = z.infer<typeof runtimeTaskGitActionRequestSchema>;
 

--- a/src/core/api-validation.ts
+++ b/src/core/api-validation.ts
@@ -19,6 +19,7 @@ import {
 	type RuntimeTaskChatMessagesRequest,
 	type RuntimeTaskChatReloadRequest,
 	type RuntimeTaskChatSendRequest,
+	type RuntimeTaskGitActionRequest,
 	type RuntimeTaskSessionInputRequest,
 	type RuntimeTaskSessionStartRequest,
 	type RuntimeTaskSessionStopRequest,
@@ -47,6 +48,7 @@ import {
 	runtimeTaskChatMessagesRequestSchema,
 	runtimeTaskChatReloadRequestSchema,
 	runtimeTaskChatSendRequestSchema,
+	runtimeTaskGitActionRequestSchema,
 	runtimeTaskSessionInputRequestSchema,
 	runtimeTaskSessionStartRequestSchema,
 	runtimeTaskSessionStopRequestSchema,
@@ -245,6 +247,23 @@ export function parseTaskSessionInputRequest(value: unknown): RuntimeTaskSession
 	return {
 		...parsed,
 		taskId,
+	};
+}
+
+export function parseTaskGitActionRequest(value: unknown): RuntimeTaskGitActionRequest {
+	const parsed = parseWithSchema(runtimeTaskGitActionRequestSchema, value);
+	const taskId = parsed.taskId.trim();
+	const baseRef = parsed.baseRef.trim();
+	if (!taskId) {
+		throw new Error("Task git action taskId cannot be empty.");
+	}
+	if (!baseRef) {
+		throw new Error("Task git action baseRef cannot be empty.");
+	}
+	return {
+		...parsed,
+		taskId,
+		baseRef,
 	};
 }
 

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -36,6 +36,7 @@ interface DisposeTrackedWorkspaceResult {
 export interface CreateRuntimeServerDependencies {
 	workspaceRegistry: WorkspaceRegistry;
 	runtimeStateHub: RuntimeStateHub;
+	onClineTaskSessionServiceReady?: (workspaceId: string, service: ClineTaskSessionService) => void;
 	warn: (message: string) => void;
 	ensureTerminalManagerForWorkspace: (workspaceId: string, repoPath: string) => Promise<TerminalSessionManager>;
 	resolveInteractiveShellCommand: () => { binary: string; args: string[] };
@@ -77,6 +78,9 @@ function readWorkspaceIdFromRequest(request: IncomingMessage, requestUrl: URL): 
 	return null;
 }
 
+/**
+ * Creates the local Kanban runtime server and wires its TRPC, websocket, and workspace-scoped services together.
+ */
 export async function createRuntimeServer(deps: CreateRuntimeServerDependencies): Promise<RuntimeServer> {
 	const webUiDir = getWebUiDir();
 
@@ -130,6 +134,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 			});
 			clineTaskSessionServiceByWorkspaceId.set(scope.workspaceId, service);
 			deps.runtimeStateHub.trackClineTaskSessionService(scope.workspaceId, scope.workspacePath, service);
+			deps.onClineTaskSessionServiceReady?.(scope.workspaceId, service);
 		}
 		return service;
 	};

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -26,6 +26,7 @@ import { createRuntimeApi } from "../trpc/runtime-api";
 import { createWorkspaceApi } from "../trpc/workspace-api";
 import { getWebUiDir, normalizeRequestPath, readAsset } from "./assets";
 import type { RuntimeStateHub } from "./runtime-state-hub";
+import type { RuntimeTaskGitActionCoordinator } from "./runtime-task-git-actions";
 import type { WorkspaceRegistry } from "./workspace-registry";
 
 interface DisposeTrackedWorkspaceResult {
@@ -36,6 +37,7 @@ interface DisposeTrackedWorkspaceResult {
 export interface CreateRuntimeServerDependencies {
 	workspaceRegistry: WorkspaceRegistry;
 	runtimeStateHub: RuntimeStateHub;
+	taskGitActionCoordinator: RuntimeTaskGitActionCoordinator;
 	onClineTaskSessionServiceReady?: (workspaceId: string, service: ClineTaskSessionService) => void;
 	warn: (message: string) => void;
 	ensureTerminalManagerForWorkspace: (workspaceId: string, repoPath: string) => Promise<TerminalSessionManager>;
@@ -189,6 +191,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 				broadcastTaskChatCleared: deps.runtimeStateHub.broadcastTaskChatCleared,
 				bumpClineSessionContextVersion: deps.runtimeStateHub.bumpClineSessionContextVersion,
 				prepareForStateReset,
+				taskGitActionCoordinator: deps.taskGitActionCoordinator,
 			}),
 			workspaceApi: createWorkspaceApi({
 				ensureTerminalManagerForWorkspace: deps.ensureTerminalManagerForWorkspace,

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -58,6 +58,7 @@ export interface CreateRuntimeServerDependencies {
 
 export interface RuntimeServer {
 	url: string;
+	ensureClineTaskSessionService: (workspaceId: string, workspacePath: string) => Promise<void>;
 	close: () => Promise<void>;
 }
 
@@ -170,6 +171,16 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 			});
 		}
 		deps.workspaceRegistry.clearActiveWorkspace();
+	};
+
+	/**
+	 * Ensures a workspace-scoped native Cline service exists so automation can rebind persisted sessions after restart.
+	 */
+	const ensureClineTaskSessionService = async (workspaceId: string, workspacePath: string): Promise<void> => {
+		await getScopedClineTaskSessionService({
+			workspaceId,
+			workspacePath,
+		});
 	};
 
 	const createTrpcContext = async (req: IncomingMessage): Promise<RuntimeTrpcContext> => {
@@ -319,6 +330,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 
 	return {
 		url,
+		ensureClineTaskSessionService,
 		close: async () => {
 			await Promise.all(
 				Array.from(clineTaskSessionServiceByWorkspaceId.values()).map(async (service) => {

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -378,12 +378,25 @@ describe("createRuntimeTaskAutomation", () => {
 		});
 		expect(runtimeClient.workspace.notifyStateUpdated.mutate).not.toHaveBeenCalled();
 
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "running",
+				reviewReason: null,
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.workspace.deleteWorktree.mutate).not.toHaveBeenCalled();
+
 		changedFilesByTaskPath["/repo/task-1"] = 0;
 		emitter.emitSummary(
 			createSummary("task-1", {
 				state: "awaiting_review",
 				reviewReason: "hook",
-				updatedAt: 6,
+				updatedAt: 7,
 			}),
 		);
 		await flushMicrotasks();

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -155,6 +155,7 @@ function createWorkspaceState(): RuntimeWorkspaceStateResponse {
  */
 function createTerminalManager(initialSummaries: RuntimeTaskSessionSummary[]): {
 	manager: {
+		hasActiveTaskSession: (taskId: string) => boolean;
 		listSummaries: () => RuntimeTaskSessionSummary[];
 		onSummary: (listener: (summary: RuntimeTaskSessionSummary) => void) => () => void;
 	};
@@ -164,6 +165,7 @@ function createTerminalManager(initialSummaries: RuntimeTaskSessionSummary[]): {
 	const listeners = new Set<(summary: RuntimeTaskSessionSummary) => void>();
 	return {
 		manager: {
+			hasActiveTaskSession: (taskId) => summaries.some((summary) => summary.taskId === taskId),
 			listSummaries: () => [...summaries],
 			onSummary: (listener) => {
 				listeners.add(listener);
@@ -517,7 +519,7 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
-	it("polls persisted workspaces before any terminal manager is created", async () => {
+	it("ignores persisted review summaries until a live session service is attached", async () => {
 		workspaceState.sessions = {
 			"task-1": createSummary("task-1", {
 				state: "awaiting_review",
@@ -534,6 +536,20 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.trackWorkspace("workspace-1");
 		await flushMicrotasks();
 
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		const { manager } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 6,
+			}),
+		]);
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
 		await vi.advanceTimersByTimeAsync(1_200);
 		await flushMicrotasks();
 

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -188,8 +188,13 @@ function createTerminalManager(initialSummaries: RuntimeTaskSessionSummary[]): {
 /**
  * Creates a fake Cline service with the subset of summary APIs used by the automation controller.
  */
-function createClineService(initialSummaries: RuntimeTaskSessionSummary[]): {
-	service: Pick<ClineTaskSessionService, "listSummaries" | "onSummary">;
+function createClineService(
+	initialSummaries: RuntimeTaskSessionSummary[],
+	options?: {
+		reboundSummaryByTaskId?: Record<string, RuntimeTaskSessionSummary>;
+	},
+): {
+	service: Pick<ClineTaskSessionService, "listSummaries" | "onSummary" | "rebindPersistedTaskSession">;
 	emitter: SummaryEmitter;
 } {
 	let summaries = [...initialSummaries];
@@ -203,6 +208,17 @@ function createClineService(initialSummaries: RuntimeTaskSessionSummary[]): {
 					listeners.delete(listener);
 				};
 			},
+			rebindPersistedTaskSession: vi.fn(async (taskId: string) => {
+				const reboundSummary = options?.reboundSummaryByTaskId?.[taskId] ?? null;
+				if (!reboundSummary) {
+					return null;
+				}
+				summaries = [
+					...summaries.filter((candidate) => candidate.taskId !== reboundSummary.taskId),
+					reboundSummary,
+				];
+				return reboundSummary;
+			}),
 		},
 		emitter: {
 			emitSummary: (summary) => {
@@ -473,6 +489,60 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("rebinds persisted cline review summaries before auto-reviewing them", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "pr",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+		workspaceState.sessions = {
+			"task-1": createSummary("task-1", {
+				state: "awaiting_review",
+				agentId: "cline",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		};
+
+		const { service } = createClineService([], {
+			reboundSummaryByTaskId: {
+				"task-1": createSummary("task-1", {
+					state: "awaiting_review",
+					agentId: "cline",
+					reviewReason: "attention",
+					updatedAt: 6,
+				}),
+			},
+		});
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackClineTaskSessionService("workspace-1", service as ClineTaskSessionService);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(service.rebindPersistedTaskSession).toHaveBeenCalledWith("task-1");
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "pr",
+			source: "auto",
+		});
+
+		automation.close();
+	});
+
 	it("suppresses auto-review while a manual git action is already pending", async () => {
 		const { manager, emitter } = createTerminalManager([
 			createSummary("task-1", {
@@ -608,6 +678,47 @@ describe("createRuntimeTaskAutomation", () => {
 			action: "commit",
 			source: "auto",
 		});
+
+		automation.close();
+	});
+
+	it("auto-trashes review cards configured for move_to_trash without a live session", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "move_to_trash",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.workspace.deleteWorktree.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+		});
+		expect(runtimeClient.runtime.startTaskSession.mutate).toHaveBeenCalledWith({
+			taskId: "task-2",
+			prompt: "Follow-up task",
+			startInPlanMode: false,
+			baseRef: "main",
+			images: undefined,
+		});
+		expect(getBoardColumn(workspaceState, "trash").cards[0]?.id).toBe("task-1");
+		expect(getBoardColumn(workspaceState, "in_progress").cards[0]?.id).toBe("task-2");
 
 		automation.close();
 	});

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -589,6 +589,53 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("preserves an in-flight manual git action when review automation is disabled", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: false,
+				autoReviewMode: "commit",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+
+		const { manager } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(false);
+
+		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
+			dispatched: false,
+			armAutoCleanup: false,
+		});
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(true);
+		taskGitActionCoordinator.clearTaskGitAction("workspace-1", "task-1");
+
+		automation.close();
+	});
+
 	it("keeps auto git actions blocked until the session changes after dispatch", async () => {
 		const { manager, emitter } = createTerminalManager([
 			createSummary("task-1", {

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -1,0 +1,487 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ClineTaskSessionService } from "../cline-sdk/cline-task-session-service";
+import type { RuntimeTaskSessionSummary, RuntimeWorkspaceStateResponse } from "../core/api-contract";
+import { createRuntimeTaskAutomation } from "./runtime-task-automation";
+
+const createTrpcProxyClientMock = vi.hoisted(() => vi.fn());
+const httpBatchLinkMock = vi.hoisted(() => vi.fn(() => ({})));
+const loadWorkspaceStateMock = vi.hoisted(() => vi.fn());
+const mutateWorkspaceStateMock = vi.hoisted(() => vi.fn());
+const resolveTaskCwdMock = vi.hoisted(() => vi.fn());
+const getGitSyncSummaryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@trpc/client", () => ({
+	createTRPCProxyClient: createTrpcProxyClientMock,
+	httpBatchLink: httpBatchLinkMock,
+}));
+
+vi.mock("../state/workspace-state", () => ({
+	loadWorkspaceState: loadWorkspaceStateMock,
+	mutateWorkspaceState: mutateWorkspaceStateMock,
+}));
+
+vi.mock("../workspace/task-worktree", () => ({
+	resolveTaskCwd: resolveTaskCwdMock,
+}));
+
+vi.mock("../workspace/git-sync", () => ({
+	getGitSyncSummary: getGitSyncSummaryMock,
+}));
+
+interface SummaryEmitter {
+	emitSummary: (summary: RuntimeTaskSessionSummary) => void;
+}
+
+/**
+ * Flushes pending promise callbacks between timer advances so the automation loop can settle.
+ */
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+/**
+ * Creates a task-session summary fixture with predictable defaults for automation tests.
+ */
+function createSummary(taskId: string, overrides: Partial<RuntimeTaskSessionSummary>): RuntimeTaskSessionSummary {
+	return {
+		taskId,
+		state: "idle",
+		mode: null,
+		agentId: "codex",
+		workspacePath: "/repo",
+		pid: 123,
+		startedAt: 1,
+		updatedAt: 1,
+		lastOutputAt: 1,
+		reviewReason: null,
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+		warningMessage: null,
+		latestTurnCheckpoint: null,
+		previousTurnCheckpoint: null,
+		...overrides,
+	};
+}
+
+/**
+ * Returns a board column by id and fails loudly if the fixture shape changes unexpectedly.
+ */
+function getBoardColumn(state: RuntimeWorkspaceStateResponse, columnId: string) {
+	const column = state.board.columns.find((candidate) => candidate.id === columnId);
+	if (!column) {
+		throw new Error(`Expected board column "${columnId}" to exist.`);
+	}
+	return column;
+}
+
+/**
+ * Creates a minimal workspace state fixture with standard Kanban columns.
+ */
+function createWorkspaceState(): RuntimeWorkspaceStateResponse {
+	return {
+		repoPath: "/repo",
+		statePath: "/repo/.state",
+		git: {
+			currentBranch: "main",
+			defaultBranch: "main",
+			branches: ["main"],
+		},
+		board: {
+			columns: [
+				{
+					id: "backlog",
+					title: "Backlog",
+					cards: [
+						{
+							id: "task-2",
+							prompt: "Follow-up task",
+							startInPlanMode: false,
+							autoReviewEnabled: false,
+							autoReviewMode: "commit",
+							baseRef: "main",
+							createdAt: 2,
+							updatedAt: 2,
+						},
+					],
+				},
+				{
+					id: "in_progress",
+					title: "In Progress",
+					cards: [
+						{
+							id: "task-1",
+							prompt: "Primary task",
+							startInPlanMode: false,
+							autoReviewEnabled: true,
+							autoReviewMode: "commit",
+							baseRef: "main",
+							createdAt: 1,
+							updatedAt: 1,
+						},
+					],
+				},
+				{
+					id: "review",
+					title: "Review",
+					cards: [],
+				},
+				{
+					id: "trash",
+					title: "Trash",
+					cards: [],
+				},
+			],
+			dependencies: [
+				{
+					id: "dep-1",
+					fromTaskId: "task-2",
+					toTaskId: "task-1",
+					createdAt: 10,
+				},
+			],
+		},
+		sessions: {},
+		revision: 1,
+	};
+}
+
+/**
+ * Creates a fake terminal manager with summary listeners that the automation controller can subscribe to.
+ */
+function createTerminalManager(initialSummaries: RuntimeTaskSessionSummary[]): {
+	manager: {
+		listSummaries: () => RuntimeTaskSessionSummary[];
+		onSummary: (listener: (summary: RuntimeTaskSessionSummary) => void) => () => void;
+	};
+	emitter: SummaryEmitter;
+} {
+	let summaries = [...initialSummaries];
+	const listeners = new Set<(summary: RuntimeTaskSessionSummary) => void>();
+	return {
+		manager: {
+			listSummaries: () => [...summaries],
+			onSummary: (listener) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			},
+		},
+		emitter: {
+			emitSummary: (summary) => {
+				summaries = [...summaries.filter((candidate) => candidate.taskId !== summary.taskId), summary];
+				for (const listener of listeners) {
+					listener(summary);
+				}
+			},
+		},
+	};
+}
+
+/**
+ * Creates a fake Cline service with the subset of summary APIs used by the automation controller.
+ */
+function createClineService(initialSummaries: RuntimeTaskSessionSummary[]): {
+	service: Pick<ClineTaskSessionService, "listSummaries" | "onSummary">;
+	emitter: SummaryEmitter;
+} {
+	let summaries = [...initialSummaries];
+	const listeners = new Set<(summary: RuntimeTaskSessionSummary) => void>();
+	return {
+		service: {
+			listSummaries: () => [...summaries],
+			onSummary: (listener) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			},
+		},
+		emitter: {
+			emitSummary: (summary) => {
+				summaries = [...summaries.filter((candidate) => candidate.taskId !== summary.taskId), summary];
+				for (const listener of listeners) {
+					listener(summary);
+				}
+			},
+		},
+	};
+}
+
+describe("createRuntimeTaskAutomation", () => {
+	let workspaceState: RuntimeWorkspaceStateResponse;
+	let runtimeClient: {
+		runtime: {
+			getConfig: { query: ReturnType<typeof vi.fn> };
+			sendTaskChatMessage: { mutate: ReturnType<typeof vi.fn> };
+			sendTaskSessionInput: { mutate: ReturnType<typeof vi.fn> };
+			startTaskSession: { mutate: ReturnType<typeof vi.fn> };
+			stopTaskSession: { mutate: ReturnType<typeof vi.fn> };
+		};
+		workspace: {
+			getTaskContext: { query: ReturnType<typeof vi.fn> };
+			ensureWorktree: { mutate: ReturnType<typeof vi.fn> };
+			deleteWorktree: { mutate: ReturnType<typeof vi.fn> };
+			notifyStateUpdated: { mutate: ReturnType<typeof vi.fn> };
+		};
+	};
+	let changedFilesByTaskPath: Record<string, number>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		workspaceState = createWorkspaceState();
+		changedFilesByTaskPath = {
+			"/repo/task-1": 2,
+			"/repo/task-2": 0,
+		};
+		runtimeClient = {
+			runtime: {
+				getConfig: {
+					query: vi.fn(async () => ({
+						selectedAgentId: "codex",
+						selectedShortcutLabel: null,
+						agentAutonomousModeEnabled: true,
+						effectiveCommand: null,
+						globalConfigPath: "/tmp/global-config.json",
+						projectConfigPath: "/tmp/project-config.json",
+						readyForReviewNotificationsEnabled: true,
+						detectedCommands: [],
+						agents: [],
+						shortcuts: [],
+						clineProviderSettings: {
+							providerId: "anthropic",
+							modelId: "claude-sonnet-4",
+							baseUrl: null,
+							apiKeyConfigured: true,
+							oauthProvider: null,
+							oauthAccessTokenConfigured: false,
+							oauthRefreshTokenConfigured: false,
+							oauthAccountId: null,
+							oauthExpiresAt: null,
+						},
+						commitPromptTemplate: "commit {{base_ref}}",
+						openPrPromptTemplate: "open pr {{base_ref}}",
+						commitPromptTemplateDefault: "commit {{base_ref}}",
+						openPrPromptTemplateDefault: "open pr {{base_ref}}",
+					})),
+				},
+				sendTaskChatMessage: {
+					mutate: vi.fn(async () => ({ ok: true })),
+				},
+				sendTaskSessionInput: {
+					mutate: vi.fn(async () => ({ ok: true })),
+				},
+				startTaskSession: {
+					mutate: vi.fn(async ({ taskId }) => ({
+						ok: true,
+						summary: createSummary(taskId, {
+							state: "running",
+							updatedAt: 20,
+						}),
+					})),
+				},
+				stopTaskSession: {
+					mutate: vi.fn(async () => ({
+						ok: true,
+						summary: null,
+					})),
+				},
+			},
+			workspace: {
+				getTaskContext: {
+					query: vi.fn(async ({ taskId, baseRef }) => ({
+						taskId,
+						path: `/repo/${taskId}`,
+						exists: true,
+						baseRef,
+						branch: taskId,
+						isDetached: false,
+						headCommit: "abc1234",
+					})),
+				},
+				ensureWorktree: {
+					mutate: vi.fn(async () => ({
+						ok: true,
+						path: "/repo/task-2",
+						baseRef: "main",
+					})),
+				},
+				deleteWorktree: {
+					mutate: vi.fn(async () => ({
+						ok: true,
+						removed: true,
+					})),
+				},
+				notifyStateUpdated: {
+					mutate: vi.fn(async () => ({ ok: true })),
+				},
+			},
+		};
+
+		createTrpcProxyClientMock.mockReset();
+		createTrpcProxyClientMock.mockReturnValue(runtimeClient);
+		httpBatchLinkMock.mockClear();
+
+		loadWorkspaceStateMock.mockReset();
+		loadWorkspaceStateMock.mockImplementation(async () => structuredClone(workspaceState));
+
+		mutateWorkspaceStateMock.mockReset();
+		mutateWorkspaceStateMock.mockImplementation(async (_cwd, mutate) => {
+			const mutation = mutate(structuredClone(workspaceState));
+			const nextBoard = mutation.board;
+			const nextSessions = mutation.sessions ?? workspaceState.sessions;
+			const nextRevision = mutation.save === false ? workspaceState.revision : workspaceState.revision + 1;
+			if (mutation.save !== false) {
+				workspaceState = {
+					...workspaceState,
+					board: nextBoard,
+					sessions: nextSessions,
+					revision: nextRevision,
+				};
+			}
+			return {
+				value: mutation.value,
+				state: structuredClone(
+					mutation.save === false
+						? workspaceState
+						: {
+								...workspaceState,
+								board: nextBoard,
+								sessions: nextSessions,
+								revision: nextRevision,
+							},
+				),
+				saved: mutation.save !== false,
+			};
+		});
+
+		resolveTaskCwdMock.mockReset();
+		resolveTaskCwdMock.mockImplementation(async ({ taskId }) => `/repo/${taskId}`);
+
+		getGitSyncSummaryMock.mockReset();
+		getGitSyncSummaryMock.mockImplementation(async (cwd: string) => ({
+			currentBranch: "main",
+			upstreamBranch: null,
+			changedFiles: changedFilesByTaskPath[cwd] ?? 0,
+			additions: 0,
+			deletions: 0,
+			aheadCount: 0,
+			behindCount: 0,
+		}));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("moves review-ready tasks on the server, auto-commits them, and starts linked tasks after trashing", async () => {
+		const { manager, emitter } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+		});
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+
+		expect(workspaceState.board.columns.find((column) => column.id === "review")?.cards[0]?.id).toBe("task-1");
+
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).toHaveBeenNthCalledWith(1, {
+			taskId: "task-1",
+			text: "commit main",
+			appendNewline: false,
+		});
+		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).toHaveBeenNthCalledWith(2, {
+			taskId: "task-1",
+			text: "\r",
+			appendNewline: false,
+		});
+
+		changedFilesByTaskPath["/repo/task-1"] = 0;
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.stopTaskSession.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+		});
+		expect(runtimeClient.workspace.deleteWorktree.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+		});
+		expect(runtimeClient.runtime.startTaskSession.mutate).toHaveBeenCalledWith({
+			taskId: "task-2",
+			prompt: "Follow-up task",
+			startInPlanMode: false,
+			baseRef: "main",
+			images: undefined,
+		});
+		expect(workspaceState.board.columns.find((column) => column.id === "trash")?.cards[0]?.id).toBe("task-1");
+		expect(workspaceState.board.columns.find((column) => column.id === "in_progress")?.cards[0]?.id).toBe("task-2");
+
+		automation.close();
+	});
+
+	it("routes auto-pr through the native cline chat API", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "pr",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+
+		const { service } = createClineService([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				agentId: "cline",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+		});
+
+		automation.trackClineTaskSessionService("workspace-1", service as ClineTaskSessionService);
+		await flushMicrotasks();
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.sendTaskChatMessage.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			text: "open pr main",
+			mode: "act",
+		});
+		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+});

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClineTaskSessionService } from "../cline-sdk/cline-task-session-service";
 import type { RuntimeTaskSessionSummary, RuntimeWorkspaceStateResponse } from "../core/api-contract";
 import { createRuntimeTaskAutomation } from "./runtime-task-automation";
+import { createRuntimeTaskGitActionCoordinator } from "./runtime-task-git-actions";
 
 const createTrpcProxyClientMock = vi.hoisted(() => vi.fn());
 const httpBatchLinkMock = vi.hoisted(() => vi.fn(() => ({})));
@@ -216,20 +217,18 @@ describe("createRuntimeTaskAutomation", () => {
 	let workspaceState: RuntimeWorkspaceStateResponse;
 	let runtimeClient: {
 		runtime: {
-			getConfig: { query: ReturnType<typeof vi.fn> };
-			sendTaskChatMessage: { mutate: ReturnType<typeof vi.fn> };
-			sendTaskSessionInput: { mutate: ReturnType<typeof vi.fn> };
+			runTaskGitAction: { mutate: ReturnType<typeof vi.fn> };
 			startTaskSession: { mutate: ReturnType<typeof vi.fn> };
 			stopTaskSession: { mutate: ReturnType<typeof vi.fn> };
 		};
 		workspace: {
-			getTaskContext: { query: ReturnType<typeof vi.fn> };
 			ensureWorktree: { mutate: ReturnType<typeof vi.fn> };
 			deleteWorktree: { mutate: ReturnType<typeof vi.fn> };
 			notifyStateUpdated: { mutate: ReturnType<typeof vi.fn> };
 		};
 	};
 	let changedFilesByTaskPath: Record<string, number>;
+	let taskGitActionCoordinator: ReturnType<typeof createRuntimeTaskGitActionCoordinator>;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -238,42 +237,24 @@ describe("createRuntimeTaskAutomation", () => {
 			"/repo/task-1": 2,
 			"/repo/task-2": 0,
 		};
+		taskGitActionCoordinator = createRuntimeTaskGitActionCoordinator();
 		runtimeClient = {
 			runtime: {
-				getConfig: {
-					query: vi.fn(async () => ({
-						selectedAgentId: "codex",
-						selectedShortcutLabel: null,
-						agentAutonomousModeEnabled: true,
-						effectiveCommand: null,
-						globalConfigPath: "/tmp/global-config.json",
-						projectConfigPath: "/tmp/project-config.json",
-						readyForReviewNotificationsEnabled: true,
-						detectedCommands: [],
-						agents: [],
-						shortcuts: [],
-						clineProviderSettings: {
-							providerId: "anthropic",
-							modelId: "claude-sonnet-4",
-							baseUrl: null,
-							apiKeyConfigured: true,
-							oauthProvider: null,
-							oauthAccessTokenConfigured: false,
-							oauthRefreshTokenConfigured: false,
-							oauthAccountId: null,
-							oauthExpiresAt: null,
-						},
-						commitPromptTemplate: "commit {{base_ref}}",
-						openPrPromptTemplate: "open pr {{base_ref}}",
-						commitPromptTemplateDefault: "commit {{base_ref}}",
-						openPrPromptTemplateDefault: "open pr {{base_ref}}",
-					})),
-				},
-				sendTaskChatMessage: {
-					mutate: vi.fn(async () => ({ ok: true })),
-				},
-				sendTaskSessionInput: {
-					mutate: vi.fn(async () => ({ ok: true })),
+				runTaskGitAction: {
+					mutate: vi.fn(async ({ taskId, action }) => {
+						const started = taskGitActionCoordinator.beginTaskGitAction("workspace-1", taskId, action);
+						if (!started) {
+							return {
+								ok: false,
+								summary: null,
+								error: "Task git action already pending.",
+							};
+						}
+						taskGitActionCoordinator.completeTaskGitAction("workspace-1", taskId, action, {
+							triggered: true,
+						});
+						return { ok: true, summary: null };
+					}),
 				},
 				startTaskSession: {
 					mutate: vi.fn(async ({ taskId }) => ({
@@ -292,17 +273,6 @@ describe("createRuntimeTaskAutomation", () => {
 				},
 			},
 			workspace: {
-				getTaskContext: {
-					query: vi.fn(async ({ taskId, baseRef }) => ({
-						taskId,
-						path: `/repo/${taskId}`,
-						exists: true,
-						baseRef,
-						branch: taskId,
-						isDetached: false,
-						headCommit: "abc1234",
-					})),
-				},
 				ensureWorktree: {
 					mutate: vi.fn(async () => ({
 						ok: true,
@@ -377,6 +347,7 @@ describe("createRuntimeTaskAutomation", () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+		taskGitActionCoordinator.close();
 	});
 
 	it("moves review-ready tasks on the server, auto-commits them, and starts linked tasks after trashing", async () => {
@@ -389,6 +360,7 @@ describe("createRuntimeTaskAutomation", () => {
 		]);
 		const automation = createRuntimeTaskAutomation({
 			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
 		});
 
 		automation.trackTerminalManager("workspace-1", manager as never);
@@ -399,15 +371,10 @@ describe("createRuntimeTaskAutomation", () => {
 		await vi.advanceTimersByTimeAsync(1_200);
 		await flushMicrotasks();
 
-		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).toHaveBeenNthCalledWith(1, {
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
 			taskId: "task-1",
-			text: "commit main",
-			appendNewline: false,
-		});
-		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).toHaveBeenNthCalledWith(2, {
-			taskId: "task-1",
-			text: "\r",
-			appendNewline: false,
+			baseRef: "main",
+			action: "commit",
 		});
 
 		changedFilesByTaskPath["/repo/task-1"] = 0;
@@ -442,7 +409,7 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
-	it("routes auto-pr through the native cline chat API", async () => {
+	it("routes auto-pr through the shared runtime git-action API", async () => {
 		getBoardColumn(workspaceState, "in_progress").cards = [];
 		getBoardColumn(workspaceState, "review").cards = [
 			{
@@ -467,6 +434,7 @@ describe("createRuntimeTaskAutomation", () => {
 		]);
 		const automation = createRuntimeTaskAutomation({
 			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
 		});
 
 		automation.trackClineTaskSessionService("workspace-1", service as ClineTaskSessionService);
@@ -475,12 +443,127 @@ describe("createRuntimeTaskAutomation", () => {
 		await vi.advanceTimersByTimeAsync(1_000);
 		await flushMicrotasks();
 
-		expect(runtimeClient.runtime.sendTaskChatMessage.mutate).toHaveBeenCalledWith({
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
 			taskId: "task-1",
-			text: "open pr main",
-			mode: "act",
+			baseRef: "main",
+			action: "pr",
 		});
-		expect(runtimeClient.runtime.sendTaskSessionInput.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
+	it("suppresses auto-review while a manual git action is already pending", async () => {
+		const { manager, emitter } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
+			triggered: true,
+		});
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		taskGitActionCoordinator.clearTaskGitAction("workspace-1", "task-1");
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "commit",
+		});
+
+		automation.close();
+	});
+
+	it("polls persisted workspaces before any terminal manager is created", async () => {
+		workspaceState.sessions = {
+			"task-1": createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		};
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+
+		expect(getBoardColumn(workspaceState, "review").cards[0]?.id).toBe("task-1");
+
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "commit",
+		});
+
+		automation.close();
+	});
+
+	it("moves interrupted tasks to trash before evaluating review automation", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "commit",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+		workspaceState.sessions = {
+			"task-1": createSummary("task-1", {
+				state: "interrupted",
+				reviewReason: "interrupted",
+				updatedAt: 5,
+			}),
+		};
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+
+		expect(getBoardColumn(workspaceState, "trash").cards[0]?.id).toBe("task-1");
+		expect(getBoardColumn(workspaceState, "review").cards).toHaveLength(0);
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
 
 		automation.close();
 	});

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -589,6 +589,50 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("keeps auto git actions blocked until the session changes after dispatch", async () => {
+		const { manager, emitter } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledTimes(1);
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledTimes(1);
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(false);
+
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "error",
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_000);
+		await flushMicrotasks();
+
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		taskGitActionCoordinator.clearTaskGitAction("workspace-1", "task-1");
+
+		automation.close();
+	});
+
 	it("ignores persisted review summaries until a live session service is attached", async () => {
 		workspaceState.sessions = {
 			"task-1": createSummary("task-1", {
@@ -883,6 +927,102 @@ describe("createRuntimeTaskAutomation", () => {
 
 		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
 		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
+	it("does not start a linked task session when another client moved the card before the board mutation", async () => {
+		const { manager, emitter } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		let mutateCallCount = 0;
+		mutateWorkspaceStateMock.mockImplementation(async (_cwd, mutate) => {
+			mutateCallCount += 1;
+			const baseState = structuredClone(workspaceState);
+			const stateForMutation =
+				mutateCallCount === 2
+					? {
+							...baseState,
+							board: (() => {
+								const next = structuredClone(baseState.board);
+								const backlog = next.columns.find((column) => column.id === "backlog");
+								const review = next.columns.find((column) => column.id === "review");
+								const task = backlog?.cards.find((card) => card.id === "task-2");
+								if (backlog && review && task) {
+									backlog.cards = backlog.cards.filter((card) => card.id !== "task-2");
+									review.cards = [...review.cards, task];
+								}
+								return next;
+							})(),
+					  }
+					: baseState;
+			const mutation = mutate(stateForMutation);
+			const nextBoard = mutation.board;
+			const nextSessions = mutation.sessions ?? workspaceState.sessions;
+			const nextRevision = mutation.save === false ? workspaceState.revision : workspaceState.revision + 1;
+			if (mutation.save !== false) {
+				workspaceState = {
+					...workspaceState,
+					board: nextBoard,
+					sessions: nextSessions,
+					revision: nextRevision,
+				};
+			}
+			return {
+				value: mutation.value,
+				state: structuredClone(
+					mutation.save === false
+						? workspaceState
+						: {
+								...workspaceState,
+								board: nextBoard,
+								sessions: nextSessions,
+								revision: nextRevision,
+							},
+				),
+				saved: mutation.save !== false,
+			};
+		});
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		changedFilesByTaskPath["/repo/task-1"] = 0;
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.startTaskSession.mutate).not.toHaveBeenCalledWith({
+			taskId: "task-2",
+			prompt: "Follow-up task",
+			startInPlanMode: false,
+			baseRef: "main",
+			images: undefined,
+		});
+		expect(runtimeClient.workspace.ensureWorktree.mutate).not.toHaveBeenCalledWith({
+			taskId: "task-2",
+			baseRef: "main",
+		});
+		expect(getBoardColumn(workspaceState, "backlog").cards[0]?.id).toBe("task-2");
 
 		automation.close();
 	});

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -563,6 +563,119 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("skips auto-review for dirty review cards until a live task session is attached", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "commit",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(3_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		const { manager } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 5,
+			}),
+		]);
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "commit",
+			source: "auto",
+		});
+
+		automation.close();
+	});
+
+	it("clears stale auto-cleanup state after a dirty review task returns from an auto git action", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "commit",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+
+		const { manager, emitter } = createTerminalManager([
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "error",
+				updatedAt: 5,
+			}),
+		]);
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
+			dispatched: true,
+			armAutoCleanup: true,
+		});
+
+		automation.trackTerminalManager("workspace-1", manager as never);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+		expect(taskGitActionCoordinator.isTaskGitActionBlocked("workspace-1", "task-1")).toBe(false);
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		taskGitActionCoordinator.clearTaskGitAction("workspace-1", "task-1");
+
+		emitter.emitSummary(
+			createSummary("task-1", {
+				state: "awaiting_review",
+				reviewReason: "hook",
+				updatedAt: 6,
+			}),
+		);
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(1_200);
+		await flushMicrotasks();
+
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "commit",
+			source: "auto",
+		});
+
+		automation.close();
+	});
+
 	it("does not auto-trash a clean review task after a manual git action is sent", async () => {
 		getBoardColumn(workspaceState, "in_progress").cards = [];
 		getBoardColumn(workspaceState, "review").cards = [

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -862,6 +862,54 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("does not auto-trash a task that was manually resumed in progress before the trash mutation", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "move_to_trash",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+		mutateWorkspaceStateMock.mockImplementation(async (_cwd, mutate) => {
+			const latestState = structuredClone(workspaceState);
+			const review = latestState.board.columns.find((column) => column.id === "review");
+			const inProgress = latestState.board.columns.find((column) => column.id === "in_progress");
+			const movedTask = review?.cards.find((card) => card.id === "task-1");
+			if (review && inProgress && movedTask) {
+				review.cards = review.cards.filter((card) => card.id !== "task-1");
+				inProgress.cards = [...inProgress.cards, movedTask];
+			}
+			const mutation = mutate(latestState);
+			return {
+				value: mutation.value,
+				state: structuredClone(workspaceState),
+				saved: mutation.save !== false,
+			};
+		});
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.workspace.deleteWorktree.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.runtime.startTaskSession.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.runtime.stopTaskSession.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
 	it("clears stale auto-cleanup state after a dirty review task returns from an auto git action", async () => {
 		getBoardColumn(workspaceState, "in_progress").cards = [];
 		getBoardColumn(workspaceState, "review").cards = [

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -1044,6 +1044,66 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("stops polling stale commit review cards that have no live session attached", async () => {
+		const baseState = createWorkspaceState();
+		workspaceState = {
+			...baseState,
+			board: {
+				...baseState.board,
+				columns: [
+					{
+						id: "backlog",
+						title: "Backlog",
+						cards: [],
+					},
+					{
+						id: "in_progress",
+						title: "In Progress",
+						cards: [],
+					},
+					{
+						id: "review",
+						title: "Review",
+						cards: [
+							{
+								id: "task-1",
+								prompt: "Primary task",
+								startInPlanMode: false,
+								autoReviewEnabled: true,
+								autoReviewMode: "commit",
+								baseRef: "main",
+								createdAt: 1,
+								updatedAt: 1,
+							},
+						],
+					},
+					{
+						id: "trash",
+						title: "Trash",
+						cards: [],
+					},
+				],
+			},
+			sessions: {},
+		};
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(3_000);
+		await flushMicrotasks();
+
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
 	it("does not start a linked task session when another client moved the card before the board mutation", async () => {
 		const { manager, emitter } = createTerminalManager([
 			createSummary("task-1", {

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -814,6 +814,54 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.close();
 	});
 
+	it("does not auto-trash a task that already left review before the trash mutation", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "move_to_trash",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+		mutateWorkspaceStateMock.mockImplementation(async (_cwd, mutate) => {
+			const latestState = structuredClone(workspaceState);
+			const review = latestState.board.columns.find((column) => column.id === "review");
+			const backlog = latestState.board.columns.find((column) => column.id === "backlog");
+			const movedTask = review?.cards.find((card) => card.id === "task-1");
+			if (review && backlog && movedTask) {
+				review.cards = review.cards.filter((card) => card.id !== "task-1");
+				backlog.cards = [...backlog.cards, movedTask];
+			}
+			const mutation = mutate(latestState);
+			return {
+				value: mutation.value,
+				state: structuredClone(workspaceState),
+				saved: mutation.save !== false,
+			};
+		});
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.workspace.deleteWorktree.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.runtime.startTaskSession.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.runtime.stopTaskSession.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
 	it("clears stale auto-cleanup state after a dirty review task returns from an auto git action", async () => {
 		getBoardColumn(workspaceState, "in_progress").cards = [];
 		getBoardColumn(workspaceState, "review").cards = [
@@ -974,6 +1022,24 @@ describe("createRuntimeTaskAutomation", () => {
 
 		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
 		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
+
+	it("only evaluates idle remembered workspaces once unless automation work appears", async () => {
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(3_000);
+		await flushMicrotasks();
+
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
 
 		automation.close();
 	});

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -641,4 +641,25 @@ describe("createRuntimeTaskAutomation", () => {
 
 		automation.close();
 	});
+
+	it("disposes a workspace after state loading fails so polling stops", async () => {
+		loadWorkspaceStateMock.mockRejectedValue(new Error("missing workspace"));
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(3_000);
+		await flushMicrotasks();
+
+		expect(loadWorkspaceStateMock).toHaveBeenCalledTimes(1);
+		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+
+		automation.close();
+	});
 });

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -391,8 +391,12 @@ describe("createRuntimeTaskAutomation", () => {
 		await vi.advanceTimersByTimeAsync(2_000);
 		await flushMicrotasks();
 
-		expect(runtimeClient.runtime.stopTaskSession.mutate).toHaveBeenCalledWith({
+		expect(runtimeClient.runtime.stopTaskSession.mutate).toHaveBeenCalledTimes(2);
+		expect(runtimeClient.runtime.stopTaskSession.mutate).toHaveBeenNthCalledWith(1, {
 			taskId: "task-1",
+		});
+		expect(runtimeClient.runtime.stopTaskSession.mutate).toHaveBeenNthCalledWith(2, {
+			taskId: "__detail_terminal__:task-1",
 		});
 		expect(runtimeClient.workspace.deleteWorktree.mutate).toHaveBeenCalledWith({
 			taskId: "task-1",
@@ -471,10 +475,6 @@ describe("createRuntimeTaskAutomation", () => {
 		await flushMicrotasks();
 
 		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
-		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
-			dispatched: true,
-			armAutoCleanup: false,
-		});
 
 		await vi.advanceTimersByTimeAsync(2_000);
 		await flushMicrotasks();
@@ -560,6 +560,8 @@ describe("createRuntimeTaskAutomation", () => {
 			dispatched: true,
 			armAutoCleanup: false,
 		});
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(true);
+		taskGitActionCoordinator.clearTaskGitAction("workspace-1", "task-1");
 
 		automation.trackWorkspace("workspace-1");
 		await flushMicrotasks();

--- a/src/server/runtime-task-automation.test.ts
+++ b/src/server/runtime-task-automation.test.ts
@@ -241,7 +241,7 @@ describe("createRuntimeTaskAutomation", () => {
 		runtimeClient = {
 			runtime: {
 				runTaskGitAction: {
-					mutate: vi.fn(async ({ taskId, action }) => {
+					mutate: vi.fn(async ({ taskId, action, source }) => {
 						const started = taskGitActionCoordinator.beginTaskGitAction("workspace-1", taskId, action);
 						if (!started) {
 							return {
@@ -251,7 +251,8 @@ describe("createRuntimeTaskAutomation", () => {
 							};
 						}
 						taskGitActionCoordinator.completeTaskGitAction("workspace-1", taskId, action, {
-							triggered: true,
+							dispatched: true,
+							armAutoCleanup: source === "auto",
 						});
 						return { ok: true, summary: null };
 					}),
@@ -350,7 +351,7 @@ describe("createRuntimeTaskAutomation", () => {
 		taskGitActionCoordinator.close();
 	});
 
-	it("moves review-ready tasks on the server, auto-commits them, and starts linked tasks after trashing", async () => {
+	it("derives review-ready tasks on the server, auto-commits them, and starts linked tasks after trashing", async () => {
 		const { manager, emitter } = createTerminalManager([
 			createSummary("task-1", {
 				state: "awaiting_review",
@@ -366,8 +367,6 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.trackTerminalManager("workspace-1", manager as never);
 		await flushMicrotasks();
 
-		expect(workspaceState.board.columns.find((column) => column.id === "review")?.cards[0]?.id).toBe("task-1");
-
 		await vi.advanceTimersByTimeAsync(1_200);
 		await flushMicrotasks();
 
@@ -375,7 +374,9 @@ describe("createRuntimeTaskAutomation", () => {
 			taskId: "task-1",
 			baseRef: "main",
 			action: "commit",
+			source: "auto",
 		});
+		expect(runtimeClient.workspace.notifyStateUpdated.mutate).not.toHaveBeenCalled();
 
 		changedFilesByTaskPath["/repo/task-1"] = 0;
 		emitter.emitSummary(
@@ -447,6 +448,7 @@ describe("createRuntimeTaskAutomation", () => {
 			taskId: "task-1",
 			baseRef: "main",
 			action: "pr",
+			source: "auto",
 		});
 
 		automation.close();
@@ -470,7 +472,8 @@ describe("createRuntimeTaskAutomation", () => {
 
 		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
 		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
-			triggered: true,
+			dispatched: true,
+			armAutoCleanup: false,
 		});
 
 		await vi.advanceTimersByTimeAsync(2_000);
@@ -495,6 +498,7 @@ describe("createRuntimeTaskAutomation", () => {
 			taskId: "task-1",
 			baseRef: "main",
 			action: "commit",
+			source: "auto",
 		});
 
 		automation.close();
@@ -517,8 +521,6 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.trackWorkspace("workspace-1");
 		await flushMicrotasks();
 
-		expect(getBoardColumn(workspaceState, "review").cards[0]?.id).toBe("task-1");
-
 		await vi.advanceTimersByTimeAsync(1_200);
 		await flushMicrotasks();
 
@@ -526,12 +528,52 @@ describe("createRuntimeTaskAutomation", () => {
 			taskId: "task-1",
 			baseRef: "main",
 			action: "commit",
+			source: "auto",
 		});
 
 		automation.close();
 	});
 
-	it("moves interrupted tasks to trash before evaluating review automation", async () => {
+	it("does not auto-trash a clean review task after a manual git action is sent", async () => {
+		getBoardColumn(workspaceState, "in_progress").cards = [];
+		getBoardColumn(workspaceState, "review").cards = [
+			{
+				id: "task-1",
+				prompt: "Primary task",
+				startInPlanMode: false,
+				autoReviewEnabled: true,
+				autoReviewMode: "pr",
+				baseRef: "main",
+				createdAt: 1,
+				updatedAt: 1,
+			},
+		];
+		changedFilesByTaskPath["/repo/task-1"] = 0;
+
+		const automation = createRuntimeTaskAutomation({
+			getWorkspacePathById: (workspaceId) => (workspaceId === "workspace-1" ? "/repo" : null),
+			taskGitActionCoordinator,
+		});
+
+		expect(taskGitActionCoordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(true);
+		taskGitActionCoordinator.completeTaskGitAction("workspace-1", "task-1", "pr", {
+			dispatched: true,
+			armAutoCleanup: false,
+		});
+
+		automation.trackWorkspace("workspace-1");
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(2_000);
+		await flushMicrotasks();
+
+		expect(runtimeClient.workspace.deleteWorktree.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.runtime.stopTaskSession.mutate).not.toHaveBeenCalled();
+		expect(getBoardColumn(workspaceState, "review").cards[0]?.id).toBe("task-1");
+
+		automation.close();
+	});
+
+	it("treats interrupted tasks as trashed during evaluation without persisting the board move", async () => {
 		getBoardColumn(workspaceState, "in_progress").cards = [];
 		getBoardColumn(workspaceState, "review").cards = [
 			{
@@ -561,9 +603,10 @@ describe("createRuntimeTaskAutomation", () => {
 		automation.trackWorkspace("workspace-1");
 		await flushMicrotasks();
 
-		expect(getBoardColumn(workspaceState, "trash").cards[0]?.id).toBe("task-1");
-		expect(getBoardColumn(workspaceState, "review").cards).toHaveLength(0);
 		expect(runtimeClient.runtime.runTaskGitAction.mutate).not.toHaveBeenCalled();
+		expect(runtimeClient.workspace.notifyStateUpdated.mutate).not.toHaveBeenCalled();
+		expect(getBoardColumn(workspaceState, "review").cards[0]?.id).toBe("task-1");
+		expect(getBoardColumn(workspaceState, "trash").cards).toHaveLength(0);
 
 		automation.close();
 	});

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -1,0 +1,765 @@
+import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
+
+import type { ClineTaskSessionService } from "../cline-sdk/cline-task-session-service";
+import type {
+	RuntimeBoardCard,
+	RuntimeBoardColumnId,
+	RuntimeTaskAutoReviewMode,
+	RuntimeTaskSessionSummary,
+	RuntimeTaskWorkspaceInfoResponse,
+	RuntimeWorkspaceStateResponse,
+} from "../core/api-contract";
+import { buildKanbanRuntimeUrl } from "../core/runtime-endpoint";
+import { moveTaskToColumn, trashTaskAndGetReadyLinkedTaskIds } from "../core/task-board-mutations";
+import { loadWorkspaceState, mutateWorkspaceState } from "../state/workspace-state";
+import type { TerminalSessionManager } from "../terminal/session-manager";
+import type { RuntimeAppRouter } from "../trpc/app-router";
+import { getGitSyncSummary } from "../workspace/git-sync";
+import { resolveTaskCwd } from "../workspace/task-worktree";
+
+const AUTO_REVIEW_ACTION_DELAY_MS = 500;
+const WORKSPACE_AUTOMATION_POLL_INTERVAL_MS = 1_000;
+
+type TaskGitAction = Extract<RuntimeTaskAutoReviewMode, "commit" | "pr">;
+
+interface TaskGitPromptTemplates {
+	commitPromptTemplate?: string | null;
+	openPrPromptTemplate?: string | null;
+	commitPromptTemplateDefault?: string | null;
+	openPrPromptTemplateDefault?: string | null;
+}
+
+interface ScheduledTaskAction {
+	action: RuntimeTaskAutoReviewMode;
+	scheduledAt: number;
+}
+
+interface TrackedWorkspaceAutomation {
+	workspaceId: string;
+	terminalManager: TerminalSessionManager | null;
+	clineTaskSessionService: ClineTaskSessionService | null;
+	pollTimer: NodeJS.Timeout | null;
+	runningTick: Promise<void> | null;
+	rerunRequested: boolean;
+	scheduledActionByTaskId: Map<string, ScheduledTaskAction>;
+	awaitingCleanActionByTaskId: Map<string, TaskGitAction>;
+	inFlightGitActionByTaskId: Map<string, TaskGitAction>;
+	moveToTrashInFlightTaskIds: Set<string>;
+	terminalSummaryUnsubscribe: (() => void) | null;
+	clineSummaryUnsubscribe: (() => void) | null;
+}
+
+export interface RuntimeTaskAutomation {
+	trackTerminalManager: (workspaceId: string, manager: TerminalSessionManager) => void;
+	trackClineTaskSessionService: (workspaceId: string, service: ClineTaskSessionService) => void;
+	disposeWorkspace: (workspaceId: string) => void;
+	close: () => void;
+}
+
+export interface CreateRuntimeTaskAutomationDependencies {
+	getWorkspacePathById: (workspaceId: string) => string | null;
+}
+
+/**
+ * Builds a runtime-scoped TRPC client that can call back into the local Kanban server.
+ */
+function createRuntimeTrpcClient(workspaceId: string) {
+	return createTRPCProxyClient<RuntimeAppRouter>({
+		links: [
+			httpBatchLink({
+				url: buildKanbanRuntimeUrl("/api/trpc"),
+				headers: () => ({ "x-kanban-workspace-id": workspaceId }),
+			}),
+		],
+	});
+}
+
+/**
+ * Normalizes the task auto-review mode to Kanban's persisted default.
+ */
+function resolveTaskAutoReviewMode(value: RuntimeTaskAutoReviewMode | null | undefined): RuntimeTaskAutoReviewMode {
+	if (value === "pr" || value === "move_to_trash") {
+		return value;
+	}
+	return "commit";
+}
+
+/**
+ * Resolves the prompt template string that should drive a commit or PR agent action.
+ */
+function resolveTaskGitActionTemplate(
+	action: TaskGitAction,
+	templates: TaskGitPromptTemplates | null | undefined,
+): string {
+	if (action === "commit") {
+		const template = templates?.commitPromptTemplate?.trim();
+		if (template) {
+			return template;
+		}
+		const defaultTemplate = templates?.commitPromptTemplateDefault?.trim();
+		if (defaultTemplate) {
+			return defaultTemplate;
+		}
+		return "Handle this commit action using the provided git context.";
+	}
+	const template = templates?.openPrPromptTemplate?.trim();
+	if (template) {
+		return template;
+	}
+	const defaultTemplate = templates?.openPrPromptTemplateDefault?.trim();
+	if (defaultTemplate) {
+		return defaultTemplate;
+	}
+	return "Handle this pull request action using the provided git context.";
+}
+
+/**
+ * Builds the agent prompt used for commit and PR automation.
+ */
+function buildTaskGitActionPrompt(input: {
+	action: TaskGitAction;
+	workspaceInfo: RuntimeTaskWorkspaceInfoResponse;
+	templates?: TaskGitPromptTemplates | null;
+}): string {
+	const template = resolveTaskGitActionTemplate(input.action, input.templates);
+	return template.replaceAll("{{base_ref}}", input.workspaceInfo.baseRef);
+}
+
+/**
+ * Selects the newest summary for a task when both the persisted snapshot and live managers know about it.
+ */
+function selectNewestTaskSessionSummary(
+	current: RuntimeTaskSessionSummary | null,
+	candidate: RuntimeTaskSessionSummary | null,
+): RuntimeTaskSessionSummary | null {
+	if (!current) {
+		return candidate;
+	}
+	if (!candidate) {
+		return current;
+	}
+	if (candidate.updatedAt !== current.updatedAt) {
+		return candidate.updatedAt > current.updatedAt ? candidate : current;
+	}
+	if (candidate.agentId === "cline" && current.agentId !== "cline") {
+		return candidate;
+	}
+	return current;
+}
+
+/**
+ * Merges the persisted session map with the latest live terminal and Cline summaries.
+ */
+function mergeLiveTaskSessionSummaries(
+	persistedSessions: Record<string, RuntimeTaskSessionSummary>,
+	terminalManager: TerminalSessionManager | null,
+	clineTaskSessionService: ClineTaskSessionService | null,
+): Record<string, RuntimeTaskSessionSummary> {
+	const mergedSessions: Record<string, RuntimeTaskSessionSummary> = { ...persistedSessions };
+	for (const summary of terminalManager?.listSummaries() ?? []) {
+		const newest = selectNewestTaskSessionSummary(mergedSessions[summary.taskId] ?? null, summary);
+		if (newest) {
+			mergedSessions[summary.taskId] = newest;
+		}
+	}
+	for (const summary of clineTaskSessionService?.listSummaries() ?? []) {
+		const newest = selectNewestTaskSessionSummary(mergedSessions[summary.taskId] ?? null, summary);
+		if (newest) {
+			mergedSessions[summary.taskId] = newest;
+		}
+	}
+	return mergedSessions;
+}
+
+/**
+ * Finds a task and its current column inside a workspace board snapshot.
+ */
+function findTaskRecord(
+	state: RuntimeWorkspaceStateResponse,
+	taskId: string,
+): { task: RuntimeBoardCard; columnId: RuntimeBoardColumnId } | null {
+	for (const column of state.board.columns) {
+		const task = column.cards.find((candidate) => candidate.id === taskId);
+		if (task) {
+			return {
+				task,
+				columnId: column.id,
+			};
+		}
+	}
+	return null;
+}
+
+/**
+ * Builds the mutable controller state for a newly tracked workspace.
+ */
+function createTrackedWorkspaceAutomation(workspaceId: string): TrackedWorkspaceAutomation {
+	return {
+		workspaceId,
+		terminalManager: null,
+		clineTaskSessionService: null,
+		pollTimer: null,
+		runningTick: null,
+		rerunRequested: false,
+		scheduledActionByTaskId: new Map(),
+		awaitingCleanActionByTaskId: new Map(),
+		inFlightGitActionByTaskId: new Map(),
+		moveToTrashInFlightTaskIds: new Set(),
+		terminalSummaryUnsubscribe: null,
+		clineSummaryUnsubscribe: null,
+	};
+}
+
+/**
+ * Loads the current worktree changed-file count for a task without creating a missing worktree.
+ */
+async function loadTaskChangedFileCount(task: RuntimeBoardCard, workspacePath: string): Promise<number | null> {
+	try {
+		const taskCwd = await resolveTaskCwd({
+			cwd: workspacePath,
+			taskId: task.id,
+			baseRef: task.baseRef,
+			ensure: false,
+		});
+		const summary = await getGitSyncSummary(taskCwd);
+		return summary.changedFiles;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Notifies connected runtime clients that a workspace state mutation has been saved.
+ */
+async function notifyRuntimeWorkspaceStateUpdated(
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>,
+): Promise<void> {
+	await runtimeClient.workspace.notifyStateUpdated.mutate().catch(() => null);
+}
+
+/**
+ * Sends the existing commit/PR prompt through the same runtime APIs the web UI already uses.
+ */
+async function sendTaskGitActionPrompt(input: {
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	task: RuntimeBoardCard;
+	action: TaskGitAction;
+	summary: RuntimeTaskSessionSummary | null;
+}): Promise<boolean> {
+	try {
+		const [config, workspaceInfo] = await Promise.all([
+			input.runtimeClient.runtime.getConfig.query(),
+			input.runtimeClient.workspace.getTaskContext.query({
+				taskId: input.task.id,
+				baseRef: input.task.baseRef,
+			}),
+		]);
+		const prompt = buildTaskGitActionPrompt({
+			action: input.action,
+			workspaceInfo,
+			templates: {
+				commitPromptTemplate: config.commitPromptTemplate,
+				openPrPromptTemplate: config.openPrPromptTemplate,
+				commitPromptTemplateDefault: config.commitPromptTemplateDefault,
+				openPrPromptTemplateDefault: config.openPrPromptTemplateDefault,
+			},
+		});
+
+		if (input.summary?.agentId === "cline") {
+			const sent = await input.runtimeClient.runtime.sendTaskChatMessage.mutate({
+				taskId: input.task.id,
+				text: prompt,
+				mode: "act",
+			});
+			return sent.ok === true;
+		}
+
+		const typed = await input.runtimeClient.runtime.sendTaskSessionInput.mutate({
+			taskId: input.task.id,
+			text: prompt,
+			appendNewline: false,
+		});
+		if (!typed.ok) {
+			return false;
+		}
+
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 200);
+		});
+
+		const submitted = await input.runtimeClient.runtime.sendTaskSessionInput.mutate({
+			taskId: input.task.id,
+			text: "\r",
+			appendNewline: false,
+		});
+		return submitted.ok === true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Starts a linked backlog task using the runtime's existing worktree and task-session APIs.
+ */
+async function startLinkedBacklogTask(input: {
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	workspacePath: string;
+	taskId: string;
+}): Promise<boolean> {
+	const state = await loadWorkspaceState(input.workspacePath).catch(() => null);
+	const record = state ? findTaskRecord(state, input.taskId) : null;
+	if (!record || record.columnId !== "backlog") {
+		return false;
+	}
+
+	const ensured = await input.runtimeClient.workspace.ensureWorktree
+		.mutate({
+			taskId: record.task.id,
+			baseRef: record.task.baseRef,
+		})
+		.catch(() => null);
+	if (!ensured?.ok) {
+		return false;
+	}
+
+	const started = await input.runtimeClient.runtime.startTaskSession
+		.mutate({
+			taskId: record.task.id,
+			prompt: record.task.prompt,
+			startInPlanMode: record.task.startInPlanMode,
+			baseRef: record.task.baseRef,
+			images: record.task.images,
+		})
+		.catch(() => null);
+	if (!started?.ok || !started.summary) {
+		return false;
+	}
+
+	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
+		const latestRecord = findTaskRecord(latestState, input.taskId);
+		if (!latestRecord || latestRecord.columnId !== "backlog") {
+			return {
+				board: latestState.board,
+				value: false,
+				save: false,
+			};
+		}
+		const moved = moveTaskToColumn(latestState.board, latestRecord.task.id, "in_progress");
+		return {
+			board: moved.moved ? moved.board : latestState.board,
+			value: moved.moved,
+			save: moved.moved,
+		};
+	}).catch(() => null);
+	if (mutation?.saved) {
+		await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
+	}
+	return mutation?.value === true;
+}
+
+/**
+ * Moves a review task to trash, starts any newly ready linked backlog tasks, and cleans up its worktree.
+ */
+async function trashTaskAndStartLinkedTasks(input: {
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	workspacePath: string;
+	taskId: string;
+}): Promise<boolean> {
+	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
+		const record = findTaskRecord(latestState, input.taskId);
+		if (!record || record.columnId === "trash") {
+			return {
+				board: latestState.board,
+				value: {
+					moved: false,
+					readyTaskIds: [] as string[],
+					previousColumnId: record?.columnId ?? null,
+				},
+				save: false,
+			};
+		}
+		const trashed = trashTaskAndGetReadyLinkedTaskIds(latestState.board, input.taskId);
+		return {
+			board: trashed.moved ? trashed.board : latestState.board,
+			value: {
+				moved: trashed.moved,
+				readyTaskIds: trashed.readyTaskIds,
+				previousColumnId: record.columnId,
+			},
+			save: trashed.moved,
+		};
+	}).catch(() => null);
+	if (!mutation?.value.moved) {
+		return false;
+	}
+
+	await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
+
+	if (mutation.value.previousColumnId === "in_progress" || mutation.value.previousColumnId === "review") {
+		await input.runtimeClient.runtime.stopTaskSession
+			.mutate({
+				taskId: input.taskId,
+			})
+			.catch(() => null);
+	}
+
+	for (const readyTaskId of mutation.value.readyTaskIds) {
+		await startLinkedBacklogTask({
+			runtimeClient: input.runtimeClient,
+			workspacePath: input.workspacePath,
+			taskId: readyTaskId,
+		});
+	}
+
+	await input.runtimeClient.workspace.deleteWorktree
+		.mutate({
+			taskId: input.taskId,
+		})
+		.catch(() => null);
+
+	return true;
+}
+
+/**
+ * Reconciles the persisted board columns with the live session summaries owned by the runtime.
+ */
+async function reconcileBoardWithLiveSessions(input: {
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	workspacePath: string;
+	state: RuntimeWorkspaceStateResponse;
+	liveSessions: Record<string, RuntimeTaskSessionSummary>;
+}): Promise<RuntimeWorkspaceStateResponse> {
+	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
+		let nextBoard = latestState.board;
+		let changed = false;
+
+		for (const summary of Object.values(input.liveSessions)) {
+			const record = findTaskRecord(
+				{
+					...latestState,
+					board: nextBoard,
+				},
+				summary.taskId,
+			);
+			if (!record) {
+				continue;
+			}
+			if (summary.state === "awaiting_review" && record.columnId === "in_progress") {
+				const moved = moveTaskToColumn(nextBoard, summary.taskId, "review");
+				if (moved.moved) {
+					nextBoard = moved.board;
+					changed = true;
+				}
+				continue;
+			}
+			if (summary.state === "running" && record.columnId === "review") {
+				const moved = moveTaskToColumn(nextBoard, summary.taskId, "in_progress");
+				if (moved.moved) {
+					nextBoard = moved.board;
+					changed = true;
+				}
+			}
+		}
+
+		return {
+			board: changed ? nextBoard : latestState.board,
+			value: changed,
+			save: changed,
+		};
+	}).catch(() => null);
+
+	if (!mutation) {
+		return {
+			...input.state,
+			sessions: input.liveSessions,
+		};
+	}
+	if (mutation.saved) {
+		await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
+		return {
+			...mutation.state,
+			sessions: input.liveSessions,
+		};
+	}
+	return {
+		...input.state,
+		sessions: input.liveSessions,
+	};
+}
+
+/**
+ * Ensures the 500ms debounce window survives polling-based evaluation without duplicating actions.
+ */
+function shouldRunScheduledTaskAction(
+	entry: TrackedWorkspaceAutomation,
+	taskId: string,
+	action: RuntimeTaskAutoReviewMode,
+	nowValue: number,
+): boolean {
+	const scheduled = entry.scheduledActionByTaskId.get(taskId);
+	if (!scheduled || scheduled.action !== action) {
+		entry.scheduledActionByTaskId.set(taskId, {
+			action,
+			scheduledAt: nowValue,
+		});
+		return false;
+	}
+	return nowValue - scheduled.scheduledAt >= AUTO_REVIEW_ACTION_DELAY_MS;
+}
+
+/**
+ * Clears any scheduled action that is no longer valid for a task.
+ */
+function clearScheduledTaskAction(entry: TrackedWorkspaceAutomation, taskId: string): void {
+	entry.scheduledActionByTaskId.delete(taskId);
+}
+
+/**
+ * Evaluates review-column tasks and runs the runtime-owned auto-review state machine.
+ */
+async function evaluateWorkspaceAutoReview(input: {
+	entry: TrackedWorkspaceAutomation;
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	workspacePath: string;
+	state: RuntimeWorkspaceStateResponse;
+	liveSessions: Record<string, RuntimeTaskSessionSummary>;
+	nowValue: number;
+}): Promise<void> {
+	const reviewColumn = input.state.board.columns.find((column) => column.id === "review");
+	const reviewCards = reviewColumn?.cards ?? [];
+	const reviewTaskIds = new Set(reviewCards.map((card) => card.id));
+
+	for (const taskId of Array.from(input.entry.awaitingCleanActionByTaskId.keys())) {
+		if (!reviewTaskIds.has(taskId)) {
+			input.entry.awaitingCleanActionByTaskId.delete(taskId);
+			clearScheduledTaskAction(input.entry, taskId);
+			input.entry.inFlightGitActionByTaskId.delete(taskId);
+			input.entry.moveToTrashInFlightTaskIds.delete(taskId);
+		}
+	}
+	for (const taskId of Array.from(input.entry.scheduledActionByTaskId.keys())) {
+		if (!reviewTaskIds.has(taskId)) {
+			clearScheduledTaskAction(input.entry, taskId);
+		}
+	}
+	for (const taskId of Array.from(input.entry.moveToTrashInFlightTaskIds)) {
+		if (!reviewTaskIds.has(taskId)) {
+			input.entry.moveToTrashInFlightTaskIds.delete(taskId);
+		}
+	}
+
+	for (const task of reviewCards) {
+		if (task.autoReviewEnabled !== true) {
+			input.entry.awaitingCleanActionByTaskId.delete(task.id);
+			input.entry.inFlightGitActionByTaskId.delete(task.id);
+			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+			clearScheduledTaskAction(input.entry, task.id);
+			continue;
+		}
+
+		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
+		const awaitingCleanAction = input.entry.awaitingCleanActionByTaskId.get(task.id) ?? null;
+		if (awaitingCleanAction && awaitingCleanAction !== autoReviewMode) {
+			input.entry.awaitingCleanActionByTaskId.delete(task.id);
+			clearScheduledTaskAction(input.entry, task.id);
+		}
+
+		if (autoReviewMode === "move_to_trash") {
+			if (input.entry.moveToTrashInFlightTaskIds.has(task.id)) {
+				continue;
+			}
+			if (!shouldRunScheduledTaskAction(input.entry, task.id, autoReviewMode, input.nowValue)) {
+				continue;
+			}
+			clearScheduledTaskAction(input.entry, task.id);
+			input.entry.moveToTrashInFlightTaskIds.add(task.id);
+			const moved = await trashTaskAndStartLinkedTasks({
+				runtimeClient: input.runtimeClient,
+				workspacePath: input.workspacePath,
+				taskId: task.id,
+			}).catch(() => false);
+			if (!moved) {
+				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+			}
+			continue;
+		}
+
+		const changedFiles = await loadTaskChangedFileCount(task, input.workspacePath);
+		if (input.entry.awaitingCleanActionByTaskId.has(task.id)) {
+			if (
+				changedFiles === 0 &&
+				!input.entry.inFlightGitActionByTaskId.has(task.id) &&
+				!input.entry.moveToTrashInFlightTaskIds.has(task.id)
+			) {
+				if (!shouldRunScheduledTaskAction(input.entry, task.id, "move_to_trash", input.nowValue)) {
+					continue;
+				}
+				clearScheduledTaskAction(input.entry, task.id);
+				input.entry.moveToTrashInFlightTaskIds.add(task.id);
+				const moved = await trashTaskAndStartLinkedTasks({
+					runtimeClient: input.runtimeClient,
+					workspacePath: input.workspacePath,
+					taskId: task.id,
+				}).catch(() => false);
+				if (!moved) {
+					input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+				}
+			} else {
+				clearScheduledTaskAction(input.entry, task.id);
+			}
+			continue;
+		}
+
+		if ((changedFiles ?? 0) <= 0 || input.entry.inFlightGitActionByTaskId.has(task.id)) {
+			clearScheduledTaskAction(input.entry, task.id);
+			continue;
+		}
+
+		if (!shouldRunScheduledTaskAction(input.entry, task.id, autoReviewMode, input.nowValue)) {
+			continue;
+		}
+
+		clearScheduledTaskAction(input.entry, task.id);
+		input.entry.inFlightGitActionByTaskId.set(task.id, autoReviewMode);
+		const summary = input.liveSessions[task.id] ?? null;
+		const triggered = await sendTaskGitActionPrompt({
+			runtimeClient: input.runtimeClient,
+			task,
+			action: autoReviewMode,
+			summary,
+		}).catch(() => false);
+		input.entry.inFlightGitActionByTaskId.delete(task.id);
+		if (triggered) {
+			input.entry.awaitingCleanActionByTaskId.set(task.id, autoReviewMode);
+		}
+	}
+}
+
+/**
+ * Creates the runtime-owned automation controller that survives hidden tabs and websocket churn.
+ */
+export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDependencies): RuntimeTaskAutomation {
+	const trackedWorkspaces = new Map<string, TrackedWorkspaceAutomation>();
+
+	/**
+	 * Returns the tracked workspace entry for an id, creating it on first use.
+	 */
+	function getTrackedWorkspace(workspaceId: string): TrackedWorkspaceAutomation {
+		const existing = trackedWorkspaces.get(workspaceId);
+		if (existing) {
+			return existing;
+		}
+		const created = createTrackedWorkspaceAutomation(workspaceId);
+		trackedWorkspaces.set(workspaceId, created);
+		return created;
+	}
+
+	/**
+	 * Runs one serialized automation pass for a workspace and reruns once more if new work arrives mid-pass.
+	 */
+	function queueWorkspaceTick(workspaceId: string): void {
+		const entry = trackedWorkspaces.get(workspaceId);
+		if (!entry) {
+			return;
+		}
+		if (entry.runningTick) {
+			entry.rerunRequested = true;
+			return;
+		}
+		entry.runningTick = (async () => {
+			do {
+				entry.rerunRequested = false;
+				const workspacePath = deps.getWorkspacePathById(workspaceId);
+				if (!workspacePath) {
+					disposeWorkspace(workspaceId);
+					return;
+				}
+				const runtimeClient = createRuntimeTrpcClient(workspaceId);
+				const persistedState = await loadWorkspaceState(workspacePath).catch(() => null);
+				if (!persistedState) {
+					return;
+				}
+				const liveSessions = mergeLiveTaskSessionSummaries(
+					persistedState.sessions,
+					entry.terminalManager,
+					entry.clineTaskSessionService,
+				);
+				const reconciledState = await reconcileBoardWithLiveSessions({
+					runtimeClient,
+					workspacePath,
+					state: persistedState,
+					liveSessions,
+				});
+				await evaluateWorkspaceAutoReview({
+					entry,
+					runtimeClient,
+					workspacePath,
+					state: reconciledState,
+					liveSessions,
+					nowValue: Date.now(),
+				});
+			} while (entry.rerunRequested);
+		})().finally(() => {
+			entry.runningTick = null;
+		});
+	}
+
+	/**
+	 * Ensures a tracked workspace has a background poller even when no browser clients are connected.
+	 */
+	function ensureWorkspacePoller(entry: TrackedWorkspaceAutomation): void {
+		if (entry.pollTimer) {
+			return;
+		}
+		const timer = setInterval(() => {
+			queueWorkspaceTick(entry.workspaceId);
+		}, WORKSPACE_AUTOMATION_POLL_INTERVAL_MS);
+		timer.unref();
+		entry.pollTimer = timer;
+	}
+
+	/**
+	 * Disposes all subscriptions, timers, and queued task state for one workspace.
+	 */
+	function disposeWorkspace(workspaceId: string): void {
+		const entry = trackedWorkspaces.get(workspaceId);
+		if (!entry) {
+			return;
+		}
+		if (entry.pollTimer) {
+			clearInterval(entry.pollTimer);
+		}
+		entry.terminalSummaryUnsubscribe?.();
+		entry.clineSummaryUnsubscribe?.();
+		trackedWorkspaces.delete(workspaceId);
+	}
+
+	return {
+		trackTerminalManager: (workspaceId, manager) => {
+			const entry = getTrackedWorkspace(workspaceId);
+			entry.terminalManager = manager;
+			entry.terminalSummaryUnsubscribe?.();
+			entry.terminalSummaryUnsubscribe = manager.onSummary(() => {
+				queueWorkspaceTick(workspaceId);
+			});
+			ensureWorkspacePoller(entry);
+			queueWorkspaceTick(workspaceId);
+		},
+		trackClineTaskSessionService: (workspaceId, service) => {
+			const entry = getTrackedWorkspace(workspaceId);
+			entry.clineTaskSessionService = service;
+			entry.clineSummaryUnsubscribe?.();
+			entry.clineSummaryUnsubscribe = service.onSummary(() => {
+				queueWorkspaceTick(workspaceId);
+			});
+			ensureWorkspacePoller(entry);
+			queueWorkspaceTick(workspaceId);
+		},
+		disposeWorkspace,
+		close: () => {
+			for (const workspaceId of Array.from(trackedWorkspaces.keys())) {
+				disposeWorkspace(workspaceId);
+			}
+		},
+	};
+}

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -593,7 +593,9 @@ async function evaluateWorkspaceAutoReview(input: {
 				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 				continue;
 			}
-			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			if (!input.taskGitActionCoordinator.isTaskGitActionInFlight(input.workspaceId, task.id)) {
+				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			}
 			clearScheduledTaskAction(input.entry, task.id);
 			clearBlockedAutoReview(input.entry, task.id);
 			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
@@ -604,7 +606,9 @@ async function evaluateWorkspaceAutoReview(input: {
 	for (const taskId of Array.from(input.entry.scheduledActionByTaskId.keys())) {
 		if (!reviewTaskIds.has(taskId) && !inProgressCleanupTaskIds.has(taskId)) {
 			clearScheduledTaskAction(input.entry, taskId);
-			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
+			if (!input.taskGitActionCoordinator.isTaskGitActionInFlight(input.workspaceId, taskId)) {
+				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
+			}
 			clearBlockedAutoReview(input.entry, taskId);
 			clearPendingAutoCleanupSessionVersion(input.entry, taskId);
 		}
@@ -627,7 +631,9 @@ async function evaluateWorkspaceAutoReview(input: {
 
 	for (const task of reviewCards) {
 		if (task.autoReviewEnabled !== true) {
-			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			if (!input.taskGitActionCoordinator.isTaskGitActionInFlight(input.workspaceId, task.id)) {
+				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			}
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			clearBlockedAutoReview(input.entry, task.id);
@@ -697,7 +703,9 @@ async function evaluateWorkspaceAutoReview(input: {
 
 		const liveSession = input.state.sessions[task.id] ?? null;
 		if (!liveSession) {
-			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			if (!input.taskGitActionCoordinator.isTaskGitActionInFlight(input.workspaceId, task.id)) {
+				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			}
 			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -198,6 +198,7 @@ async function runTaskGitAction(input: {
 			taskId: input.task.id,
 			baseRef: input.task.baseRef,
 			action: input.action,
+			source: "auto",
 		})
 		.catch(() => null);
 	return response?.ok === true;
@@ -269,6 +270,7 @@ async function trashTaskAndStartLinkedTasks(input: {
 	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
 	workspacePath: string;
 	taskId: string;
+	sourceColumnId: RuntimeBoardColumnId;
 }): Promise<boolean> {
 	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
 		const record = findTaskRecord(latestState, input.taskId);
@@ -283,7 +285,11 @@ async function trashTaskAndStartLinkedTasks(input: {
 				save: false,
 			};
 		}
-		const trashed = trashTaskAndGetReadyLinkedTaskIds(latestState.board, input.taskId);
+		const boardForTrashMutation =
+			input.sourceColumnId === "review" && record.columnId === "in_progress"
+				? (moveTaskToColumn(latestState.board, input.taskId, "review").board ?? latestState.board)
+				: latestState.board;
+		const trashed = trashTaskAndGetReadyLinkedTaskIds(boardForTrashMutation, input.taskId);
 		return {
 			board: trashed.moved ? trashed.board : latestState.board,
 			value: {
@@ -326,76 +332,42 @@ async function trashTaskAndStartLinkedTasks(input: {
 }
 
 /**
- * Reconciles the persisted board columns with the live session summaries owned by the runtime.
+ * Derives the board shape automation should evaluate without persisting session-driven column moves.
  */
-async function reconcileBoardWithLiveSessions(input: {
-	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
-	workspacePath: string;
+function deriveAutomationWorkspaceState(input: {
 	state: RuntimeWorkspaceStateResponse;
 	liveSessions: Record<string, RuntimeTaskSessionSummary>;
-}): Promise<RuntimeWorkspaceStateResponse> {
-	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
-		let nextBoard = latestState.board;
-		let changed = false;
-
-		for (const summary of Object.values(input.liveSessions)) {
-			const record = findTaskRecord(
-				{
-					...latestState,
-					board: nextBoard,
-				},
-				summary.taskId,
-			);
-			if (!record) {
-				continue;
-			}
-			if (summary.state === "awaiting_review" && record.columnId === "in_progress") {
-				const moved = moveTaskToColumn(nextBoard, summary.taskId, "review");
-				if (moved.moved) {
-					nextBoard = moved.board;
-					changed = true;
-				}
-				continue;
-			}
-			if (summary.state === "running" && record.columnId === "review") {
-				const moved = moveTaskToColumn(nextBoard, summary.taskId, "in_progress");
-				if (moved.moved) {
-					nextBoard = moved.board;
-					changed = true;
-				}
-				continue;
-			}
-			if (summary.state === "interrupted" && record.columnId !== "trash") {
-				const moved = moveTaskToColumn(nextBoard, summary.taskId, "trash");
-				if (moved.moved) {
-					nextBoard = moved.board;
-					changed = true;
-				}
-			}
+}): RuntimeWorkspaceStateResponse {
+	let nextBoard = input.state.board;
+	for (const summary of Object.values(input.liveSessions)) {
+		const record = findTaskRecord(
+			{
+				...input.state,
+				board: nextBoard,
+			},
+			summary.taskId,
+		);
+		if (!record) {
+			continue;
 		}
-
-		return {
-			board: changed ? nextBoard : latestState.board,
-			value: changed,
-			save: changed,
-		};
-	}).catch(() => null);
-
-	if (!mutation) {
-		return {
-			...input.state,
-			sessions: input.liveSessions,
-		};
-	}
-	if (mutation.saved) {
-		await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
-		return {
-			...mutation.state,
-			sessions: input.liveSessions,
-		};
+		if (summary.state === "awaiting_review" && record.columnId === "in_progress") {
+			const moved = moveTaskToColumn(nextBoard, summary.taskId, "review");
+			nextBoard = moved.moved ? moved.board : nextBoard;
+			continue;
+		}
+		if (summary.state === "running" && record.columnId === "review") {
+			const moved = moveTaskToColumn(nextBoard, summary.taskId, "in_progress");
+			nextBoard = moved.moved ? moved.board : nextBoard;
+			continue;
+		}
+		if (summary.state === "interrupted" && record.columnId !== "trash") {
+			const moved = moveTaskToColumn(nextBoard, summary.taskId, "trash");
+			nextBoard = moved.moved ? moved.board : nextBoard;
+		}
 	}
 	return {
 		...input.state,
+		board: nextBoard,
 		sessions: input.liveSessions,
 	};
 }
@@ -474,8 +446,8 @@ async function evaluateWorkspaceAutoReview(input: {
 		}
 
 		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
-		const pendingGitAction = input.taskGitActionCoordinator.getPendingTaskGitAction(input.workspaceId, task.id);
-		if (pendingGitAction) {
+		const autoCleanupAction = input.taskGitActionCoordinator.getAutoCleanupTaskGitAction(input.workspaceId, task.id);
+		if (autoCleanupAction) {
 			const changedFiles = await loadTaskChangedFileCount(task, input.workspacePath);
 			if (changedFiles === 0 && !input.entry.moveToTrashInFlightTaskIds.has(task.id)) {
 				if (!shouldRunScheduledTaskAction(input.entry, task.id, "move_to_trash", input.nowValue)) {
@@ -487,6 +459,7 @@ async function evaluateWorkspaceAutoReview(input: {
 					runtimeClient: input.runtimeClient,
 					workspacePath: input.workspacePath,
 					taskId: task.id,
+					sourceColumnId: "review",
 				}).catch(() => false);
 				if (!moved) {
 					input.entry.moveToTrashInFlightTaskIds.delete(task.id);
@@ -512,6 +485,7 @@ async function evaluateWorkspaceAutoReview(input: {
 				runtimeClient: input.runtimeClient,
 				workspacePath: input.workspacePath,
 				taskId: task.id,
+				sourceColumnId: "review",
 			}).catch(() => false);
 			if (!moved) {
 				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
@@ -590,9 +564,7 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 					entry.terminalManager,
 					entry.clineTaskSessionService,
 				);
-				const reconciledState = await reconcileBoardWithLiveSessions({
-					runtimeClient,
-					workspacePath,
+				const automationState = deriveAutomationWorkspaceState({
 					state: persistedState,
 					liveSessions,
 				});
@@ -602,7 +574,7 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 					taskGitActionCoordinator: deps.taskGitActionCoordinator,
 					workspaceId,
 					workspacePath,
-					state: reconciledState,
+					state: automationState,
 					nowValue: Date.now(),
 				});
 			} while (entry.rerunRequested);

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -575,7 +575,16 @@ function shouldKeepWorkspacePoller(
 		return true;
 	}
 	const reviewColumn = state.board.columns.find((column) => column.id === "review");
-	return (reviewColumn?.cards ?? []).some((task) => task.autoReviewEnabled === true);
+	return (reviewColumn?.cards ?? []).some((task) => {
+		if (task.autoReviewEnabled !== true) {
+			return false;
+		}
+		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
+		if (autoReviewMode === "move_to_trash") {
+			return true;
+		}
+		return state.sessions[task.id] != null;
+	});
 }
 
 /**

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -34,6 +34,7 @@ interface TrackedWorkspaceAutomation {
 	rerunRequested: boolean;
 	scheduledActionByTaskId: Map<string, ScheduledTaskAction>;
 	blockedAutoReviewSessionVersionByTaskId: Map<string, number>;
+	pendingAutoCleanupSessionVersionByTaskId: Map<string, number>;
 	moveToTrashInFlightTaskIds: Set<string>;
 	terminalSummaryUnsubscribe: (() => void) | null;
 	clineSummaryUnsubscribe: (() => void) | null;
@@ -183,6 +184,7 @@ function createTrackedWorkspaceAutomation(workspaceId: string): TrackedWorkspace
 		rerunRequested: false,
 		scheduledActionByTaskId: new Map(),
 		blockedAutoReviewSessionVersionByTaskId: new Map(),
+		pendingAutoCleanupSessionVersionByTaskId: new Map(),
 		moveToTrashInFlightTaskIds: new Set(),
 		terminalSummaryUnsubscribe: null,
 		clineSummaryUnsubscribe: null,
@@ -250,45 +252,83 @@ async function startLinkedBacklogTask(input: {
 	workspacePath: string;
 	taskId: string;
 }): Promise<boolean> {
-	const state = await loadWorkspaceState(input.workspacePath).catch(() => null);
-	const record = state ? findTaskRecord(state, input.taskId) : null;
-	if (!record || record.columnId !== "backlog") {
+	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
+		const latestRecord = findTaskRecord(latestState, input.taskId);
+		if (!latestRecord || latestRecord.columnId !== "backlog") {
+			return {
+				board: latestState.board,
+				value: null,
+				save: false,
+			};
+		}
+		const moved = moveTaskToColumn(latestState.board, latestRecord.task.id, "in_progress");
+		return {
+			board: moved.moved ? moved.board : latestState.board,
+			value: moved.moved
+				? {
+						task: latestRecord.task,
+				  }
+				: null,
+			save: moved.moved,
+		};
+	}).catch(() => null);
+	if (!mutation?.saved || !mutation.value) {
 		return false;
 	}
 
+	await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
+
 	const ensured = await input.runtimeClient.workspace.ensureWorktree
 		.mutate({
-			taskId: record.task.id,
-			baseRef: record.task.baseRef,
+			taskId: mutation.value.task.id,
+			baseRef: mutation.value.task.baseRef,
 		})
 		.catch(() => null);
 	if (!ensured?.ok) {
+		await rollbackLinkedBacklogTaskStart(input);
 		return false;
 	}
 
 	const started = await input.runtimeClient.runtime.startTaskSession
 		.mutate({
-			taskId: record.task.id,
-			prompt: record.task.prompt,
-			startInPlanMode: record.task.startInPlanMode,
-			baseRef: record.task.baseRef,
-			images: record.task.images,
+			taskId: mutation.value.task.id,
+			prompt: mutation.value.task.prompt,
+			startInPlanMode: mutation.value.task.startInPlanMode,
+			baseRef: mutation.value.task.baseRef,
+			images: mutation.value.task.images,
 		})
 		.catch(() => null);
 	if (!started?.ok || !started.summary) {
+		await input.runtimeClient.workspace.deleteWorktree
+			.mutate({
+				taskId: mutation.value.task.id,
+			})
+			.catch(() => null);
+		await rollbackLinkedBacklogTaskStart(input);
 		return false;
 	}
 
+	return true;
+}
+
+/**
+ * Rolls a linked task back to Backlog when automation reserved the card but could not start the session.
+ */
+async function rollbackLinkedBacklogTaskStart(input: {
+	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	workspacePath: string;
+	taskId: string;
+}): Promise<void> {
 	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
 		const latestRecord = findTaskRecord(latestState, input.taskId);
-		if (!latestRecord || latestRecord.columnId !== "backlog") {
+		if (!latestRecord || latestRecord.columnId !== "in_progress") {
 			return {
 				board: latestState.board,
 				value: false,
 				save: false,
 			};
 		}
-		const moved = moveTaskToColumn(latestState.board, latestRecord.task.id, "in_progress");
+		const moved = moveTaskToColumn(latestState.board, latestRecord.task.id, "backlog");
 		return {
 			board: moved.moved ? moved.board : latestState.board,
 			value: moved.moved,
@@ -298,7 +338,6 @@ async function startLinkedBacklogTask(input: {
 	if (mutation?.saved) {
 		await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
 	}
-	return mutation?.value === true;
 }
 
 /**
@@ -482,6 +521,43 @@ function clearBlockedAutoReview(entry: TrackedWorkspaceAutomation, taskId: strin
 }
 
 /**
+ * Records the session version that an auto git action was dispatched against so cleanup stays locked.
+ */
+function markPendingAutoCleanupSessionVersion(
+	entry: TrackedWorkspaceAutomation,
+	taskId: string,
+	session: RuntimeTaskSessionSummary,
+): void {
+	entry.pendingAutoCleanupSessionVersionByTaskId.set(taskId, session.updatedAt);
+}
+
+/**
+ * Returns whether the auto git action is still waiting for the session to reflect new agent activity.
+ */
+function isWaitingForAutoCleanupSessionChange(
+	entry: TrackedWorkspaceAutomation,
+	taskId: string,
+	session: RuntimeTaskSessionSummary,
+): boolean {
+	const pendingUpdatedAt = entry.pendingAutoCleanupSessionVersionByTaskId.get(taskId);
+	if (pendingUpdatedAt === undefined) {
+		return false;
+	}
+	if (pendingUpdatedAt === session.updatedAt) {
+		return true;
+	}
+	entry.pendingAutoCleanupSessionVersionByTaskId.delete(taskId);
+	return false;
+}
+
+/**
+ * Clears any pending auto-cleanup session version once the lock is no longer needed.
+ */
+function clearPendingAutoCleanupSessionVersion(entry: TrackedWorkspaceAutomation, taskId: string): void {
+	entry.pendingAutoCleanupSessionVersionByTaskId.delete(taskId);
+}
+
+/**
  * Evaluates review-column tasks and runs the runtime-owned auto-review state machine.
  */
 async function evaluateWorkspaceAutoReview(input: {
@@ -513,12 +589,14 @@ async function evaluateWorkspaceAutoReview(input: {
 			}
 			if (preserveAutoCleanupState) {
 				clearScheduledTaskAction(input.entry, task.id);
+				clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 				continue;
 			}
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			clearBlockedAutoReview(input.entry, task.id);
+			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 		}
 	}
@@ -528,6 +606,7 @@ async function evaluateWorkspaceAutoReview(input: {
 			clearScheduledTaskAction(input.entry, taskId);
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
 			clearBlockedAutoReview(input.entry, taskId);
+			clearPendingAutoCleanupSessionVersion(input.entry, taskId);
 		}
 	}
 	for (const taskId of Array.from(input.entry.moveToTrashInFlightTaskIds)) {
@@ -540,6 +619,11 @@ async function evaluateWorkspaceAutoReview(input: {
 			clearBlockedAutoReview(input.entry, taskId);
 		}
 	}
+	for (const taskId of Array.from(input.entry.pendingAutoCleanupSessionVersionByTaskId.keys())) {
+		if (!reviewTaskIds.has(taskId)) {
+			clearPendingAutoCleanupSessionVersion(input.entry, taskId);
+		}
+	}
 
 	for (const task of reviewCards) {
 		if (task.autoReviewEnabled !== true) {
@@ -547,12 +631,18 @@ async function evaluateWorkspaceAutoReview(input: {
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			clearBlockedAutoReview(input.entry, task.id);
+			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 			continue;
 		}
 
 		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
 		const autoCleanupAction = input.taskGitActionCoordinator.getAutoCleanupTaskGitAction(input.workspaceId, task.id);
 		if (autoCleanupAction) {
+			const liveSession = input.state.sessions[task.id] ?? null;
+			if (liveSession && isWaitingForAutoCleanupSessionChange(input.entry, task.id, liveSession)) {
+				clearScheduledTaskAction(input.entry, task.id);
+				continue;
+			}
 			const changedFiles = await loadTaskChangedFileCount(task, input.workspacePath);
 			if (changedFiles === 0 && !input.entry.moveToTrashInFlightTaskIds.has(task.id)) {
 				if (!shouldRunScheduledTaskAction(input.entry, task.id, "move_to_trash", input.nowValue)) {
@@ -571,10 +661,11 @@ async function evaluateWorkspaceAutoReview(input: {
 				} else {
 					input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 					clearBlockedAutoReview(input.entry, task.id);
+					clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 				}
 			} else {
-				const liveSession = input.state.sessions[task.id] ?? null;
 				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+				clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 				if (liveSession) {
 					blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
 				}
@@ -607,6 +698,7 @@ async function evaluateWorkspaceAutoReview(input: {
 		const liveSession = input.state.sessions[task.id] ?? null;
 		if (!liveSession) {
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			continue;
@@ -638,7 +730,10 @@ async function evaluateWorkspaceAutoReview(input: {
 		}).catch(() => false);
 		if (!ranTaskGitAction) {
 			blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
+			clearPendingAutoCleanupSessionVersion(input.entry, task.id);
+			continue;
 		}
+		markPendingAutoCleanupSessionVersion(input.entry, task.id, liveSession);
 	}
 }
 

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -428,11 +428,25 @@ async function evaluateWorkspaceAutoReview(input: {
 	const reviewColumn = input.state.board.columns.find((column) => column.id === "review");
 	const reviewCards = reviewColumn?.cards ?? [];
 	const reviewTaskIds = new Set(reviewCards.map((card) => card.id));
+	const inProgressCleanupTaskIds = new Set<string>();
 	for (const column of input.state.board.columns) {
 		if (column.id === "review") {
 			continue;
 		}
 		for (const task of column.cards) {
+			const autoCleanupAction = input.taskGitActionCoordinator.getAutoCleanupTaskGitAction(
+				input.workspaceId,
+				task.id,
+			);
+			const preserveAutoCleanupState = autoCleanupAction !== null && column.id === "in_progress";
+			if (preserveAutoCleanupState) {
+				inProgressCleanupTaskIds.add(task.id);
+			}
+			if (preserveAutoCleanupState) {
+				clearScheduledTaskAction(input.entry, task.id);
+				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+				continue;
+			}
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
@@ -440,7 +454,7 @@ async function evaluateWorkspaceAutoReview(input: {
 	}
 
 	for (const taskId of Array.from(input.entry.scheduledActionByTaskId.keys())) {
-		if (!reviewTaskIds.has(taskId)) {
+		if (!reviewTaskIds.has(taskId) && !inProgressCleanupTaskIds.has(taskId)) {
 			clearScheduledTaskAction(input.entry, taskId);
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
 		}

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -159,6 +159,13 @@ function createTrackedWorkspaceAutomation(workspaceId: string): TrackedWorkspace
 }
 
 /**
+ * Resolves the companion terminal-session id used for the task detail shell.
+ */
+function getDetailTerminalTaskId(taskId: string): string {
+	return `__detail_terminal__:${taskId}`;
+}
+
+/**
  * Loads the current worktree changed-file count for a task without creating a missing worktree.
  */
 async function loadTaskChangedFileCount(task: RuntimeBoardCard, workspacePath: string): Promise<number | null> {
@@ -307,11 +314,18 @@ async function trashTaskAndStartLinkedTasks(input: {
 	await notifyRuntimeWorkspaceStateUpdated(input.runtimeClient);
 
 	if (mutation.value.previousColumnId === "in_progress" || mutation.value.previousColumnId === "review") {
-		await input.runtimeClient.runtime.stopTaskSession
-			.mutate({
-				taskId: input.taskId,
-			})
-			.catch(() => null);
+		await Promise.all([
+			input.runtimeClient.runtime.stopTaskSession
+				.mutate({
+					taskId: input.taskId,
+				})
+				.catch(() => null),
+			input.runtimeClient.runtime.stopTaskSession
+				.mutate({
+					taskId: getDetailTerminalTaskId(input.taskId),
+				})
+				.catch(() => null),
+		]);
 	}
 
 	for (const readyTaskId of mutation.value.readyTaskIds) {

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -6,7 +6,6 @@ import type {
 	RuntimeBoardColumnId,
 	RuntimeTaskAutoReviewMode,
 	RuntimeTaskSessionSummary,
-	RuntimeTaskWorkspaceInfoResponse,
 	RuntimeWorkspaceStateResponse,
 } from "../core/api-contract";
 import { buildKanbanRuntimeUrl } from "../core/runtime-endpoint";
@@ -16,18 +15,10 @@ import type { TerminalSessionManager } from "../terminal/session-manager";
 import type { RuntimeAppRouter } from "../trpc/app-router";
 import { getGitSyncSummary } from "../workspace/git-sync";
 import { resolveTaskCwd } from "../workspace/task-worktree";
+import type { RuntimeTaskGitAction, RuntimeTaskGitActionCoordinator } from "./runtime-task-git-actions";
 
 const AUTO_REVIEW_ACTION_DELAY_MS = 500;
 const WORKSPACE_AUTOMATION_POLL_INTERVAL_MS = 1_000;
-
-type TaskGitAction = Extract<RuntimeTaskAutoReviewMode, "commit" | "pr">;
-
-interface TaskGitPromptTemplates {
-	commitPromptTemplate?: string | null;
-	openPrPromptTemplate?: string | null;
-	commitPromptTemplateDefault?: string | null;
-	openPrPromptTemplateDefault?: string | null;
-}
 
 interface ScheduledTaskAction {
 	action: RuntimeTaskAutoReviewMode;
@@ -42,14 +33,13 @@ interface TrackedWorkspaceAutomation {
 	runningTick: Promise<void> | null;
 	rerunRequested: boolean;
 	scheduledActionByTaskId: Map<string, ScheduledTaskAction>;
-	awaitingCleanActionByTaskId: Map<string, TaskGitAction>;
-	inFlightGitActionByTaskId: Map<string, TaskGitAction>;
 	moveToTrashInFlightTaskIds: Set<string>;
 	terminalSummaryUnsubscribe: (() => void) | null;
 	clineSummaryUnsubscribe: (() => void) | null;
 }
 
 export interface RuntimeTaskAutomation {
+	trackWorkspace: (workspaceId: string) => void;
 	trackTerminalManager: (workspaceId: string, manager: TerminalSessionManager) => void;
 	trackClineTaskSessionService: (workspaceId: string, service: ClineTaskSessionService) => void;
 	disposeWorkspace: (workspaceId: string) => void;
@@ -58,6 +48,7 @@ export interface RuntimeTaskAutomation {
 
 export interface CreateRuntimeTaskAutomationDependencies {
 	getWorkspacePathById: (workspaceId: string) => string | null;
+	taskGitActionCoordinator: RuntimeTaskGitActionCoordinator;
 }
 
 /**
@@ -82,47 +73,6 @@ function resolveTaskAutoReviewMode(value: RuntimeTaskAutoReviewMode | null | und
 		return value;
 	}
 	return "commit";
-}
-
-/**
- * Resolves the prompt template string that should drive a commit or PR agent action.
- */
-function resolveTaskGitActionTemplate(
-	action: TaskGitAction,
-	templates: TaskGitPromptTemplates | null | undefined,
-): string {
-	if (action === "commit") {
-		const template = templates?.commitPromptTemplate?.trim();
-		if (template) {
-			return template;
-		}
-		const defaultTemplate = templates?.commitPromptTemplateDefault?.trim();
-		if (defaultTemplate) {
-			return defaultTemplate;
-		}
-		return "Handle this commit action using the provided git context.";
-	}
-	const template = templates?.openPrPromptTemplate?.trim();
-	if (template) {
-		return template;
-	}
-	const defaultTemplate = templates?.openPrPromptTemplateDefault?.trim();
-	if (defaultTemplate) {
-		return defaultTemplate;
-	}
-	return "Handle this pull request action using the provided git context.";
-}
-
-/**
- * Builds the agent prompt used for commit and PR automation.
- */
-function buildTaskGitActionPrompt(input: {
-	action: TaskGitAction;
-	workspaceInfo: RuntimeTaskWorkspaceInfoResponse;
-	templates?: TaskGitPromptTemplates | null;
-}): string {
-	const template = resolveTaskGitActionTemplate(input.action, input.templates);
-	return template.replaceAll("{{base_ref}}", input.workspaceInfo.baseRef);
 }
 
 /**
@@ -202,8 +152,6 @@ function createTrackedWorkspaceAutomation(workspaceId: string): TrackedWorkspace
 		runningTick: null,
 		rerunRequested: false,
 		scheduledActionByTaskId: new Map(),
-		awaitingCleanActionByTaskId: new Map(),
-		inFlightGitActionByTaskId: new Map(),
 		moveToTrashInFlightTaskIds: new Set(),
 		terminalSummaryUnsubscribe: null,
 		clineSummaryUnsubscribe: null,
@@ -238,64 +186,21 @@ async function notifyRuntimeWorkspaceStateUpdated(
 }
 
 /**
- * Sends the existing commit/PR prompt through the same runtime APIs the web UI already uses.
+ * Triggers a runtime-owned commit or PR action for a review task.
  */
-async function sendTaskGitActionPrompt(input: {
+async function runTaskGitAction(input: {
 	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
 	task: RuntimeBoardCard;
-	action: TaskGitAction;
-	summary: RuntimeTaskSessionSummary | null;
+	action: RuntimeTaskGitAction;
 }): Promise<boolean> {
-	try {
-		const [config, workspaceInfo] = await Promise.all([
-			input.runtimeClient.runtime.getConfig.query(),
-			input.runtimeClient.workspace.getTaskContext.query({
-				taskId: input.task.id,
-				baseRef: input.task.baseRef,
-			}),
-		]);
-		const prompt = buildTaskGitActionPrompt({
+	const response = await input.runtimeClient.runtime.runTaskGitAction
+		.mutate({
+			taskId: input.task.id,
+			baseRef: input.task.baseRef,
 			action: input.action,
-			workspaceInfo,
-			templates: {
-				commitPromptTemplate: config.commitPromptTemplate,
-				openPrPromptTemplate: config.openPrPromptTemplate,
-				commitPromptTemplateDefault: config.commitPromptTemplateDefault,
-				openPrPromptTemplateDefault: config.openPrPromptTemplateDefault,
-			},
-		});
-
-		if (input.summary?.agentId === "cline") {
-			const sent = await input.runtimeClient.runtime.sendTaskChatMessage.mutate({
-				taskId: input.task.id,
-				text: prompt,
-				mode: "act",
-			});
-			return sent.ok === true;
-		}
-
-		const typed = await input.runtimeClient.runtime.sendTaskSessionInput.mutate({
-			taskId: input.task.id,
-			text: prompt,
-			appendNewline: false,
-		});
-		if (!typed.ok) {
-			return false;
-		}
-
-		await new Promise<void>((resolve) => {
-			setTimeout(resolve, 200);
-		});
-
-		const submitted = await input.runtimeClient.runtime.sendTaskSessionInput.mutate({
-			taskId: input.task.id,
-			text: "\r",
-			appendNewline: false,
-		});
-		return submitted.ok === true;
-	} catch {
-		return false;
-	}
+		})
+		.catch(() => null);
+	return response?.ok === true;
 }
 
 /**
@@ -458,6 +363,14 @@ async function reconcileBoardWithLiveSessions(input: {
 					nextBoard = moved.board;
 					changed = true;
 				}
+				continue;
+			}
+			if (summary.state === "interrupted" && record.columnId !== "trash") {
+				const moved = moveTaskToColumn(nextBoard, summary.taskId, "trash");
+				if (moved.moved) {
+					nextBoard = moved.board;
+					changed = true;
+				}
 			}
 		}
 
@@ -520,26 +433,30 @@ function clearScheduledTaskAction(entry: TrackedWorkspaceAutomation, taskId: str
 async function evaluateWorkspaceAutoReview(input: {
 	entry: TrackedWorkspaceAutomation;
 	runtimeClient: ReturnType<typeof createRuntimeTrpcClient>;
+	taskGitActionCoordinator: RuntimeTaskGitActionCoordinator;
+	workspaceId: string;
 	workspacePath: string;
 	state: RuntimeWorkspaceStateResponse;
-	liveSessions: Record<string, RuntimeTaskSessionSummary>;
 	nowValue: number;
 }): Promise<void> {
 	const reviewColumn = input.state.board.columns.find((column) => column.id === "review");
 	const reviewCards = reviewColumn?.cards ?? [];
 	const reviewTaskIds = new Set(reviewCards.map((card) => card.id));
-
-	for (const taskId of Array.from(input.entry.awaitingCleanActionByTaskId.keys())) {
-		if (!reviewTaskIds.has(taskId)) {
-			input.entry.awaitingCleanActionByTaskId.delete(taskId);
-			clearScheduledTaskAction(input.entry, taskId);
-			input.entry.inFlightGitActionByTaskId.delete(taskId);
-			input.entry.moveToTrashInFlightTaskIds.delete(taskId);
+	for (const column of input.state.board.columns) {
+		if (column.id === "review") {
+			continue;
+		}
+		for (const task of column.cards) {
+			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			clearScheduledTaskAction(input.entry, task.id);
+			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 		}
 	}
+
 	for (const taskId of Array.from(input.entry.scheduledActionByTaskId.keys())) {
 		if (!reviewTaskIds.has(taskId)) {
 			clearScheduledTaskAction(input.entry, taskId);
+			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
 		}
 	}
 	for (const taskId of Array.from(input.entry.moveToTrashInFlightTaskIds)) {
@@ -550,18 +467,36 @@ async function evaluateWorkspaceAutoReview(input: {
 
 	for (const task of reviewCards) {
 		if (task.autoReviewEnabled !== true) {
-			input.entry.awaitingCleanActionByTaskId.delete(task.id);
-			input.entry.inFlightGitActionByTaskId.delete(task.id);
+			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);
 			continue;
 		}
 
 		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
-		const awaitingCleanAction = input.entry.awaitingCleanActionByTaskId.get(task.id) ?? null;
-		if (awaitingCleanAction && awaitingCleanAction !== autoReviewMode) {
-			input.entry.awaitingCleanActionByTaskId.delete(task.id);
-			clearScheduledTaskAction(input.entry, task.id);
+		const pendingGitAction = input.taskGitActionCoordinator.getPendingTaskGitAction(input.workspaceId, task.id);
+		if (pendingGitAction) {
+			const changedFiles = await loadTaskChangedFileCount(task, input.workspacePath);
+			if (changedFiles === 0 && !input.entry.moveToTrashInFlightTaskIds.has(task.id)) {
+				if (!shouldRunScheduledTaskAction(input.entry, task.id, "move_to_trash", input.nowValue)) {
+					continue;
+				}
+				clearScheduledTaskAction(input.entry, task.id);
+				input.entry.moveToTrashInFlightTaskIds.add(task.id);
+				const moved = await trashTaskAndStartLinkedTasks({
+					runtimeClient: input.runtimeClient,
+					workspacePath: input.workspacePath,
+					taskId: task.id,
+				}).catch(() => false);
+				if (!moved) {
+					input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+				} else {
+					input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+				}
+			} else {
+				clearScheduledTaskAction(input.entry, task.id);
+			}
+			continue;
 		}
 
 		if (autoReviewMode === "move_to_trash") {
@@ -585,32 +520,10 @@ async function evaluateWorkspaceAutoReview(input: {
 		}
 
 		const changedFiles = await loadTaskChangedFileCount(task, input.workspacePath);
-		if (input.entry.awaitingCleanActionByTaskId.has(task.id)) {
-			if (
-				changedFiles === 0 &&
-				!input.entry.inFlightGitActionByTaskId.has(task.id) &&
-				!input.entry.moveToTrashInFlightTaskIds.has(task.id)
-			) {
-				if (!shouldRunScheduledTaskAction(input.entry, task.id, "move_to_trash", input.nowValue)) {
-					continue;
-				}
-				clearScheduledTaskAction(input.entry, task.id);
-				input.entry.moveToTrashInFlightTaskIds.add(task.id);
-				const moved = await trashTaskAndStartLinkedTasks({
-					runtimeClient: input.runtimeClient,
-					workspacePath: input.workspacePath,
-					taskId: task.id,
-				}).catch(() => false);
-				if (!moved) {
-					input.entry.moveToTrashInFlightTaskIds.delete(task.id);
-				}
-			} else {
-				clearScheduledTaskAction(input.entry, task.id);
-			}
-			continue;
-		}
-
-		if ((changedFiles ?? 0) <= 0 || input.entry.inFlightGitActionByTaskId.has(task.id)) {
+		if (
+			(changedFiles ?? 0) <= 0 ||
+			input.taskGitActionCoordinator.isTaskGitActionBlocked(input.workspaceId, task.id)
+		) {
 			clearScheduledTaskAction(input.entry, task.id);
 			continue;
 		}
@@ -620,18 +533,11 @@ async function evaluateWorkspaceAutoReview(input: {
 		}
 
 		clearScheduledTaskAction(input.entry, task.id);
-		input.entry.inFlightGitActionByTaskId.set(task.id, autoReviewMode);
-		const summary = input.liveSessions[task.id] ?? null;
-		const triggered = await sendTaskGitActionPrompt({
+		await runTaskGitAction({
 			runtimeClient: input.runtimeClient,
 			task,
 			action: autoReviewMode,
-			summary,
 		}).catch(() => false);
-		input.entry.inFlightGitActionByTaskId.delete(task.id);
-		if (triggered) {
-			input.entry.awaitingCleanActionByTaskId.set(task.id, autoReviewMode);
-		}
 	}
 }
 
@@ -693,9 +599,10 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 				await evaluateWorkspaceAutoReview({
 					entry,
 					runtimeClient,
+					taskGitActionCoordinator: deps.taskGitActionCoordinator,
+					workspaceId,
 					workspacePath,
 					state: reconciledState,
-					liveSessions,
 					nowValue: Date.now(),
 				});
 			} while (entry.rerunRequested);
@@ -731,10 +638,16 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 		}
 		entry.terminalSummaryUnsubscribe?.();
 		entry.clineSummaryUnsubscribe?.();
+		deps.taskGitActionCoordinator.disposeWorkspace(workspaceId);
 		trackedWorkspaces.delete(workspaceId);
 	}
 
 	return {
+		trackWorkspace: (workspaceId) => {
+			const entry = getTrackedWorkspace(workspaceId);
+			ensureWorkspacePoller(entry);
+			queueWorkspaceTick(workspaceId);
+		},
 		trackTerminalManager: (workspaceId, manager) => {
 			const entry = getTrackedWorkspace(workspaceId);
 			entry.terminalManager = manager;

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -98,15 +98,18 @@ function selectNewestTaskSessionSummary(
 }
 
 /**
- * Merges the persisted session map with the latest live terminal and Cline summaries.
+ * Collects the session summaries that automation can act on immediately.
+ * Disk-only terminal snapshots are excluded because they cannot receive input after restart.
  */
-function mergeLiveTaskSessionSummaries(
-	persistedSessions: Record<string, RuntimeTaskSessionSummary>,
+function collectAutomationTaskSessionSummaries(
 	terminalManager: TerminalSessionManager | null,
 	clineTaskSessionService: ClineTaskSessionService | null,
 ): Record<string, RuntimeTaskSessionSummary> {
-	const mergedSessions: Record<string, RuntimeTaskSessionSummary> = { ...persistedSessions };
+	const mergedSessions: Record<string, RuntimeTaskSessionSummary> = {};
 	for (const summary of terminalManager?.listSummaries() ?? []) {
+		if (!terminalManager?.hasActiveTaskSession(summary.taskId)) {
+			continue;
+		}
 		const newest = selectNewestTaskSessionSummary(mergedSessions[summary.taskId] ?? null, summary);
 		if (newest) {
 			mergedSessions[summary.taskId] = newest;
@@ -587,8 +590,7 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 				if (!persistedState) {
 					return;
 				}
-				const liveSessions = mergeLiveTaskSessionSummaries(
-					persistedState.sessions,
+				const liveSessions = collectAutomationTaskSessionSummaries(
 					entry.terminalManager,
 					entry.clineTaskSessionService,
 				);

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -348,10 +348,14 @@ async function trashTaskAndStartLinkedTasks(input: {
 	workspacePath: string;
 	taskId: string;
 	sourceColumnId: RuntimeBoardColumnId;
+	allowInProgressRecovery?: boolean;
 }): Promise<boolean> {
 	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
 		const record = findTaskRecord(latestState, input.taskId);
-		const canRecoverFromInProgress = input.sourceColumnId === "review" && record?.columnId === "in_progress";
+		const canRecoverFromInProgress =
+			input.allowInProgressRecovery === true &&
+			input.sourceColumnId === "review" &&
+			record?.columnId === "in_progress";
 		const isEligibleSourceColumn = record?.columnId === input.sourceColumnId || canRecoverFromInProgress;
 		if (!record || record.columnId === "trash" || !isEligibleSourceColumn) {
 			return {
@@ -365,7 +369,7 @@ async function trashTaskAndStartLinkedTasks(input: {
 			};
 		}
 		const boardForTrashMutation =
-			input.sourceColumnId === "review" && record.columnId === "in_progress"
+			canRecoverFromInProgress
 				? (moveTaskToColumn(latestState.board, input.taskId, "review").board ?? latestState.board)
 				: latestState.board;
 		const trashed = trashTaskAndGetReadyLinkedTaskIds(boardForTrashMutation, input.taskId);
@@ -691,6 +695,7 @@ async function evaluateWorkspaceAutoReview(input: {
 					workspacePath: input.workspacePath,
 					taskId: task.id,
 					sourceColumnId: "review",
+					allowInProgressRecovery: liveSession?.state === "awaiting_review",
 				}).catch(() => false);
 				if (!moved) {
 					input.entry.moveToTrashInFlightTaskIds.delete(task.id);

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -588,6 +588,8 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 				const runtimeClient = createRuntimeTrpcClient(workspaceId);
 				const persistedState = await loadWorkspaceState(workspacePath).catch(() => null);
 				if (!persistedState) {
+					// A remembered workspace with unreadable state should stop polling until it is tracked again.
+					disposeWorkspace(workspaceId);
 					return;
 				}
 				const liveSessions = collectAutomationTaskSessionSummaries(

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -33,6 +33,7 @@ interface TrackedWorkspaceAutomation {
 	runningTick: Promise<void> | null;
 	rerunRequested: boolean;
 	scheduledActionByTaskId: Map<string, ScheduledTaskAction>;
+	blockedAutoReviewSessionVersionByTaskId: Map<string, number>;
 	moveToTrashInFlightTaskIds: Set<string>;
 	terminalSummaryUnsubscribe: (() => void) | null;
 	clineSummaryUnsubscribe: (() => void) | null;
@@ -155,6 +156,7 @@ function createTrackedWorkspaceAutomation(workspaceId: string): TrackedWorkspace
 		runningTick: null,
 		rerunRequested: false,
 		scheduledActionByTaskId: new Map(),
+		blockedAutoReviewSessionVersionByTaskId: new Map(),
 		moveToTrashInFlightTaskIds: new Set(),
 		terminalSummaryUnsubscribe: null,
 		clineSummaryUnsubscribe: null,
@@ -417,6 +419,43 @@ function clearScheduledTaskAction(entry: TrackedWorkspaceAutomation, taskId: str
 }
 
 /**
+ * Marks a live session as needing new activity before automation can retry another git action.
+ */
+function blockAutoReviewUntilSessionChanges(
+	entry: TrackedWorkspaceAutomation,
+	taskId: string,
+	session: RuntimeTaskSessionSummary,
+): void {
+	entry.blockedAutoReviewSessionVersionByTaskId.set(taskId, session.updatedAt);
+}
+
+/**
+ * Returns whether automation should wait for new session activity before retrying a failed git action.
+ */
+function shouldWaitForSessionChangeBeforeAutoReview(
+	entry: TrackedWorkspaceAutomation,
+	taskId: string,
+	session: RuntimeTaskSessionSummary,
+): boolean {
+	const blockedUpdatedAt = entry.blockedAutoReviewSessionVersionByTaskId.get(taskId);
+	if (blockedUpdatedAt === undefined) {
+		return false;
+	}
+	if (blockedUpdatedAt === session.updatedAt) {
+		return true;
+	}
+	entry.blockedAutoReviewSessionVersionByTaskId.delete(taskId);
+	return false;
+}
+
+/**
+ * Clears any session-version block once a task leaves the failed auto-review state.
+ */
+function clearBlockedAutoReview(entry: TrackedWorkspaceAutomation, taskId: string): void {
+	entry.blockedAutoReviewSessionVersionByTaskId.delete(taskId);
+}
+
+/**
  * Evaluates review-column tasks and runs the runtime-owned auto-review state machine.
  */
 async function evaluateWorkspaceAutoReview(input: {
@@ -441,7 +480,8 @@ async function evaluateWorkspaceAutoReview(input: {
 				input.workspaceId,
 				task.id,
 			);
-			const preserveAutoCleanupState = autoCleanupAction !== null && column.id === "in_progress";
+			const preserveAutoCleanupState =
+				autoCleanupAction !== null && column.id === "in_progress" && input.state.sessions[task.id] != null;
 			if (preserveAutoCleanupState) {
 				inProgressCleanupTaskIds.add(task.id);
 			}
@@ -452,6 +492,7 @@ async function evaluateWorkspaceAutoReview(input: {
 			}
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 			clearScheduledTaskAction(input.entry, task.id);
+			clearBlockedAutoReview(input.entry, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 		}
 	}
@@ -460,6 +501,7 @@ async function evaluateWorkspaceAutoReview(input: {
 		if (!reviewTaskIds.has(taskId) && !inProgressCleanupTaskIds.has(taskId)) {
 			clearScheduledTaskAction(input.entry, taskId);
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, taskId);
+			clearBlockedAutoReview(input.entry, taskId);
 		}
 	}
 	for (const taskId of Array.from(input.entry.moveToTrashInFlightTaskIds)) {
@@ -467,9 +509,23 @@ async function evaluateWorkspaceAutoReview(input: {
 			input.entry.moveToTrashInFlightTaskIds.delete(taskId);
 		}
 	}
+	for (const taskId of Array.from(input.entry.blockedAutoReviewSessionVersionByTaskId.keys())) {
+		if (!reviewTaskIds.has(taskId)) {
+			clearBlockedAutoReview(input.entry, taskId);
+		}
+	}
 
 	for (const task of reviewCards) {
 		if (task.autoReviewEnabled !== true) {
+			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+			clearScheduledTaskAction(input.entry, task.id);
+			clearBlockedAutoReview(input.entry, task.id);
+			continue;
+		}
+
+		const liveSession = input.state.sessions[task.id] ?? null;
+		if (!liveSession) {
 			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
 			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			clearScheduledTaskAction(input.entry, task.id);
@@ -496,10 +552,18 @@ async function evaluateWorkspaceAutoReview(input: {
 					input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 				} else {
 					input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+					clearBlockedAutoReview(input.entry, task.id);
 				}
 			} else {
+				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+				blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
 				clearScheduledTaskAction(input.entry, task.id);
 			}
+			continue;
+		}
+
+		if (shouldWaitForSessionChangeBeforeAutoReview(input.entry, task.id, liveSession)) {
+			clearScheduledTaskAction(input.entry, task.id);
 			continue;
 		}
 
@@ -538,11 +602,14 @@ async function evaluateWorkspaceAutoReview(input: {
 		}
 
 		clearScheduledTaskAction(input.entry, task.id);
-		await runTaskGitAction({
+		const ranTaskGitAction = await runTaskGitAction({
 			runtimeClient: input.runtimeClient,
 			task,
 			action: autoReviewMode,
 		}).catch(() => false);
+		if (!ranTaskGitAction) {
+			blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
+		}
 	}
 }
 

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -351,7 +351,9 @@ async function trashTaskAndStartLinkedTasks(input: {
 }): Promise<boolean> {
 	const mutation = await mutateWorkspaceState(input.workspacePath, (latestState) => {
 		const record = findTaskRecord(latestState, input.taskId);
-		if (!record || record.columnId === "trash") {
+		const canRecoverFromInProgress = input.sourceColumnId === "review" && record?.columnId === "in_progress";
+		const isEligibleSourceColumn = record?.columnId === input.sourceColumnId || canRecoverFromInProgress;
+		if (!record || record.columnId === "trash" || !isEligibleSourceColumn) {
 			return {
 				board: latestState.board,
 				value: {
@@ -555,6 +557,25 @@ function isWaitingForAutoCleanupSessionChange(
  */
 function clearPendingAutoCleanupSessionVersion(entry: TrackedWorkspaceAutomation, taskId: string): void {
 	entry.pendingAutoCleanupSessionVersionByTaskId.delete(taskId);
+}
+
+/**
+ * Returns whether a workspace still needs a background poller after the current automation pass.
+ */
+function shouldKeepWorkspacePoller(
+	entry: TrackedWorkspaceAutomation,
+	state: RuntimeWorkspaceStateResponse,
+): boolean {
+	if (
+		entry.scheduledActionByTaskId.size > 0 ||
+		entry.blockedAutoReviewSessionVersionByTaskId.size > 0 ||
+		entry.pendingAutoCleanupSessionVersionByTaskId.size > 0 ||
+		entry.moveToTrashInFlightTaskIds.size > 0
+	) {
+		return true;
+	}
+	const reviewColumn = state.board.columns.find((column) => column.id === "review");
+	return (reviewColumn?.cards ?? []).some((task) => task.autoReviewEnabled === true);
 }
 
 /**
@@ -809,6 +830,7 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 					state: automationState,
 					nowValue: Date.now(),
 				});
+				syncWorkspacePoller(entry, automationState);
 			} while (entry.rerunRequested);
 		})().finally(() => {
 			entry.runningTick = null;
@@ -830,6 +852,20 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 	}
 
 	/**
+	 * Starts or stops the background poller to match the workspace's current automation workload.
+	 */
+	function syncWorkspacePoller(entry: TrackedWorkspaceAutomation, state: RuntimeWorkspaceStateResponse): void {
+		if (shouldKeepWorkspacePoller(entry, state)) {
+			ensureWorkspacePoller(entry);
+			return;
+		}
+		if (entry.pollTimer) {
+			clearInterval(entry.pollTimer);
+			entry.pollTimer = null;
+		}
+	}
+
+	/**
 	 * Disposes all subscriptions, timers, and queued task state for one workspace.
 	 */
 	function disposeWorkspace(workspaceId: string): void {
@@ -848,8 +884,7 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 
 	return {
 		trackWorkspace: (workspaceId) => {
-			const entry = getTrackedWorkspace(workspaceId);
-			ensureWorkspacePoller(entry);
+			getTrackedWorkspace(workspaceId);
 			queueWorkspaceTick(workspaceId);
 		},
 		trackTerminalManager: (workspaceId, manager) => {
@@ -859,7 +894,6 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 			entry.terminalSummaryUnsubscribe = manager.onSummary(() => {
 				queueWorkspaceTick(workspaceId);
 			});
-			ensureWorkspacePoller(entry);
 			queueWorkspaceTick(workspaceId);
 		},
 		trackClineTaskSessionService: (workspaceId, service) => {
@@ -869,7 +903,6 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 			entry.clineSummaryUnsubscribe = service.onSummary(() => {
 				queueWorkspaceTick(workspaceId);
 			});
-			ensureWorkspacePoller(entry);
 			queueWorkspaceTick(workspaceId);
 		},
 		disposeWorkspace,

--- a/src/server/runtime-task-automation.ts
+++ b/src/server/runtime-task-automation.ts
@@ -100,15 +100,16 @@ function selectNewestTaskSessionSummary(
 
 /**
  * Collects the session summaries that automation can act on immediately.
- * Disk-only terminal snapshots are excluded because they cannot receive input after restart.
+ * Disk-only terminal snapshots are excluded, while persisted Cline review sessions are rebound on demand.
  */
-function collectAutomationTaskSessionSummaries(
-	terminalManager: TerminalSessionManager | null,
-	clineTaskSessionService: ClineTaskSessionService | null,
-): Record<string, RuntimeTaskSessionSummary> {
+async function collectAutomationTaskSessionSummaries(input: {
+	persistedSessions: Record<string, RuntimeTaskSessionSummary>;
+	terminalManager: TerminalSessionManager | null;
+	clineTaskSessionService: ClineTaskSessionService | null;
+}): Promise<Record<string, RuntimeTaskSessionSummary>> {
 	const mergedSessions: Record<string, RuntimeTaskSessionSummary> = {};
-	for (const summary of terminalManager?.listSummaries() ?? []) {
-		if (!terminalManager?.hasActiveTaskSession(summary.taskId)) {
+	for (const summary of input.terminalManager?.listSummaries() ?? []) {
+		if (!input.terminalManager?.hasActiveTaskSession(summary.taskId)) {
 			continue;
 		}
 		const newest = selectNewestTaskSessionSummary(mergedSessions[summary.taskId] ?? null, summary);
@@ -116,10 +117,35 @@ function collectAutomationTaskSessionSummaries(
 			mergedSessions[summary.taskId] = newest;
 		}
 	}
-	for (const summary of clineTaskSessionService?.listSummaries() ?? []) {
+	for (const summary of input.clineTaskSessionService?.listSummaries() ?? []) {
 		const newest = selectNewestTaskSessionSummary(mergedSessions[summary.taskId] ?? null, summary);
 		if (newest) {
 			mergedSessions[summary.taskId] = newest;
+		}
+	}
+	if (!input.clineTaskSessionService) {
+		return mergedSessions;
+	}
+	for (const persistedSummary of Object.values(input.persistedSessions)) {
+		if (persistedSummary.agentId !== "cline" || mergedSessions[persistedSummary.taskId]) {
+			continue;
+		}
+		if (
+			persistedSummary.state !== "awaiting_review" &&
+			persistedSummary.state !== "running" &&
+			persistedSummary.state !== "interrupted"
+		) {
+			continue;
+		}
+		const reboundSummary = await input.clineTaskSessionService
+			.rebindPersistedTaskSession(persistedSummary.taskId)
+			.catch(() => null);
+		if (!reboundSummary) {
+			continue;
+		}
+		const newest = selectNewestTaskSessionSummary(mergedSessions[reboundSummary.taskId] ?? null, reboundSummary);
+		if (newest) {
+			mergedSessions[reboundSummary.taskId] = newest;
 		}
 	}
 	return mergedSessions;
@@ -524,14 +550,6 @@ async function evaluateWorkspaceAutoReview(input: {
 			continue;
 		}
 
-		const liveSession = input.state.sessions[task.id] ?? null;
-		if (!liveSession) {
-			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
-			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
-			clearScheduledTaskAction(input.entry, task.id);
-			continue;
-		}
-
 		const autoReviewMode = resolveTaskAutoReviewMode(task.autoReviewMode);
 		const autoCleanupAction = input.taskGitActionCoordinator.getAutoCleanupTaskGitAction(input.workspaceId, task.id);
 		if (autoCleanupAction) {
@@ -555,15 +573,13 @@ async function evaluateWorkspaceAutoReview(input: {
 					clearBlockedAutoReview(input.entry, task.id);
 				}
 			} else {
+				const liveSession = input.state.sessions[task.id] ?? null;
 				input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
-				blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
+				if (liveSession) {
+					blockAutoReviewUntilSessionChanges(input.entry, task.id, liveSession);
+				}
 				clearScheduledTaskAction(input.entry, task.id);
 			}
-			continue;
-		}
-
-		if (shouldWaitForSessionChangeBeforeAutoReview(input.entry, task.id, liveSession)) {
-			clearScheduledTaskAction(input.entry, task.id);
 			continue;
 		}
 
@@ -585,6 +601,19 @@ async function evaluateWorkspaceAutoReview(input: {
 			if (!moved) {
 				input.entry.moveToTrashInFlightTaskIds.delete(task.id);
 			}
+			continue;
+		}
+
+		const liveSession = input.state.sessions[task.id] ?? null;
+		if (!liveSession) {
+			input.taskGitActionCoordinator.clearTaskGitAction(input.workspaceId, task.id);
+			input.entry.moveToTrashInFlightTaskIds.delete(task.id);
+			clearScheduledTaskAction(input.entry, task.id);
+			continue;
+		}
+
+		if (shouldWaitForSessionChangeBeforeAutoReview(input.entry, task.id, liveSession)) {
+			clearScheduledTaskAction(input.entry, task.id);
 			continue;
 		}
 
@@ -659,10 +688,11 @@ export function createRuntimeTaskAutomation(deps: CreateRuntimeTaskAutomationDep
 					disposeWorkspace(workspaceId);
 					return;
 				}
-				const liveSessions = collectAutomationTaskSessionSummaries(
-					entry.terminalManager,
-					entry.clineTaskSessionService,
-				);
+				const liveSessions = await collectAutomationTaskSessionSummaries({
+					persistedSessions: persistedState.sessions,
+					terminalManager: entry.terminalManager,
+					clineTaskSessionService: entry.clineTaskSessionService,
+				});
 				const automationState = deriveAutomationWorkspaceState({
 					state: persistedState,
 					liveSessions,

--- a/src/server/runtime-task-git-actions.test.ts
+++ b/src/server/runtime-task-git-actions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { createRuntimeTaskGitActionCoordinator } from "./runtime-task-git-actions";
+
+describe("createRuntimeTaskGitActionCoordinator", () => {
+	it("blocks new git actions while auto-cleanup is armed", () => {
+		const coordinator = createRuntimeTaskGitActionCoordinator();
+
+		expect(coordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		coordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
+			dispatched: true,
+			armAutoCleanup: true,
+		});
+
+		expect(coordinator.getAutoCleanupTaskGitAction("workspace-1", "task-1")).toBe("commit");
+		expect(coordinator.isTaskGitActionBlocked("workspace-1", "task-1")).toBe(true);
+		expect(coordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(false);
+	});
+
+	it("allows new git actions after auto-cleanup state is cleared", () => {
+		const coordinator = createRuntimeTaskGitActionCoordinator();
+
+		expect(coordinator.beginTaskGitAction("workspace-1", "task-1", "commit")).toBe(true);
+		coordinator.completeTaskGitAction("workspace-1", "task-1", "commit", {
+			dispatched: true,
+			armAutoCleanup: true,
+		});
+		coordinator.clearTaskGitAction("workspace-1", "task-1");
+
+		expect(coordinator.isTaskGitActionBlocked("workspace-1", "task-1")).toBe(false);
+		expect(coordinator.beginTaskGitAction("workspace-1", "task-1", "pr")).toBe(true);
+	});
+});

--- a/src/server/runtime-task-git-actions.ts
+++ b/src/server/runtime-task-git-actions.ts
@@ -118,7 +118,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 	return {
 		beginTaskGitAction: (workspaceId, taskId, action) => {
 			const taskState = getTaskState(workspaceId, taskId);
-			if (taskState.inFlightAction !== null) {
+			if (taskState.inFlightAction !== null || taskState.autoCleanupAction !== null) {
 				return false;
 			}
 			taskState.inFlightAction = action;

--- a/src/server/runtime-task-git-actions.ts
+++ b/src/server/runtime-task-git-actions.ts
@@ -12,6 +12,7 @@ interface TaskGitPromptTemplates {
 interface TaskGitActionState {
 	inFlightAction: RuntimeTaskGitAction | null;
 	pendingAction: RuntimeTaskGitAction | null;
+	autoCleanupAction: RuntimeTaskGitAction | null;
 }
 
 export interface RuntimeTaskGitActionCoordinator {
@@ -20,9 +21,9 @@ export interface RuntimeTaskGitActionCoordinator {
 		workspaceId: string,
 		taskId: string,
 		action: RuntimeTaskGitAction,
-		options: { triggered: boolean },
+		options: { dispatched: boolean; armAutoCleanup: boolean },
 	) => void;
-	getPendingTaskGitAction: (workspaceId: string, taskId: string) => RuntimeTaskGitAction | null;
+	getAutoCleanupTaskGitAction: (workspaceId: string, taskId: string) => RuntimeTaskGitAction | null;
 	isTaskGitActionBlocked: (workspaceId: string, taskId: string) => boolean;
 	clearTaskGitAction: (workspaceId: string, taskId: string) => void;
 	disposeWorkspace: (workspaceId: string) => void;
@@ -91,6 +92,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 			taskState = {
 				inFlightAction: null,
 				pendingAction: null,
+				autoCleanupAction: null,
 			};
 			taskStateByTaskId.set(taskId, taskState);
 		}
@@ -106,7 +108,11 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 		if (!taskStateByTaskId || !taskState) {
 			return;
 		}
-		if (taskState.inFlightAction !== null || taskState.pendingAction !== null) {
+		if (
+			taskState.inFlightAction !== null ||
+			taskState.pendingAction !== null ||
+			taskState.autoCleanupAction !== null
+		) {
 			return;
 		}
 		taskStateByTaskId.delete(taskId);
@@ -129,17 +135,26 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 			if (taskState.inFlightAction === action) {
 				taskState.inFlightAction = null;
 			}
-			if (options.triggered) {
+			if (options.dispatched) {
 				taskState.pendingAction = action;
+				taskState.autoCleanupAction = options.armAutoCleanup ? action : null;
+			} else {
+				taskState.pendingAction = null;
+				taskState.autoCleanupAction = null;
 			}
 			pruneTaskState(workspaceId, taskId);
 		},
-		getPendingTaskGitAction: (workspaceId, taskId) => {
-			return taskStateByWorkspaceId.get(workspaceId)?.get(taskId)?.pendingAction ?? null;
+		getAutoCleanupTaskGitAction: (workspaceId, taskId) => {
+			return taskStateByWorkspaceId.get(workspaceId)?.get(taskId)?.autoCleanupAction ?? null;
 		},
 		isTaskGitActionBlocked: (workspaceId, taskId) => {
 			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
-			return Boolean(taskState && (taskState.inFlightAction !== null || taskState.pendingAction !== null));
+			return Boolean(
+				taskState &&
+					(taskState.inFlightAction !== null ||
+						taskState.pendingAction !== null ||
+						taskState.autoCleanupAction !== null),
+			);
 		},
 		clearTaskGitAction: (workspaceId, taskId) => {
 			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
@@ -148,6 +163,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 			}
 			taskState.inFlightAction = null;
 			taskState.pendingAction = null;
+			taskState.autoCleanupAction = null;
 			pruneTaskState(workspaceId, taskId);
 		},
 		disposeWorkspace: (workspaceId) => {

--- a/src/server/runtime-task-git-actions.ts
+++ b/src/server/runtime-task-git-actions.ts
@@ -23,6 +23,7 @@ export interface RuntimeTaskGitActionCoordinator {
 		options: { dispatched: boolean; armAutoCleanup: boolean },
 	) => void;
 	getAutoCleanupTaskGitAction: (workspaceId: string, taskId: string) => RuntimeTaskGitAction | null;
+	isTaskGitActionInFlight: (workspaceId: string, taskId: string) => boolean;
 	isTaskGitActionBlocked: (workspaceId: string, taskId: string) => boolean;
 	clearTaskGitAction: (workspaceId: string, taskId: string) => void;
 	disposeWorkspace: (workspaceId: string) => void;
@@ -138,6 +139,9 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 		},
 		getAutoCleanupTaskGitAction: (workspaceId, taskId) => {
 			return taskStateByWorkspaceId.get(workspaceId)?.get(taskId)?.autoCleanupAction ?? null;
+		},
+		isTaskGitActionInFlight: (workspaceId, taskId) => {
+			return taskStateByWorkspaceId.get(workspaceId)?.get(taskId)?.inFlightAction !== null;
 		},
 		isTaskGitActionBlocked: (workspaceId, taskId) => {
 			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);

--- a/src/server/runtime-task-git-actions.ts
+++ b/src/server/runtime-task-git-actions.ts
@@ -11,7 +11,6 @@ interface TaskGitPromptTemplates {
 
 interface TaskGitActionState {
 	inFlightAction: RuntimeTaskGitAction | null;
-	pendingAction: RuntimeTaskGitAction | null;
 	autoCleanupAction: RuntimeTaskGitAction | null;
 }
 
@@ -91,7 +90,6 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 		if (!taskState) {
 			taskState = {
 				inFlightAction: null,
-				pendingAction: null,
 				autoCleanupAction: null,
 			};
 			taskStateByTaskId.set(taskId, taskState);
@@ -108,11 +106,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 		if (!taskStateByTaskId || !taskState) {
 			return;
 		}
-		if (
-			taskState.inFlightAction !== null ||
-			taskState.pendingAction !== null ||
-			taskState.autoCleanupAction !== null
-		) {
+		if (taskState.inFlightAction !== null || taskState.autoCleanupAction !== null) {
 			return;
 		}
 		taskStateByTaskId.delete(taskId);
@@ -124,7 +118,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 	return {
 		beginTaskGitAction: (workspaceId, taskId, action) => {
 			const taskState = getTaskState(workspaceId, taskId);
-			if (taskState.inFlightAction !== null || taskState.pendingAction !== null) {
+			if (taskState.inFlightAction !== null) {
 				return false;
 			}
 			taskState.inFlightAction = action;
@@ -136,10 +130,8 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 				taskState.inFlightAction = null;
 			}
 			if (options.dispatched) {
-				taskState.pendingAction = action;
 				taskState.autoCleanupAction = options.armAutoCleanup ? action : null;
 			} else {
-				taskState.pendingAction = null;
 				taskState.autoCleanupAction = null;
 			}
 			pruneTaskState(workspaceId, taskId);
@@ -149,12 +141,7 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 		},
 		isTaskGitActionBlocked: (workspaceId, taskId) => {
 			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
-			return Boolean(
-				taskState &&
-					(taskState.inFlightAction !== null ||
-						taskState.pendingAction !== null ||
-						taskState.autoCleanupAction !== null),
-			);
+			return Boolean(taskState && (taskState.inFlightAction !== null || taskState.autoCleanupAction !== null));
 		},
 		clearTaskGitAction: (workspaceId, taskId) => {
 			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
@@ -162,7 +149,6 @@ export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoo
 				return;
 			}
 			taskState.inFlightAction = null;
-			taskState.pendingAction = null;
 			taskState.autoCleanupAction = null;
 			pruneTaskState(workspaceId, taskId);
 		},

--- a/src/server/runtime-task-git-actions.ts
+++ b/src/server/runtime-task-git-actions.ts
@@ -1,0 +1,160 @@
+import type { RuntimeTaskAutoReviewMode, RuntimeTaskWorkspaceInfoResponse } from "../core/api-contract";
+
+export type RuntimeTaskGitAction = Extract<RuntimeTaskAutoReviewMode, "commit" | "pr">;
+
+interface TaskGitPromptTemplates {
+	commitPromptTemplate?: string | null;
+	openPrPromptTemplate?: string | null;
+	commitPromptTemplateDefault?: string | null;
+	openPrPromptTemplateDefault?: string | null;
+}
+
+interface TaskGitActionState {
+	inFlightAction: RuntimeTaskGitAction | null;
+	pendingAction: RuntimeTaskGitAction | null;
+}
+
+export interface RuntimeTaskGitActionCoordinator {
+	beginTaskGitAction: (workspaceId: string, taskId: string, action: RuntimeTaskGitAction) => boolean;
+	completeTaskGitAction: (
+		workspaceId: string,
+		taskId: string,
+		action: RuntimeTaskGitAction,
+		options: { triggered: boolean },
+	) => void;
+	getPendingTaskGitAction: (workspaceId: string, taskId: string) => RuntimeTaskGitAction | null;
+	isTaskGitActionBlocked: (workspaceId: string, taskId: string) => boolean;
+	clearTaskGitAction: (workspaceId: string, taskId: string) => void;
+	disposeWorkspace: (workspaceId: string) => void;
+	close: () => void;
+}
+
+/**
+ * Resolves the prompt template string that should drive a commit or PR agent action.
+ */
+function resolveTaskGitActionTemplate(
+	action: RuntimeTaskGitAction,
+	templates: TaskGitPromptTemplates | null | undefined,
+): string {
+	if (action === "commit") {
+		const template = templates?.commitPromptTemplate?.trim();
+		if (template) {
+			return template;
+		}
+		const defaultTemplate = templates?.commitPromptTemplateDefault?.trim();
+		if (defaultTemplate) {
+			return defaultTemplate;
+		}
+		return "Handle this commit action using the provided git context.";
+	}
+	const template = templates?.openPrPromptTemplate?.trim();
+	if (template) {
+		return template;
+	}
+	const defaultTemplate = templates?.openPrPromptTemplateDefault?.trim();
+	if (defaultTemplate) {
+		return defaultTemplate;
+	}
+	return "Handle this pull request action using the provided git context.";
+}
+
+/**
+ * Builds the agent prompt used for commit and PR actions from the runtime config templates.
+ */
+export function buildTaskGitActionPrompt(input: {
+	action: RuntimeTaskGitAction;
+	workspaceInfo: RuntimeTaskWorkspaceInfoResponse;
+	templates?: TaskGitPromptTemplates | null;
+}): string {
+	const template = resolveTaskGitActionTemplate(input.action, input.templates);
+	return template.replaceAll("{{base_ref}}", input.workspaceInfo.baseRef);
+}
+
+/**
+ * Creates a workspace-scoped coordinator for commit/PR actions so manual and automatic flows
+ * share one source of truth about which tasks are already waiting on git work.
+ */
+export function createRuntimeTaskGitActionCoordinator(): RuntimeTaskGitActionCoordinator {
+	const taskStateByWorkspaceId = new Map<string, Map<string, TaskGitActionState>>();
+
+	/**
+	 * Returns the mutable per-task state for a workspace, creating it on first write.
+	 */
+	function getTaskState(workspaceId: string, taskId: string): TaskGitActionState {
+		let taskStateByTaskId = taskStateByWorkspaceId.get(workspaceId);
+		if (!taskStateByTaskId) {
+			taskStateByTaskId = new Map<string, TaskGitActionState>();
+			taskStateByWorkspaceId.set(workspaceId, taskStateByTaskId);
+		}
+		let taskState = taskStateByTaskId.get(taskId);
+		if (!taskState) {
+			taskState = {
+				inFlightAction: null,
+				pendingAction: null,
+			};
+			taskStateByTaskId.set(taskId, taskState);
+		}
+		return taskState;
+	}
+
+	/**
+	 * Removes an empty task-state map after the last action for a workspace has been cleared.
+	 */
+	function pruneTaskState(workspaceId: string, taskId: string): void {
+		const taskStateByTaskId = taskStateByWorkspaceId.get(workspaceId);
+		const taskState = taskStateByTaskId?.get(taskId);
+		if (!taskStateByTaskId || !taskState) {
+			return;
+		}
+		if (taskState.inFlightAction !== null || taskState.pendingAction !== null) {
+			return;
+		}
+		taskStateByTaskId.delete(taskId);
+		if (taskStateByTaskId.size === 0) {
+			taskStateByWorkspaceId.delete(workspaceId);
+		}
+	}
+
+	return {
+		beginTaskGitAction: (workspaceId, taskId, action) => {
+			const taskState = getTaskState(workspaceId, taskId);
+			if (taskState.inFlightAction !== null || taskState.pendingAction !== null) {
+				return false;
+			}
+			taskState.inFlightAction = action;
+			return true;
+		},
+		completeTaskGitAction: (workspaceId, taskId, action, options) => {
+			const taskState = getTaskState(workspaceId, taskId);
+			if (taskState.inFlightAction === action) {
+				taskState.inFlightAction = null;
+			}
+			if (options.triggered) {
+				taskState.pendingAction = action;
+			}
+			pruneTaskState(workspaceId, taskId);
+		},
+		getPendingTaskGitAction: (workspaceId, taskId) => {
+			return taskStateByWorkspaceId.get(workspaceId)?.get(taskId)?.pendingAction ?? null;
+		},
+		isTaskGitActionBlocked: (workspaceId, taskId) => {
+			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
+			return Boolean(taskState && (taskState.inFlightAction !== null || taskState.pendingAction !== null));
+		},
+		clearTaskGitAction: (workspaceId, taskId) => {
+			const taskState = taskStateByWorkspaceId.get(workspaceId)?.get(taskId);
+			if (!taskState) {
+				return;
+			}
+			taskState.inFlightAction = null;
+			taskState.pendingAction = null;
+			pruneTaskState(workspaceId, taskId);
+		},
+		disposeWorkspace: (workspaceId) => {
+			taskStateByWorkspaceId.delete(workspaceId);
+		},
+		close: () => {
+			taskStateByWorkspaceId.clear();
+		},
+	};
+}

--- a/src/server/workspace-registry.test.ts
+++ b/src/server/workspace-registry.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RuntimeConfigState } from "../config/runtime-config";
+import { createWorkspaceRegistry } from "./workspace-registry";
+
+const listWorkspaceIndexEntriesMock = vi.hoisted(() => vi.fn());
+const loadWorkspaceContextMock = vi.hoisted(() => vi.fn());
+const loadWorkspaceStateMock = vi.hoisted(() => vi.fn());
+const removeWorkspaceIndexEntryMock = vi.hoisted(() => vi.fn());
+const removeWorkspaceStateFilesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../state/workspace-state", () => ({
+	listWorkspaceIndexEntries: listWorkspaceIndexEntriesMock,
+	loadWorkspaceContext: loadWorkspaceContextMock,
+	loadWorkspaceState: loadWorkspaceStateMock,
+	removeWorkspaceIndexEntry: removeWorkspaceIndexEntryMock,
+	removeWorkspaceStateFiles: removeWorkspaceStateFilesMock,
+}));
+
+vi.mock("../terminal/session-manager", () => ({
+	TerminalSessionManager: class TerminalSessionManager {
+		/**
+		 * Mirrors the session-manager API that workspace-registry uses during tests.
+		 */
+		hydrateFromRecord(): void {}
+
+		/**
+		 * Mirrors the session-manager API that workspace-registry uses during tests.
+		 */
+		listSummaries(): [] {
+			return [];
+		}
+
+		/**
+		 * Mirrors the session-manager API that workspace-registry uses during tests.
+		 */
+		markInterruptedAndStopAll(): [] {
+			return [];
+		}
+	},
+}));
+
+/**
+ * Returns a minimal runtime-config fixture for workspace-registry tests.
+ */
+function createRuntimeConfig() {
+	return {
+		globalConfigPath: "/tmp/global-config.json",
+		projectConfigPath: null,
+		selectedAgentId: "codex",
+		selectedShortcutLabel: null,
+		agentAutonomousModeEnabled: false,
+		readyForReviewNotificationsEnabled: true,
+		shortcuts: [],
+		commitPromptTemplate: "Commit prompt",
+		openPrPromptTemplate: "PR prompt",
+		commitPromptTemplateDefault: "Commit prompt",
+		openPrPromptTemplateDefault: "PR prompt",
+	} satisfies RuntimeConfigState;
+}
+
+describe("createWorkspaceRegistry", () => {
+	beforeEach(() => {
+		listWorkspaceIndexEntriesMock.mockReset();
+		listWorkspaceIndexEntriesMock.mockResolvedValue([]);
+		loadWorkspaceContextMock.mockReset();
+		loadWorkspaceContextMock.mockResolvedValue(null);
+		loadWorkspaceStateMock.mockReset();
+		loadWorkspaceStateMock.mockRejectedValue(new Error("not needed"));
+		removeWorkspaceIndexEntryMock.mockReset();
+		removeWorkspaceStateFilesMock.mockReset();
+	});
+
+	it("notifies when a workspace is remembered after startup", async () => {
+		const onWorkspaceRemembered = vi.fn();
+		const registry = await createWorkspaceRegistry({
+			cwd: "/repo",
+			loadGlobalRuntimeConfig: async () => createRuntimeConfig(),
+			loadRuntimeConfig: async () => createRuntimeConfig(),
+			hasGitRepository: () => false,
+			pathIsDirectory: async () => true,
+			onWorkspaceRemembered,
+		});
+
+		registry.rememberWorkspace("workspace-2", "/repo/two");
+
+		expect(onWorkspaceRemembered).toHaveBeenCalledWith("workspace-2", "/repo/two");
+		expect(registry.getWorkspacePathById("workspace-2")).toBe("/repo/two");
+	});
+});

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -28,6 +28,7 @@ export interface CreateWorkspaceRegistryDependencies {
 	hasGitRepository: (path: string) => boolean;
 	pathIsDirectory: (path: string) => Promise<boolean>;
 	onTerminalManagerReady?: (workspaceId: string, manager: TerminalSessionManager) => void;
+	onWorkspaceRemembered?: (workspaceId: string, repoPath: string) => void;
 }
 
 export interface DisposeWorkspaceRegistryOptions {
@@ -206,6 +207,7 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 
 	const rememberWorkspace = (workspaceId: string, repoPath: string): void => {
 		workspacePathsById.set(workspaceId, repoPath);
+		deps.onWorkspaceRemembered?.(workspaceId, repoPath);
 	};
 
 	const notifyTerminalManagerReady = (workspaceId: string, manager: TerminalSessionManager): void => {

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -734,6 +734,13 @@ export class TerminalSessionManager implements TerminalSessionService {
 		return cloneSummary(summary);
 	}
 
+	/**
+	 * Reports whether the task currently has a live PTY session that can receive input.
+	 */
+	hasActiveTaskSession(taskId: string): boolean {
+		return this.entries.get(taskId)?.active != null;
+	}
+
 	writeInput(taskId: string, data: Buffer): RuntimeTaskSessionSummary | null {
 		const entry = this.entries.get(taskId);
 		if (!entry?.active) {

--- a/src/terminal/terminal-session-service.ts
+++ b/src/terminal/terminal-session-service.ts
@@ -11,6 +11,7 @@ export interface TerminalSessionService {
 	attach(taskId: string, listener: TerminalSessionListener): (() => void) | null;
 	getRestoreSnapshot(taskId: string): Promise<TerminalRestoreSnapshot | null>;
 	recoverStaleSession(taskId: string): RuntimeTaskSessionSummary | null;
+	hasActiveTaskSession(taskId: string): boolean;
 	writeInput(taskId: string, data: Buffer): RuntimeTaskSessionSummary | null;
 	resize(taskId: string, cols: number, rows: number, pixelWidth?: number, pixelHeight?: number): boolean;
 	pauseOutput(taskId: string): boolean;

--- a/src/trpc/app-router.ts
+++ b/src/trpc/app-router.ts
@@ -62,6 +62,8 @@ import type {
 	RuntimeTaskChatReloadResponse,
 	RuntimeTaskChatSendRequest,
 	RuntimeTaskChatSendResponse,
+	RuntimeTaskGitActionRequest,
+	RuntimeTaskGitActionResponse,
 	RuntimeTaskSessionInputRequest,
 	RuntimeTaskSessionInputResponse,
 	RuntimeTaskSessionStartRequest,
@@ -139,6 +141,8 @@ import {
 	runtimeTaskChatReloadResponseSchema,
 	runtimeTaskChatSendRequestSchema,
 	runtimeTaskChatSendResponseSchema,
+	runtimeTaskGitActionRequestSchema,
+	runtimeTaskGitActionResponseSchema,
 	runtimeTaskSessionInputRequestSchema,
 	runtimeTaskSessionInputResponseSchema,
 	runtimeTaskSessionStartRequestSchema,
@@ -194,6 +198,10 @@ export interface RuntimeTrpcContext {
 			scope: RuntimeTrpcWorkspaceScope,
 			input: RuntimeTaskSessionInputRequest,
 		) => Promise<RuntimeTaskSessionInputResponse>;
+		runTaskGitAction: (
+			scope: RuntimeTrpcWorkspaceScope,
+			input: RuntimeTaskGitActionRequest,
+		) => Promise<RuntimeTaskGitActionResponse>;
 		getTaskChatMessages: (
 			scope: RuntimeTrpcWorkspaceScope,
 			input: RuntimeTaskChatMessagesRequest,
@@ -414,6 +422,12 @@ export const runtimeAppRouter = t.router({
 			.output(runtimeTaskSessionInputResponseSchema)
 			.mutation(async ({ ctx, input }) => {
 				return await ctx.runtimeApi.sendTaskSessionInput(ctx.workspaceScope, input);
+			}),
+		runTaskGitAction: workspaceProcedure
+			.input(runtimeTaskGitActionRequestSchema)
+			.output(runtimeTaskGitActionResponseSchema)
+			.mutation(async ({ ctx, input }) => {
+				return await ctx.runtimeApi.runTaskGitAction(ctx.workspaceScope, input);
 			}),
 		getTaskChatMessages: workspaceProcedure
 			.input(runtimeTaskChatMessagesRequestSchema)

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -30,15 +30,17 @@ import {
 	parseTaskChatMessagesRequest,
 	parseTaskChatReloadRequest,
 	parseTaskChatSendRequest,
+	parseTaskGitActionRequest,
 	parseTaskSessionInputRequest,
 	parseTaskSessionStartRequest,
 	parseTaskSessionStopRequest,
 } from "../core/api-validation";
 import { isHomeAgentSessionId } from "../core/home-agent-session";
 import { openInBrowser } from "../server/browser";
+import { buildTaskGitActionPrompt, type RuntimeTaskGitActionCoordinator } from "../server/runtime-task-git-actions";
 import { buildRuntimeConfigResponse, resolveAgentCommand } from "../terminal/agent-registry";
 import type { TerminalSessionManager } from "../terminal/session-manager";
-import { resolveTaskCwd } from "../workspace/task-worktree";
+import { getTaskWorkspaceInfo, resolveTaskCwd } from "../workspace/task-worktree";
 import { captureTaskTurnCheckpoint } from "../workspace/turn-checkpoints";
 import type { RuntimeTrpcContext, RuntimeTrpcWorkspaceScope } from "./app-router";
 
@@ -57,6 +59,7 @@ export interface CreateRuntimeApiDependencies {
 	broadcastTaskChatCleared?: (workspaceId: string, taskId: string) => void;
 	bumpClineSessionContextVersion?: () => void;
 	prepareForStateReset?: () => Promise<void>;
+	taskGitActionCoordinator?: RuntimeTaskGitActionCoordinator;
 }
 
 async function resolveExistingTaskCwdOrEnsure(options: {
@@ -81,6 +84,30 @@ async function resolveExistingTaskCwdOrEnsure(options: {
 	}
 }
 
+/**
+ * Chooses whether a task git action should be delivered through the native Cline chat path.
+ */
+function shouldUseClineChatForTaskGitAction(input: {
+	terminalSummaryAgentId: string | null;
+	clineSummaryAgentId: string | null;
+}): boolean {
+	if (input.clineSummaryAgentId === "cline") {
+		return true;
+	}
+	if (input.terminalSummaryAgentId === null) {
+		// When no terminal summary exists, prefer the Cline path first so persisted
+		// native sessions can be rebound before falling back to terminal I/O.
+		return true;
+	}
+	if (input.terminalSummaryAgentId === "cline") {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Creates the runtime-side TRPC handlers that back task sessions, git actions, and configuration flows.
+ */
 export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrpcContext["runtimeApi"] {
 	const clineProviderService = createClineProviderService();
 	const clineMcpSettingsService = createClineMcpSettingsService();
@@ -323,6 +350,134 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					summary,
 				};
 			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return {
+					ok: false,
+					summary: null,
+					error: message,
+				};
+			}
+		},
+		runTaskGitAction: async (workspaceScope, input) => {
+			const body = parseTaskGitActionRequest(input);
+			const started = deps.taskGitActionCoordinator
+				? deps.taskGitActionCoordinator.beginTaskGitAction(workspaceScope.workspaceId, body.taskId, body.action)
+				: true;
+			if (!started) {
+				return {
+					ok: false,
+					summary: null,
+					error: "A commit or pull request action is already pending for this task.",
+				};
+			}
+
+			try {
+				const [runtimeConfig, workspaceInfo, terminalManager, clineTaskSessionService] = await Promise.all([
+					deps.loadScopedRuntimeConfig(workspaceScope),
+					getTaskWorkspaceInfo({
+						cwd: workspaceScope.workspacePath,
+						taskId: body.taskId,
+						baseRef: body.baseRef,
+					}),
+					deps.getScopedTerminalManager(workspaceScope),
+					deps.getScopedClineTaskSessionService(workspaceScope),
+				]);
+				const prompt = buildTaskGitActionPrompt({
+					action: body.action,
+					workspaceInfo,
+					templates: {
+						commitPromptTemplate: runtimeConfig.commitPromptTemplate,
+						openPrPromptTemplate: runtimeConfig.openPrPromptTemplate,
+						commitPromptTemplateDefault: runtimeConfig.commitPromptTemplateDefault,
+						openPrPromptTemplateDefault: runtimeConfig.openPrPromptTemplateDefault,
+					},
+				});
+				const terminalSummary = terminalManager.getSummary(body.taskId);
+				const clineSummary = clineTaskSessionService.getSummary(body.taskId);
+
+				if (
+					shouldUseClineChatForTaskGitAction({
+						terminalSummaryAgentId: terminalSummary?.agentId ?? null,
+						clineSummaryAgentId: clineSummary?.agentId ?? null,
+					})
+				) {
+					let summary = await clineTaskSessionService.sendTaskSessionInput(body.taskId, prompt, "act");
+					if (!summary && !isHomeAgentSessionId(body.taskId)) {
+						const reboundSummary = await clineTaskSessionService.rebindPersistedTaskSession(body.taskId);
+						if (reboundSummary) {
+							summary = await clineTaskSessionService.sendTaskSessionInput(body.taskId, prompt, "act");
+						}
+					}
+					if (!summary) {
+						deps.taskGitActionCoordinator?.completeTaskGitAction(
+							workspaceScope.workspaceId,
+							body.taskId,
+							body.action,
+							{ triggered: false },
+						);
+						return {
+							ok: false,
+							summary: null,
+							error: "Task chat session is not running.",
+						};
+					}
+					deps.taskGitActionCoordinator?.completeTaskGitAction(
+						workspaceScope.workspaceId,
+						body.taskId,
+						body.action,
+						{ triggered: true },
+					);
+					return {
+						ok: true,
+						summary,
+					};
+				}
+
+				const typedSummary = terminalManager.writeInput(body.taskId, Buffer.from(prompt, "utf8"));
+				if (!typedSummary) {
+					deps.taskGitActionCoordinator?.completeTaskGitAction(
+						workspaceScope.workspaceId,
+						body.taskId,
+						body.action,
+						{ triggered: false },
+					);
+					return {
+						ok: false,
+						summary: null,
+						error: "Task session is not running.",
+					};
+				}
+
+				await new Promise<void>((resolve) => {
+					setTimeout(resolve, 200);
+				});
+
+				const submittedSummary = terminalManager.writeInput(body.taskId, Buffer.from("\r", "utf8"));
+				if (!submittedSummary) {
+					deps.taskGitActionCoordinator?.completeTaskGitAction(
+						workspaceScope.workspaceId,
+						body.taskId,
+						body.action,
+						{ triggered: false },
+					);
+					return {
+						ok: false,
+						summary: null,
+						error: "Task session is not running.",
+					};
+				}
+
+				deps.taskGitActionCoordinator?.completeTaskGitAction(workspaceScope.workspaceId, body.taskId, body.action, {
+					triggered: true,
+				});
+				return {
+					ok: true,
+					summary: submittedSummary,
+				};
+			} catch (error) {
+				deps.taskGitActionCoordinator?.completeTaskGitAction(workspaceScope.workspaceId, body.taskId, body.action, {
+					triggered: false,
+				});
 				const message = error instanceof Error ? error.message : String(error);
 				return {
 					ok: false,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -450,9 +450,7 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					};
 				}
 
-				const terminalPromptBuffer =
-					body.source === "manual" ? encodeTerminalPasteInput(prompt) : Buffer.from(prompt, "utf8");
-				const typedSummary = terminalManager.writeInput(body.taskId, terminalPromptBuffer);
+				const typedSummary = terminalManager.writeInput(body.taskId, encodeTerminalPasteInput(prompt));
 				if (!typedSummary) {
 					deps.taskGitActionCoordinator?.completeTaskGitAction(
 						workspaceScope.workspaceId,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -62,6 +62,13 @@ export interface CreateRuntimeApiDependencies {
 	taskGitActionCoordinator?: RuntimeTaskGitActionCoordinator;
 }
 
+/**
+ * Wraps terminal input in xterm's bracketed-paste control sequences so multiline prompts stay intact.
+ */
+function encodeTerminalPasteInput(text: string): Buffer {
+	return Buffer.from(`\u001b[200~${text}\u001b[201~`, "utf8");
+}
+
 async function resolveExistingTaskCwdOrEnsure(options: {
 	cwd: string;
 	taskId: string;
@@ -443,7 +450,9 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					};
 				}
 
-				const typedSummary = terminalManager.writeInput(body.taskId, Buffer.from(prompt, "utf8"));
+				const terminalPromptBuffer =
+					body.source === "manual" ? encodeTerminalPasteInput(prompt) : Buffer.from(prompt, "utf8");
+				const typedSummary = terminalManager.writeInput(body.taskId, terminalPromptBuffer);
 				if (!typedSummary) {
 					deps.taskGitActionCoordinator?.completeTaskGitAction(
 						workspaceScope.workspaceId,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -413,7 +413,10 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 							workspaceScope.workspaceId,
 							body.taskId,
 							body.action,
-							{ triggered: false },
+							{
+								dispatched: false,
+								armAutoCleanup: false,
+							},
 						);
 						return {
 							ok: false,
@@ -425,7 +428,10 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						workspaceScope.workspaceId,
 						body.taskId,
 						body.action,
-						{ triggered: true },
+						{
+							dispatched: true,
+							armAutoCleanup: body.source === "auto",
+						},
 					);
 					return {
 						ok: true,
@@ -439,7 +445,10 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						workspaceScope.workspaceId,
 						body.taskId,
 						body.action,
-						{ triggered: false },
+						{
+							dispatched: false,
+							armAutoCleanup: false,
+						},
 					);
 					return {
 						ok: false,
@@ -458,7 +467,10 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						workspaceScope.workspaceId,
 						body.taskId,
 						body.action,
-						{ triggered: false },
+						{
+							dispatched: false,
+							armAutoCleanup: false,
+						},
 					);
 					return {
 						ok: false,
@@ -468,7 +480,8 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				}
 
 				deps.taskGitActionCoordinator?.completeTaskGitAction(workspaceScope.workspaceId, body.taskId, body.action, {
-					triggered: true,
+					dispatched: true,
+					armAutoCleanup: body.source === "auto",
 				});
 				return {
 					ok: true,
@@ -476,7 +489,8 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				};
 			} catch (error) {
 				deps.taskGitActionCoordinator?.completeTaskGitAction(workspaceScope.workspaceId, body.taskId, body.action, {
-					triggered: false,
+					dispatched: false,
+					armAutoCleanup: false,
 				});
 				const message = error instanceof Error ? error.message : String(error);
 				return {

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -86,20 +86,22 @@ async function resolveExistingTaskCwdOrEnsure(options: {
 
 /**
  * Chooses whether a task git action should be delivered through the native Cline chat path.
+ * Live terminal sessions always win over stale persisted Cline history.
  */
 function shouldUseClineChatForTaskGitAction(input: {
+	hasActiveTerminalSession: boolean;
 	terminalSummaryAgentId: string | null;
 	clineSummaryAgentId: string | null;
 }): boolean {
+	if (input.hasActiveTerminalSession) {
+		return input.terminalSummaryAgentId === "cline";
+	}
 	if (input.clineSummaryAgentId === "cline") {
 		return true;
 	}
-	if (input.terminalSummaryAgentId === null) {
-		// When no terminal summary exists, prefer the Cline path first so persisted
-		// native sessions can be rebound before falling back to terminal I/O.
-		return true;
-	}
 	if (input.terminalSummaryAgentId === "cline") {
+		// Persisted Cline tasks can still be rebound from SDK artifacts even when the
+		// in-memory Cline service has not loaded a summary yet.
 		return true;
 	}
 	return false;
@@ -394,9 +396,11 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				});
 				const terminalSummary = terminalManager.getSummary(body.taskId);
 				const clineSummary = clineTaskSessionService.getSummary(body.taskId);
+				const hasActiveTerminalSession = terminalManager.hasActiveTaskSession(body.taskId);
 
 				if (
 					shouldUseClineChatForTaskGitAction({
+						hasActiveTerminalSession,
 						terminalSummaryAgentId: terminalSummary?.agentId ?? null,
 						clineSummaryAgentId: clineSummary?.agentId ?? null,
 					})

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -68,6 +68,10 @@ class FakeTerminalManager implements TerminalSessionService {
 		}),
 	);
 	recoverStaleSession = vi.fn(() => createSummary());
+	/**
+	 * Mirrors the runtime terminal service contract for tests that only need a live session.
+	 */
+	hasActiveTaskSession = vi.fn(() => true);
 	writeInput = vi.fn(() => createSummary());
 	resize = vi.fn(() => true);
 	pauseOutput = vi.fn(() => true);

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -12,6 +12,7 @@ const agentRegistryMocks = vi.hoisted(() => ({
 
 const taskWorktreeMocks = vi.hoisted(() => ({
 	resolveTaskCwd: vi.fn(),
+	getTaskWorkspaceInfo: vi.fn(),
 }));
 
 const turnCheckpointMocks = vi.hoisted(() => ({
@@ -57,6 +58,7 @@ vi.mock("../../../src/terminal/agent-registry.js", () => ({
 
 vi.mock("../../../src/workspace/task-worktree.js", () => ({
 	resolveTaskCwd: taskWorktreeMocks.resolveTaskCwd,
+	getTaskWorkspaceInfo: taskWorktreeMocks.getTaskWorkspaceInfo,
 }));
 
 vi.mock("../../../src/workspace/turn-checkpoints.js", () => ({
@@ -204,6 +206,7 @@ describe("createRuntimeApi startTaskSession", () => {
 		agentRegistryMocks.resolveAgentCommand.mockReset();
 		agentRegistryMocks.buildRuntimeConfigResponse.mockReset();
 		taskWorktreeMocks.resolveTaskCwd.mockReset();
+		taskWorktreeMocks.getTaskWorkspaceInfo.mockReset();
 		turnCheckpointMocks.captureTaskTurnCheckpoint.mockReset();
 		oauthMocks.addLocalProvider.mockReset();
 		oauthMocks.ensureCustomProvidersLoaded.mockReset();
@@ -237,6 +240,15 @@ describe("createRuntimeApi startTaskSession", () => {
 			ref: "refs/kanban/checkpoints/task-1/turn/1",
 			commit: "1111111",
 			createdAt: Date.now(),
+		});
+		taskWorktreeMocks.getTaskWorkspaceInfo.mockResolvedValue({
+			taskId: "task-1",
+			path: "/tmp/existing-worktree",
+			exists: true,
+			baseRef: "main",
+			branch: "task-1",
+			isDetached: false,
+			headCommit: "1111111",
 		});
 		oauthMocks.loginClineOAuth.mockResolvedValue({
 			access: "oauth-access",
@@ -999,6 +1011,76 @@ describe("createRuntimeApi startTaskSession", () => {
 		expect(stopResponse.ok).toBe(true);
 		expect(clineTaskSessionService.stopTaskSession).toHaveBeenCalledWith("task-1");
 		expect(terminalManager.stopTaskSession).not.toHaveBeenCalled();
+	});
+
+	it("routes task git actions to the active terminal session before stale cline history", async () => {
+		const summary = createSummary({ agentId: "codex" });
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+			hasActiveTaskSession: vi.fn(() => true),
+			writeInput: vi.fn(() => summary),
+		};
+		const clineTaskSessionService = createClineTaskSessionServiceMock();
+		clineTaskSessionService.getSummary.mockReturnValue(createSummary({ agentId: "cline", pid: null }));
+
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.runTaskGitAction(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-1", baseRef: "main", action: "commit", source: "manual" },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			summary,
+		});
+		expect(terminalManager.writeInput).toHaveBeenCalledWith("task-1", Buffer.from("commit", "utf8"));
+		expect(clineTaskSessionService.sendTaskSessionInput).not.toHaveBeenCalled();
+	});
+
+	it("rebinds persisted cline git actions when no active terminal session exists", async () => {
+		const summary = createSummary({ agentId: "cline", pid: null });
+		const terminalManager = {
+			getSummary: vi.fn(() => createSummary({ agentId: "cline", pid: null })),
+			hasActiveTaskSession: vi.fn(() => false),
+			writeInput: vi.fn(() => null),
+		};
+		const clineTaskSessionService = createClineTaskSessionServiceMock();
+		clineTaskSessionService.getSummary.mockReturnValue(null);
+		clineTaskSessionService.sendTaskSessionInput.mockResolvedValueOnce(null).mockResolvedValueOnce(summary);
+		clineTaskSessionService.rebindPersistedTaskSession.mockResolvedValue(summary);
+
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.runTaskGitAction(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-1", baseRef: "main", action: "pr", source: "manual" },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			summary,
+		});
+		expect(terminalManager.writeInput).not.toHaveBeenCalled();
+		expect(clineTaskSessionService.rebindPersistedTaskSession).toHaveBeenCalledWith("task-1");
+		expect(clineTaskSessionService.sendTaskSessionInput).toHaveBeenNthCalledWith(1, "task-1", "pr", "act");
+		expect(clineTaskSessionService.sendTaskSessionInput).toHaveBeenNthCalledWith(2, "task-1", "pr", "act");
 	});
 
 	it("returns cline chat messages and sends chat message through cline service", async () => {

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -1013,7 +1013,7 @@ describe("createRuntimeApi startTaskSession", () => {
 		expect(terminalManager.stopTaskSession).not.toHaveBeenCalled();
 	});
 
-	it("routes task git actions to the active terminal session before stale cline history", async () => {
+	it("routes manual multiline task git actions to the active terminal session as bracketed paste", async () => {
 		const summary = createSummary({ agentId: "codex" });
 		const terminalManager = {
 			getSummary: vi.fn(() => summary),
@@ -1022,10 +1022,12 @@ describe("createRuntimeApi startTaskSession", () => {
 		};
 		const clineTaskSessionService = createClineTaskSessionServiceMock();
 		clineTaskSessionService.getSummary.mockReturnValue(createSummary({ agentId: "cline", pid: null }));
+		const runtimeConfigState = createRuntimeConfigState();
+		runtimeConfigState.commitPromptTemplate = "line 1\nline 2";
 
 		const api = createRuntimeApi({
 			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
-			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			loadScopedRuntimeConfig: vi.fn(async () => runtimeConfigState),
 			setActiveRuntimeConfig: vi.fn(),
 			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
 			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
@@ -1042,7 +1044,12 @@ describe("createRuntimeApi startTaskSession", () => {
 			ok: true,
 			summary,
 		});
-		expect(terminalManager.writeInput).toHaveBeenCalledWith("task-1", Buffer.from("commit", "utf8"));
+		expect(terminalManager.writeInput).toHaveBeenNthCalledWith(
+			1,
+			"task-1",
+			Buffer.from("\u001b[200~line 1\nline 2\u001b[201~", "utf8"),
+		);
+		expect(terminalManager.writeInput).toHaveBeenNthCalledWith(2, "task-1", Buffer.from("\r", "utf8"));
 		expect(clineTaskSessionService.sendTaskSessionInput).not.toHaveBeenCalled();
 	});
 

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -1053,6 +1053,45 @@ describe("createRuntimeApi startTaskSession", () => {
 		expect(clineTaskSessionService.sendTaskSessionInput).not.toHaveBeenCalled();
 	});
 
+	it("routes auto multiline task git actions to the active terminal session as bracketed paste", async () => {
+		const summary = createSummary({ agentId: "codex" });
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+			hasActiveTaskSession: vi.fn(() => true),
+			writeInput: vi.fn(() => summary),
+		};
+		const clineTaskSessionService = createClineTaskSessionServiceMock();
+		const runtimeConfigState = createRuntimeConfigState();
+		runtimeConfigState.openPrPromptTemplate = "line 1\nline 2";
+
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => runtimeConfigState),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.runTaskGitAction(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-1", baseRef: "main", action: "pr", source: "auto" },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			summary,
+		});
+		expect(terminalManager.writeInput).toHaveBeenNthCalledWith(
+			1,
+			"task-1",
+			Buffer.from("\u001b[200~line 1\nline 2\u001b[201~", "utf8"),
+		);
+		expect(terminalManager.writeInput).toHaveBeenNthCalledWith(2, "task-1", Buffer.from("\r", "utf8"));
+		expect(clineTaskSessionService.sendTaskSessionInput).not.toHaveBeenCalled();
+	});
+
 	it("rebinds persisted cline git actions when no active terminal session exists", async () => {
 		const summary = createSummary({ agentId: "cline", pid: null });
 		const terminalManager = {

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -342,7 +342,6 @@ export default function App(): ReactElement {
 
 	const {
 		runningGitAction,
-		taskGitActionLoadingByTaskId,
 		commitTaskLoadingById,
 		openPrTaskLoadingById,
 		agentCommitTaskLoadingById,
@@ -359,7 +358,6 @@ export default function App(): ReactElement {
 		handleOpenPrTask,
 		handleAgentCommitTask,
 		handleAgentOpenPrTask,
-		runAutoReviewGitAction,
 		resetGitActionState,
 	} = useGitActions({
 		currentProjectId,
@@ -583,8 +581,6 @@ export default function App(): ReactElement {
 		fetchTaskWorkspaceInfo,
 		sendTaskSessionInput,
 		readyForReviewNotificationsEnabled,
-		taskGitActionLoadingByTaskId,
-		runAutoReviewGitAction,
 	});
 
 	const {

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -363,10 +363,6 @@ export default function App(): ReactElement {
 		currentProjectId,
 		board,
 		selectedCard,
-		runtimeProjectConfig,
-		sendTaskSessionInput,
-		sendTaskChatMessage,
-		fetchTaskWorkspaceInfo,
 		isGitHistoryOpen,
 		refreshWorkspaceState,
 	});

--- a/web-ui/src/hooks/use-board-interactions.test.tsx
+++ b/web-ui/src/hooks/use-board-interactions.test.tsx
@@ -25,10 +25,6 @@ vi.mock("@/hooks/use-programmatic-card-moves", () => ({
 	useProgrammaticCardMoves: useProgrammaticCardMovesMock,
 }));
 
-vi.mock("@/hooks/use-review-auto-actions", () => ({
-	useReviewAutoActions: () => ({}) as ReturnType<typeof useBoardInteractions>,
-}));
-
 function createTask(taskId: string, prompt: string, createdAt: number): BoardCard {
 	return {
 		id: taskId,
@@ -62,8 +58,6 @@ const NOOP_STOP_SESSION = async (): Promise<void> => {};
 const NOOP_CLEANUP_WORKSPACE = async (): Promise<null> => null;
 const NOOP_FETCH_WORKSPACE_INFO = async (): Promise<null> => null;
 const NOOP_SEND_TASK_INPUT = async (): Promise<{ ok: boolean }> => ({ ok: true });
-const NOOP_RUN_AUTO_REVIEW = async (): Promise<boolean> => false;
-
 interface HookSnapshot {
 	handleRestoreTaskFromTrash: (taskId: string) => void;
 	handleStartTask: (taskId: string) => void;
@@ -121,8 +115,6 @@ function HookHarness({
 		fetchTaskWorkspaceInfo: NOOP_FETCH_WORKSPACE_INFO,
 		sendTaskSessionInput: NOOP_SEND_TASK_INPUT,
 		readyForReviewNotificationsEnabled: false,
-		taskGitActionLoadingByTaskId: {},
-		runAutoReviewGitAction: NOOP_RUN_AUTO_REVIEW,
 	});
 
 	useEffect(() => {

--- a/web-ui/src/hooks/use-board-interactions.ts
+++ b/web-ui/src/hooks/use-board-interactions.ts
@@ -2,10 +2,8 @@ import type { DropResult } from "@hello-pangea/dnd";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notifyError, showAppToast } from "@/components/app-toaster";
-import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
 import { useLinkedBacklogTaskActions } from "@/hooks/use-linked-backlog-task-actions";
 import { useProgrammaticCardMoves } from "@/hooks/use-programmatic-card-moves";
-import { useReviewAutoActions } from "@/hooks/use-review-auto-actions";
 import type { UseTaskSessionsResult } from "@/hooks/use-task-sessions";
 import type { RuntimeTaskSessionSummary, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
 import {
@@ -27,11 +25,6 @@ import {
 	hasPromptedForBrowserNotificationPermission,
 	requestBrowserNotificationPermission,
 } from "@/utils/notification-permission";
-
-interface TaskGitActionLoadingStateLike {
-	commitSource: string | null;
-	prSource: string | null;
-}
 
 interface SelectedBoardCard {
 	card: BoardCard;
@@ -67,8 +60,6 @@ interface UseBoardInteractionsInput {
 		options?: SendTerminalInputOptions,
 	) => Promise<{ ok: boolean; message?: string }>;
 	readyForReviewNotificationsEnabled: boolean;
-	taskGitActionLoadingByTaskId: Record<string, TaskGitActionLoadingStateLike>;
-	runAutoReviewGitAction: (taskId: string, action: TaskGitAction) => Promise<boolean>;
 }
 
 export interface UseBoardInteractionsResult {
@@ -93,6 +84,9 @@ export interface UseBoardInteractionsResult {
 	trashTaskCount: number;
 }
 
+/**
+ * Coordinates drag/drop, task lifecycle, dependency, and review interactions for the board UI.
+ */
 export function useBoardInteractions({
 	board,
 	setBoard,
@@ -111,8 +105,6 @@ export function useBoardInteractions({
 	fetchTaskWorkspaceInfo,
 	sendTaskSessionInput,
 	readyForReviewNotificationsEnabled,
-	taskGitActionLoadingByTaskId,
-	runAutoReviewGitAction,
 }: UseBoardInteractionsInput): UseBoardInteractionsResult {
 	const previousSessionsRef = useRef<Record<string, RuntimeTaskSessionSummary>>({});
 	const notificationPermissionPromptInFlightRef = useRef(false);
@@ -522,14 +514,6 @@ export function useBoardInteractions({
 	useEffect(() => {
 		setRequestMoveTaskToTrashHandler(requestMoveTaskToTrash);
 	}, [requestMoveTaskToTrash, setRequestMoveTaskToTrashHandler]);
-
-	useReviewAutoActions({
-		board,
-		taskGitActionLoadingByTaskId,
-		runAutoReviewGitAction,
-		requestMoveTaskToTrash: requestMoveTaskToTrashWithAnimation,
-		resetKey: currentProjectId,
-	});
 
 	const resumeTaskFromTrash = useCallback(
 		async (task: BoardCard, taskId: string, options?: { optimisticMoveApplied?: boolean }): Promise<void> => {

--- a/web-ui/src/hooks/use-git-actions.test.tsx
+++ b/web-ui/src/hooks/use-git-actions.test.tsx
@@ -171,6 +171,7 @@ describe("useGitActions", () => {
 			taskId: "task-1",
 			baseRef: "main",
 			action: "commit",
+			source: "manual",
 		});
 		expect(showAppToastMock).not.toHaveBeenCalled();
 	});

--- a/web-ui/src/hooks/use-git-actions.test.tsx
+++ b/web-ui/src/hooks/use-git-actions.test.tsx
@@ -3,12 +3,12 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type UseGitActionsResult, useGitActions } from "@/hooks/use-git-actions";
-import type { RuntimeConfigResponse, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
 import { clearTaskWorkspaceInfo, clearTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 import type { BoardData } from "@/types";
 
 const showAppToastMock = vi.hoisted(() => vi.fn());
 const useGitHistoryDataMock = vi.hoisted(() => vi.fn());
+const runTaskGitActionMutateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/app-toaster", () => ({
 	showAppToast: showAppToastMock,
@@ -16,6 +16,16 @@ vi.mock("@/components/app-toaster", () => ({
 
 vi.mock("@/components/git-history/use-git-history-data", () => ({
 	useGitHistoryData: useGitHistoryDataMock,
+}));
+
+vi.mock("@/runtime/trpc-client", () => ({
+	getRuntimeTrpcClient: () => ({
+		runtime: {
+			runTaskGitAction: {
+				mutate: runTaskGitActionMutateMock,
+			},
+		},
+	}),
 }));
 
 interface HookSnapshot {
@@ -75,75 +85,11 @@ function createBoard(): BoardData {
 	};
 }
 
-function createRuntimeConfig(selectedAgentId: RuntimeConfigResponse["selectedAgentId"]): RuntimeConfigResponse {
-	return {
-		selectedAgentId,
-		selectedShortcutLabel: null,
-		agentAutonomousModeEnabled: true,
-		effectiveCommand: null,
-		globalConfigPath: "/tmp/global-config.json",
-		projectConfigPath: "/tmp/project-config.json",
-		readyForReviewNotificationsEnabled: true,
-		detectedCommands: [],
-		agents: [
-			{
-				id: selectedAgentId,
-				label: selectedAgentId,
-				binary: selectedAgentId,
-				command: selectedAgentId,
-				defaultArgs: [],
-				installed: true,
-				configured: true,
-			},
-		],
-		shortcuts: [],
-		clineProviderSettings: {
-			providerId: "anthropic",
-			modelId: "claude-sonnet-4",
-			baseUrl: null,
-			apiKeyConfigured: true,
-			oauthProvider: null,
-			oauthAccessTokenConfigured: false,
-			oauthRefreshTokenConfigured: false,
-			oauthAccountId: null,
-			oauthExpiresAt: null,
-		},
-		commitPromptTemplate: "commit",
-		openPrPromptTemplate: "pr",
-		commitPromptTemplateDefault: "commit",
-		openPrPromptTemplateDefault: "pr",
-	};
-}
-
-function createWorkspaceInfo(): RuntimeTaskWorkspaceInfoResponse {
-	return {
-		taskId: "task-1",
-		path: "/tmp/task-1",
-		exists: true,
-		baseRef: "main",
-		branch: "task-1",
-		isDetached: false,
-		headCommit: "abc1234",
-	};
-}
-
-function HookHarness({
-	onSnapshot,
-	sendTaskSessionInput,
-	sendTaskChatMessage,
-}: {
-	onSnapshot: (snapshot: HookSnapshot) => void;
-	sendTaskSessionInput: Parameters<typeof useGitActions>[0]["sendTaskSessionInput"];
-	sendTaskChatMessage: Parameters<typeof useGitActions>[0]["sendTaskChatMessage"];
-}): null {
+function HookHarness({ onSnapshot }: { onSnapshot: (snapshot: HookSnapshot) => void }): null {
 	const gitActions = useGitActions({
 		currentProjectId: "project-1",
 		board: createBoard(),
 		selectedCard: null,
-		runtimeProjectConfig: createRuntimeConfig("cline"),
-		sendTaskSessionInput,
-		sendTaskChatMessage,
-		fetchTaskWorkspaceInfo: async () => createWorkspaceInfo(),
 		isGitHistoryOpen: false,
 		refreshWorkspaceState: async () => {},
 	});
@@ -166,6 +112,11 @@ describe("useGitActions", () => {
 		showAppToastMock.mockReset();
 		useGitHistoryDataMock.mockReset();
 		useGitHistoryDataMock.mockReturnValue(createGitHistoryResult());
+		runTaskGitActionMutateMock.mockReset();
+		runTaskGitActionMutateMock.mockResolvedValue({
+			ok: true,
+			summary: null,
+		});
 		clearTaskWorkspaceInfo("task-1");
 		clearTaskWorkspaceSnapshot("task-1");
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -191,16 +142,12 @@ describe("useGitActions", () => {
 		}
 	});
 
-	it("sends commit prompts through the native cline chat API", async () => {
-		const sendTaskSessionInput = vi.fn(async () => ({ ok: true }));
-		const sendTaskChatMessage = vi.fn(async () => ({ ok: true }));
+	it("routes task commit actions through the runtime git-action endpoint", async () => {
 		let latestSnapshot: HookSnapshot | null = null;
 
 		await act(async () => {
 			root.render(
 				<HookHarness
-					sendTaskSessionInput={sendTaskSessionInput}
-					sendTaskChatMessage={sendTaskChatMessage}
 					onSnapshot={(snapshot) => {
 						latestSnapshot = snapshot;
 					}}
@@ -220,8 +167,11 @@ describe("useGitActions", () => {
 			await Promise.resolve();
 		});
 
-		expect(sendTaskChatMessage).toHaveBeenCalledWith("task-1", expect.any(String), { mode: "act" });
-		expect(sendTaskSessionInput).not.toHaveBeenCalled();
+		expect(runTaskGitActionMutateMock).toHaveBeenCalledWith({
+			taskId: "task-1",
+			baseRef: "main",
+			action: "commit",
+		});
 		expect(showAppToastMock).not.toHaveBeenCalled();
 	});
 });

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -1,23 +1,18 @@
 import { useCallback, useMemo, useState } from "react";
 import { showAppToast } from "@/components/app-toaster";
 import { type UseGitHistoryDataResult, useGitHistoryData } from "@/components/git-history/use-git-history-data";
-import { buildTaskGitActionPrompt, type TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
-import { isNativeClineAgentSelected } from "@/runtime/native-agent";
+import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
-import type { RuntimeConfigResponse, RuntimeGitSyncAction, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
+import type { RuntimeGitSyncAction } from "@/runtime/types";
 import { findCardSelection } from "@/state/board-state";
 import {
-	getTaskWorkspaceInfo,
-	getTaskWorkspaceSnapshot,
 	setHomeGitSummary,
-	setTaskWorkspaceInfo,
 	useHomeGitStateVersionValue,
 	useHomeGitSummaryValue,
 	useTaskWorkspaceSnapshotValue,
 	useTaskWorkspaceStateVersionValue,
 } from "@/stores/workspace-metadata-store";
-import type { SendTerminalInputOptions } from "@/terminal/terminal-input";
-import type { BoardCard, BoardData, CardSelection } from "@/types";
+import type { BoardData, CardSelection } from "@/types";
 
 type TaskGitActionSource = "card" | "agent";
 
@@ -30,18 +25,6 @@ interface UseGitActionsInput {
 	currentProjectId: string | null;
 	board: BoardData;
 	selectedCard: CardSelection | null;
-	runtimeProjectConfig: RuntimeConfigResponse | null;
-	sendTaskSessionInput: (
-		taskId: string,
-		text: string,
-		options?: SendTerminalInputOptions,
-	) => Promise<{ ok: boolean; message?: string }>;
-	sendTaskChatMessage: (
-		taskId: string,
-		text: string,
-		options?: { mode?: "plan" | "act" },
-	) => Promise<{ ok: boolean; message?: string }>;
-	fetchTaskWorkspaceInfo: (task: BoardCard) => Promise<RuntimeTaskWorkspaceInfoResponse | null>;
 	isGitHistoryOpen: boolean;
 	refreshWorkspaceState: () => Promise<void>;
 }
@@ -74,24 +57,13 @@ export interface UseGitActionsResult {
 	resetGitActionState: () => void;
 }
 
-function matchesWorkspaceInfoSelection(
-	workspaceInfo: RuntimeTaskWorkspaceInfoResponse | null,
-	card: BoardCard | null,
-): workspaceInfo is RuntimeTaskWorkspaceInfoResponse {
-	if (!workspaceInfo || !card) {
-		return false;
-	}
-	return workspaceInfo.taskId === card.id && workspaceInfo.baseRef === card.baseRef;
-}
-
+/**
+ * Coordinates git actions for the home workspace and review tasks while keeping loading state scoped to each UI surface.
+ */
 export function useGitActions({
 	currentProjectId,
 	board,
 	selectedCard,
-	runtimeProjectConfig,
-	sendTaskSessionInput,
-	sendTaskChatMessage,
-	fetchTaskWorkspaceInfo,
 	isGitHistoryOpen,
 	refreshWorkspaceState,
 }: UseGitActionsInput): UseGitActionsResult {
@@ -214,10 +186,6 @@ export function useGitActions({
 		return next;
 	}, [taskGitActionLoadingByTaskId]);
 
-	const shouldUseClineChatForTaskGitActions = isNativeClineAgentSelected(
-		runtimeProjectConfig?.selectedAgentId ?? null,
-	);
-
 	const runTaskGitAction = useCallback(
 		async (taskId: string, action: TaskGitAction, source: TaskGitActionSource) => {
 			const taskLoadingState = taskGitActionLoadingByTaskId[taskId];
@@ -246,78 +214,25 @@ export function useGitActions({
 					});
 					return false;
 				}
-
-				const snapshot = getTaskWorkspaceSnapshot(taskId);
-				const snapshotWorkspaceInfo = snapshot
-					? {
-							taskId,
-							path: snapshot.path,
-							exists: true,
-							baseRef: selection.card.baseRef,
-							branch: snapshot.branch,
-							isDetached: snapshot.isDetached,
-							headCommit: snapshot.headCommit,
-						}
-					: null;
-				const storedWorkspaceInfo = getTaskWorkspaceInfo(selection.card.id, selection.card.baseRef);
-				const workspaceInfo = matchesWorkspaceInfoSelection(storedWorkspaceInfo, selection.card)
-					? storedWorkspaceInfo
-					: (snapshotWorkspaceInfo ?? (await fetchTaskWorkspaceInfo(selection.card)));
-				if (!workspaceInfo) {
+				if (!currentProjectId) {
 					showAppToast({
 						intent: "danger",
 						icon: "warning-sign",
-						message: "Could not resolve task workspace details.",
-						timeout: 6000,
+						message: "No project selected.",
+						timeout: 5000,
 					});
 					return false;
 				}
-				setTaskWorkspaceInfo(workspaceInfo);
-
-				const prompt = buildTaskGitActionPrompt({
+				const payload = await getRuntimeTrpcClient(currentProjectId).runtime.runTaskGitAction.mutate({
+					taskId,
+					baseRef: selection.card.baseRef,
 					action,
-					workspaceInfo,
-					templates: runtimeProjectConfig
-						? {
-								commitPromptTemplate: runtimeProjectConfig.commitPromptTemplate,
-								openPrPromptTemplate: runtimeProjectConfig.openPrPromptTemplate,
-								commitPromptTemplateDefault: runtimeProjectConfig.commitPromptTemplateDefault,
-								openPrPromptTemplateDefault: runtimeProjectConfig.openPrPromptTemplateDefault,
-							}
-						: null,
 				});
-				if (shouldUseClineChatForTaskGitActions) {
-					const sent = await sendTaskChatMessage(taskId, prompt, { mode: "act" });
-					if (!sent.ok) {
-						showAppToast({
-							intent: "danger",
-							icon: "warning-sign",
-							message: sent.message ?? "Could not send instructions to the task chat session.",
-							timeout: 7000,
-						});
-						return false;
-					}
-					return true;
-				}
-				const typed = await sendTaskSessionInput(taskId, prompt, { appendNewline: false, mode: "paste" });
-				if (!typed.ok) {
+				if (!payload.ok) {
 					showAppToast({
 						intent: "danger",
 						icon: "warning-sign",
-						message: typed.message ?? "Could not send instructions to the task session.",
-						timeout: 7000,
-					});
-					return false;
-				}
-				await new Promise<void>((resolve) => {
-					window.setTimeout(resolve, 200);
-				});
-				const submitted = await sendTaskSessionInput(taskId, "\r", { appendNewline: false });
-				if (!submitted.ok) {
-					showAppToast({
-						intent: "danger",
-						icon: "warning-sign",
-						message: submitted.message ?? "Could not submit instructions to the task session.",
+						message: payload.error ?? "Could not send instructions to the task session.",
 						timeout: 7000,
 					});
 					return false;
@@ -327,16 +242,7 @@ export function useGitActions({
 				setTaskGitActionLoading(taskId, action, null);
 			}
 		},
-		[
-			board,
-			fetchTaskWorkspaceInfo,
-			runtimeProjectConfig,
-			sendTaskChatMessage,
-			sendTaskSessionInput,
-			setTaskGitActionLoading,
-			shouldUseClineChatForTaskGitActions,
-			taskGitActionLoadingByTaskId,
-		],
+		[board, currentProjectId, setTaskGitActionLoading, taskGitActionLoadingByTaskId],
 	);
 
 	const handleCommitTask = useCallback(

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -227,6 +227,7 @@ export function useGitActions({
 					taskId,
 					baseRef: selection.card.baseRef,
 					action,
+					source: "manual",
 				});
 				if (!payload.ok) {
 					showAppToast({


### PR DESCRIPTION
## Summary

This PR fixes #161 by moving review automation out of the browser UI and into the local Kanban runtime. Auto-review / auto-commit / Auto PR for tasks should no longer depend on the Kanban tab being visible, focused, or currently driving the relevant React state transitions. The runtime now owns the logic that decides when a task is review-ready and what follow-up automation should happen next.

## Problem

Issue #161 reports that auto-commit can fail to trigger while the Kanban tab is in the background and then fire only after returning to the tab. My investigation found that the review-ready → auto-review / auto-commit flow was effectively owned by browser-side hooks/state/timers instead of a runtime-side state machine. In that setup, hidden-tab timer throttling, tab suspension, websocket reconnect timing, or missed frontend transitions can delay or suppress automation.

## What changed

A new runtime-owned automation controller now tracks workspaces, terminal managers, and Cline task-session services. It merges persisted workspace state with live task summaries, can rebind persisted Cline review sessions when needed, evaluates review-column automation on the server, and keeps a lightweight background poller running only while there is automation work to do. In other words, **review automation is now driven by the runtime process instead of the browser tab.**

Commit/PR dispatch for tasks now goes through a shared runtime `runTaskGitAction` API with explicit request/response types and a `source` of `manual` or `auto`. The runtime builds the prompt from runtime config templates, resolves task workspace info, decides whether to route through the active terminal session or the Cline chat path, rebinds persisted Cline sessions when necessary, and uses bracketed paste when sending multiline prompts to a terminal session. A workspace-scoped git-action coordinator prevents overlapping manual/auto commit or PR actions for the same task and keeps post-dispatch cleanup state coordinated in one place.

The browser no longer owns auto-review timing. The UI-side auto-review hook is removed, and `useGitActions` no longer assembles git-action prompts or writes directly to terminal/chat sessions for task commit/PR actions. Manual task git actions now call the same runtime endpoint that auto-review uses. That is intentional: once automation lives in the runtime, manual and automatic git actions need one shared execution path so prompt generation, routing, multiline input behavior, and duplicate/race prevention stay consistent.

Server startup and recovery were updated to support this runtime-owned model. `startServer()` now creates the automation controller and git-action coordinator, wires them to terminal managers and Cline services, re-tracks remembered workspaces on startup, and ensures workspace-scoped Cline services can be recreated so persisted review sessions can be rebound after restart. This is why the PR also touches server bootstrap and workspace tracking code.

Post-review cleanup also moves under runtime ownership. After an auto git action is dispatched, the runtime re-checks the task worktree. If the worktree is clean, it can move the review card to trash, stop the task/detail sessions, delete the worktree, and auto-start any newly unblocked linked backlog tasks. If the worktree is still dirty, it clears cleanup state and waits for fresh session activity before retrying automation.

## Why this fixes #161

The bug in #161 comes from review automation being gated by browser-side behavior. This PR changes the owner of that automation loop. The runtime now subscribes to live session summaries and can also keep polling while automation work exists, so background tabs are no longer the thing that decides whether auto-review actions happen.

## Scope note

This PR touches manual git actions, startup recovery, and cleanup flows in addition to auto-review because **all of those paths now need to agree on one runtime-owned source of truth.** Without that, the fix would still leave duplicated browser/runtime behavior and race conditions between user-triggered and automation-triggered commit/PR actions.

## Testing

Test coverage and validation called out in the PR currently include `npm test -- src/server/runtime-task-automation.test.ts`, `npm --prefix web-ui run test -- src/hooks/use-board-interactions.test.tsx`, and a `biome check` over the touched runtime/web-ui files.