### PR TITLE
feat: configurable agent concurrency limit with backlog queueing

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -15,6 +15,7 @@ interface RuntimeGlobalConfigFileShape {
 	selectedShortcutLabel?: string;
 	agentAutonomousModeEnabled?: boolean;
 	readyForReviewNotificationsEnabled?: boolean;
+	maxConcurrentAgents?: number | null;
 	commitPromptTemplate?: string;
 	openPrPromptTemplate?: string;
 }
@@ -30,6 +31,7 @@ export interface RuntimeConfigState {
 	selectedShortcutLabel: string | null;
 	agentAutonomousModeEnabled: boolean;
 	readyForReviewNotificationsEnabled: boolean;
+	maxConcurrentAgents: number | null;
 	shortcuts: RuntimeProjectShortcut[];
 	commitPromptTemplate: string;
 	openPrPromptTemplate: string;
@@ -42,6 +44,7 @@ export interface RuntimeConfigUpdateInput {
 	selectedShortcutLabel?: string | null;
 	agentAutonomousModeEnabled?: boolean;
 	readyForReviewNotificationsEnabled?: boolean;
+	maxConcurrentAgents?: number | null;
 	shortcuts?: RuntimeProjectShortcut[];
 	commitPromptTemplate?: string;
 	openPrPromptTemplate?: string;
@@ -280,6 +283,7 @@ function toRuntimeConfigState({
 			globalConfig?.readyForReviewNotificationsEnabled,
 			DEFAULT_READY_FOR_REVIEW_NOTIFICATIONS_ENABLED,
 		),
+		maxConcurrentAgents: typeof globalConfig?.maxConcurrentAgents === "number" ? globalConfig.maxConcurrentAgents : null,
 		shortcuts: normalizeShortcuts(projectConfig?.shortcuts),
 		commitPromptTemplate: normalizePromptTemplate(globalConfig?.commitPromptTemplate, DEFAULT_COMMIT_PROMPT_TEMPLATE),
 		openPrPromptTemplate: normalizePromptTemplate(
@@ -307,6 +311,7 @@ async function writeRuntimeGlobalConfigFile(
 		selectedShortcutLabel?: string | null;
 		agentAutonomousModeEnabled?: boolean;
 		readyForReviewNotificationsEnabled?: boolean;
+		maxConcurrentAgents?: number | null;
 		commitPromptTemplate?: string;
 		openPrPromptTemplate?: string;
 	},
@@ -370,6 +375,11 @@ async function writeRuntimeGlobalConfigFile(
 	}
 	if (hasOwnKey(existing, "openPrPromptTemplate") || openPrPromptTemplate !== DEFAULT_OPEN_PR_PROMPT_TEMPLATE) {
 		payload.openPrPromptTemplate = openPrPromptTemplate;
+	}
+	if (config.maxConcurrentAgents !== undefined) {
+		payload.maxConcurrentAgents = config.maxConcurrentAgents;
+	} else if (hasOwnKey(existing, "maxConcurrentAgents")) {
+		payload.maxConcurrentAgents = existing?.maxConcurrentAgents;
 	}
 
 	await lockedFileSystem.writeJsonFileAtomic(configPath, payload, {
@@ -450,6 +460,7 @@ function createRuntimeConfigStateFromValues(input: {
 	selectedShortcutLabel: string | null;
 	agentAutonomousModeEnabled: boolean;
 	readyForReviewNotificationsEnabled: boolean;
+	maxConcurrentAgents?: number | null;
 	shortcuts: RuntimeProjectShortcut[];
 	commitPromptTemplate: string;
 	openPrPromptTemplate: string;
@@ -467,6 +478,7 @@ function createRuntimeConfigStateFromValues(input: {
 			input.readyForReviewNotificationsEnabled,
 			DEFAULT_READY_FOR_REVIEW_NOTIFICATIONS_ENABLED,
 		),
+		maxConcurrentAgents: typeof input.maxConcurrentAgents === "number" ? input.maxConcurrentAgents : null,
 		shortcuts: normalizeShortcuts(input.shortcuts),
 		commitPromptTemplate: normalizePromptTemplate(input.commitPromptTemplate, DEFAULT_COMMIT_PROMPT_TEMPLATE),
 		openPrPromptTemplate: normalizePromptTemplate(input.openPrPromptTemplate, DEFAULT_OPEN_PR_PROMPT_TEMPLATE),
@@ -555,6 +567,8 @@ export async function updateRuntimeConfig(cwd: string, updates: RuntimeConfigUpd
 		if (projectConfigPath === null && normalizeShortcuts(updates.shortcuts).length > 0) {
 			throw new Error("Cannot save project shortcuts without a selected project.");
 		}
+		const nextMaxConcurrentAgents =
+			updates.maxConcurrentAgents === undefined ? current.maxConcurrentAgents : updates.maxConcurrentAgents;
 		const nextConfig = {
 			selectedAgentId: updates.selectedAgentId ?? current.selectedAgentId,
 			selectedShortcutLabel:
@@ -562,6 +576,7 @@ export async function updateRuntimeConfig(cwd: string, updates: RuntimeConfigUpd
 			agentAutonomousModeEnabled: updates.agentAutonomousModeEnabled ?? current.agentAutonomousModeEnabled,
 			readyForReviewNotificationsEnabled:
 				updates.readyForReviewNotificationsEnabled ?? current.readyForReviewNotificationsEnabled,
+			maxConcurrentAgents: nextMaxConcurrentAgents,
 			shortcuts: projectConfigPath ? (updates.shortcuts ?? current.shortcuts) : current.shortcuts,
 			commitPromptTemplate: updates.commitPromptTemplate ?? current.commitPromptTemplate,
 			openPrPromptTemplate: updates.openPrPromptTemplate ?? current.openPrPromptTemplate,
@@ -572,6 +587,7 @@ export async function updateRuntimeConfig(cwd: string, updates: RuntimeConfigUpd
 			nextConfig.selectedShortcutLabel !== current.selectedShortcutLabel ||
 			nextConfig.agentAutonomousModeEnabled !== current.agentAutonomousModeEnabled ||
 			nextConfig.readyForReviewNotificationsEnabled !== current.readyForReviewNotificationsEnabled ||
+			nextConfig.maxConcurrentAgents !== current.maxConcurrentAgents ||
 			nextConfig.commitPromptTemplate !== current.commitPromptTemplate ||
 			nextConfig.openPrPromptTemplate !== current.openPrPromptTemplate ||
 			!areRuntimeProjectShortcutsEqual(nextConfig.shortcuts, current.shortcuts);
@@ -585,6 +601,7 @@ export async function updateRuntimeConfig(cwd: string, updates: RuntimeConfigUpd
 			selectedShortcutLabel: nextConfig.selectedShortcutLabel,
 			agentAutonomousModeEnabled: nextConfig.agentAutonomousModeEnabled,
 			readyForReviewNotificationsEnabled: nextConfig.readyForReviewNotificationsEnabled,
+			maxConcurrentAgents: nextConfig.maxConcurrentAgents,
 			commitPromptTemplate: nextConfig.commitPromptTemplate,
 			openPrPromptTemplate: nextConfig.openPrPromptTemplate,
 		});
@@ -598,6 +615,7 @@ export async function updateRuntimeConfig(cwd: string, updates: RuntimeConfigUpd
 			selectedShortcutLabel: nextConfig.selectedShortcutLabel,
 			agentAutonomousModeEnabled: nextConfig.agentAutonomousModeEnabled,
 			readyForReviewNotificationsEnabled: nextConfig.readyForReviewNotificationsEnabled,
+			maxConcurrentAgents: nextConfig.maxConcurrentAgents,
 			shortcuts: nextConfig.shortcuts,
 			commitPromptTemplate: nextConfig.commitPromptTemplate,
 			openPrPromptTemplate: nextConfig.openPrPromptTemplate,
@@ -618,6 +636,8 @@ export async function updateGlobalRuntimeConfig(
 			},
 		],
 		async () => {
+			const nextMaxConcurrentAgents =
+				updates.maxConcurrentAgents === undefined ? current.maxConcurrentAgents : updates.maxConcurrentAgents;
 			const nextConfig = {
 				selectedAgentId: updates.selectedAgentId ?? current.selectedAgentId,
 				selectedShortcutLabel:
@@ -627,6 +647,7 @@ export async function updateGlobalRuntimeConfig(
 				agentAutonomousModeEnabled: updates.agentAutonomousModeEnabled ?? current.agentAutonomousModeEnabled,
 				readyForReviewNotificationsEnabled:
 					updates.readyForReviewNotificationsEnabled ?? current.readyForReviewNotificationsEnabled,
+				maxConcurrentAgents: nextMaxConcurrentAgents,
 				shortcuts: current.shortcuts,
 				commitPromptTemplate: updates.commitPromptTemplate ?? current.commitPromptTemplate,
 				openPrPromptTemplate: updates.openPrPromptTemplate ?? current.openPrPromptTemplate,
@@ -637,6 +658,7 @@ export async function updateGlobalRuntimeConfig(
 				nextConfig.selectedShortcutLabel !== current.selectedShortcutLabel ||
 				nextConfig.agentAutonomousModeEnabled !== current.agentAutonomousModeEnabled ||
 				nextConfig.readyForReviewNotificationsEnabled !== current.readyForReviewNotificationsEnabled ||
+				nextConfig.maxConcurrentAgents !== current.maxConcurrentAgents ||
 				nextConfig.commitPromptTemplate !== current.commitPromptTemplate ||
 				nextConfig.openPrPromptTemplate !== current.openPrPromptTemplate;
 
@@ -649,6 +671,7 @@ export async function updateGlobalRuntimeConfig(
 				selectedShortcutLabel: nextConfig.selectedShortcutLabel,
 				agentAutonomousModeEnabled: nextConfig.agentAutonomousModeEnabled,
 				readyForReviewNotificationsEnabled: nextConfig.readyForReviewNotificationsEnabled,
+				maxConcurrentAgents: nextConfig.maxConcurrentAgents,
 				commitPromptTemplate: nextConfig.commitPromptTemplate,
 				openPrPromptTemplate: nextConfig.openPrPromptTemplate,
 			});
@@ -660,6 +683,7 @@ export async function updateGlobalRuntimeConfig(
 				selectedShortcutLabel: nextConfig.selectedShortcutLabel,
 				agentAutonomousModeEnabled: nextConfig.agentAutonomousModeEnabled,
 				readyForReviewNotificationsEnabled: nextConfig.readyForReviewNotificationsEnabled,
+				maxConcurrentAgents: nextConfig.maxConcurrentAgents,
 				shortcuts: nextConfig.shortcuts,
 				commitPromptTemplate: nextConfig.commitPromptTemplate,
 				openPrPromptTemplate: nextConfig.openPrPromptTemplate,

--- a/src/core/agent-concurrency-manager.ts
+++ b/src/core/agent-concurrency-manager.ts
@@ -1,0 +1,223 @@
+/**
+ * Global concurrency limiter for agent task sessions.
+ *
+ * Tracks the number of actively running agent sessions across all workspaces
+ * and enforces a configurable maximum. When a slot frees up (a task completes,
+ * is stopped, or fails) the manager automatically starts the next eligible
+ * backlog task in the same workspace.
+ *
+ * All slot operations are synchronous, which is safe because Node.js runs on
+ * a single thread — a synchronous check-and-set cannot be interrupted.
+ */
+
+import type { RuntimeTaskSessionState } from "./api-contract";
+
+/** Per-slot metadata so we know which workspace a task belongs to. */
+interface ActiveTaskEntry {
+	workspaceId: string;
+	workspacePath: string;
+}
+
+/** Parameters required to auto-start a queued backlog task. */
+export interface QueuedTaskStartParams {
+	taskId: string;
+	workspaceId: string;
+	workspacePath: string;
+	prompt: string;
+	baseRef: string;
+	startInPlanMode: boolean;
+	autoReviewEnabled?: boolean;
+	autoReviewMode?: string;
+	images?: Array<{ id: string; data: string; mimeType: string; name?: string }>;
+}
+
+/** Delegate that performs the full task-start pipeline (worktree + session + board move). */
+export type StartTaskFromQueueDelegate = (params: QueuedTaskStartParams) => Promise<boolean>;
+
+/** Delegate that reads the current backlog for a workspace in display order. */
+export type GetBacklogTasksDelegate = (
+	workspaceId: string,
+	workspacePath: string,
+) => Promise<QueuedTaskStartParams[]>;
+
+/** Snapshot of the concurrency manager's current state. */
+export interface AgentConcurrencyStatus {
+	active: number;
+	max: number | null;
+	availableSlots: number | null;
+	activeTaskIds: string[];
+}
+
+export interface AgentConcurrencyManagerDeps {
+	getBacklogTasks: GetBacklogTasksDelegate;
+	startTaskFromQueue: StartTaskFromQueueDelegate;
+}
+
+export interface AgentConcurrencyManager {
+	/**
+	 * Atomically check whether a slot is available and claim it.
+	 * Returns `true` if the slot was claimed, `false` if no slot is available
+	 * or the task is already tracked as active.
+	 *
+	 * Because Node.js is single-threaded, the synchronous check + set cannot
+	 * be interleaved with another caller.
+	 */
+	tryClaimSlot(taskId: string, workspaceId: string, workspacePath: string): boolean;
+
+	/**
+	 * Release a previously claimed slot without triggering queue processing.
+	 * Used when a task start fails after the slot was claimed.
+	 */
+	releaseSlot(taskId: string): void;
+
+	/**
+	 * Notify the manager that a task's session state has changed.
+	 * If the task transitioned from active to inactive, its slot is released
+	 * and queue processing is triggered for the originating workspace.
+	 */
+	notifyTaskStateChanged(
+		taskId: string,
+		workspaceId: string,
+		workspacePath: string,
+		previousState: RuntimeTaskSessionState,
+		newState: RuntimeTaskSessionState,
+	): void;
+
+	/** Update the maximum number of concurrent agents. `null` means unlimited. */
+	updateMaxConcurrency(max: number | null): void;
+
+	/** Return a snapshot of the current concurrency status. */
+	getStatus(): AgentConcurrencyStatus;
+
+	/** Whether the given task is currently occupying a slot. */
+	isTaskActive(taskId: string): boolean;
+}
+
+/** Returns `true` when a session state represents an actively running agent. */
+function isActiveSessionState(state: RuntimeTaskSessionState): boolean {
+	return state === "running" || state === "awaiting_review";
+}
+
+/** Returns `true` when a session state represents a finished or idle agent. */
+function isInactiveSessionState(state: RuntimeTaskSessionState): boolean {
+	return state === "idle" || state === "interrupted" || state === "failed";
+}
+
+export function createAgentConcurrencyManager(deps: AgentConcurrencyManagerDeps): AgentConcurrencyManager {
+	const activeTasks = new Map<string, ActiveTaskEntry>();
+	let maxConcurrent: number | null = null;
+	let processingQueue = false;
+
+	/** Whether at least one slot is available for a new task. */
+	function hasAvailableSlot(): boolean {
+		if (maxConcurrent === null) {
+			return true;
+		}
+		return activeTasks.size < maxConcurrent;
+	}
+
+	/**
+	 * Process the backlog queue for a given workspace.
+	 * Picks the next eligible backlog task (top-to-bottom order) and starts it
+	 * using the full start pipeline delegate. Repeats while slots are available.
+	 *
+	 * Guarded by `processingQueue` to prevent concurrent runs.
+	 */
+	async function processQueue(workspaceId: string, workspacePath: string): Promise<void> {
+		if (processingQueue) {
+			return;
+		}
+		if (maxConcurrent === null) {
+			// Unlimited mode — nothing to queue-process.
+			return;
+		}
+		processingQueue = true;
+
+		try {
+			while (hasAvailableSlot()) {
+				let backlogTasks: QueuedTaskStartParams[];
+				try {
+					backlogTasks = await deps.getBacklogTasks(workspaceId, workspacePath);
+				} catch {
+					// Cannot read workspace state; stop processing.
+					break;
+				}
+
+				// Find the first backlog task that is not already active.
+				const nextTask = backlogTasks.find((task) => !activeTasks.has(task.taskId));
+				if (!nextTask) {
+					break;
+				}
+
+				// Claim the slot before the async start.
+				activeTasks.set(nextTask.taskId, { workspaceId, workspacePath });
+
+				try {
+					const started = await deps.startTaskFromQueue(nextTask);
+					if (!started) {
+						// Start delegate returned false (e.g. task was deleted meanwhile).
+						activeTasks.delete(nextTask.taskId);
+					}
+				} catch {
+					// Start failed — release the slot and skip this task.
+					activeTasks.delete(nextTask.taskId);
+				}
+			}
+		} finally {
+			processingQueue = false;
+		}
+	}
+
+	return {
+		tryClaimSlot(taskId: string, workspaceId: string, workspacePath: string): boolean {
+			if (activeTasks.has(taskId)) {
+				return false;
+			}
+			if (!hasAvailableSlot()) {
+				return false;
+			}
+			activeTasks.set(taskId, { workspaceId, workspacePath });
+			return true;
+		},
+
+		releaseSlot(taskId: string): void {
+			activeTasks.delete(taskId);
+		},
+
+		notifyTaskStateChanged(
+			taskId: string,
+			workspaceId: string,
+			workspacePath: string,
+			previousState: RuntimeTaskSessionState,
+			newState: RuntimeTaskSessionState,
+		): void {
+			const wasActive = isActiveSessionState(previousState);
+			const nowInactive = isInactiveSessionState(newState);
+
+			if (wasActive && nowInactive) {
+				const wasTracked = activeTasks.delete(taskId);
+				if (wasTracked) {
+					// Fire-and-forget: auto-start next backlog task.
+					void processQueue(workspaceId, workspacePath);
+				}
+			}
+		},
+
+		updateMaxConcurrency(max: number | null): void {
+			maxConcurrent = max;
+		},
+
+		getStatus(): AgentConcurrencyStatus {
+			return {
+				active: activeTasks.size,
+				max: maxConcurrent,
+				availableSlots: maxConcurrent === null ? null : Math.max(0, maxConcurrent - activeTasks.size),
+				activeTaskIds: Array.from(activeTasks.keys()),
+			};
+		},
+
+		isTaskActive(taskId: string): boolean {
+			return activeTasks.has(taskId);
+		},
+	};
+}

--- a/test/runtime/agent-concurrency-manager.test.ts
+++ b/test/runtime/agent-concurrency-manager.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	type AgentConcurrencyManagerDeps,
+	type QueuedTaskStartParams,
+	createAgentConcurrencyManager,
+} from "../../src/core/agent-concurrency-manager";
+
+function createMockDeps(overrides?: Partial<AgentConcurrencyManagerDeps>): AgentConcurrencyManagerDeps {
+	return {
+		getBacklogTasks: overrides?.getBacklogTasks ?? vi.fn(async () => []),
+		startTaskFromQueue: overrides?.startTaskFromQueue ?? vi.fn(async () => true),
+	};
+}
+
+function createTaskParams(taskId: string, workspaceId = "ws-1", workspacePath = "/repo"): QueuedTaskStartParams {
+	return {
+		taskId,
+		workspaceId,
+		workspacePath,
+		prompt: `Task ${taskId}`,
+		baseRef: "main",
+		startInPlanMode: false,
+	};
+}
+
+describe("AgentConcurrencyManager", () => {
+	describe("tryClaimSlot", () => {
+		it("claims a slot when unlimited (default)", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			expect(manager.tryClaimSlot("task-1", "ws-1", "/repo")).toBe(true);
+			expect(manager.isTaskActive("task-1")).toBe(true);
+		});
+
+		it("claims slots up to the max", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(2);
+
+			expect(manager.tryClaimSlot("task-1", "ws-1", "/repo")).toBe(true);
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(true);
+			expect(manager.tryClaimSlot("task-3", "ws-1", "/repo")).toBe(false);
+		});
+
+		it("rejects duplicate task IDs", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			expect(manager.tryClaimSlot("task-1", "ws-1", "/repo")).toBe(true);
+			expect(manager.tryClaimSlot("task-1", "ws-1", "/repo")).toBe(false);
+		});
+
+		it("allows unlimited tasks when maxConcurrency is null", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(null);
+
+			for (let i = 0; i < 100; i++) {
+				expect(manager.tryClaimSlot(`task-${i}`, "ws-1", "/repo")).toBe(true);
+			}
+		});
+	});
+
+	describe("releaseSlot", () => {
+		it("frees a slot so another task can claim it", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+
+			expect(manager.tryClaimSlot("task-1", "ws-1", "/repo")).toBe(true);
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(false);
+
+			manager.releaseSlot("task-1");
+			expect(manager.isTaskActive("task-1")).toBe(false);
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(true);
+		});
+
+		it("is a no-op for unknown task IDs", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.releaseSlot("nonexistent");
+			expect(manager.getStatus().active).toBe(0);
+		});
+	});
+
+	describe("getStatus", () => {
+		it("returns correct status with no limit", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			const status = manager.getStatus();
+			expect(status.active).toBe(1);
+			expect(status.max).toBeNull();
+			expect(status.availableSlots).toBeNull();
+			expect(status.activeTaskIds).toEqual(["task-1"]);
+		});
+
+		it("returns correct status with limit", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(3);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+			manager.tryClaimSlot("task-2", "ws-1", "/repo");
+
+			const status = manager.getStatus();
+			expect(status.active).toBe(2);
+			expect(status.max).toBe(3);
+			expect(status.availableSlots).toBe(1);
+		});
+	});
+
+	describe("updateMaxConcurrency", () => {
+		it("allows increasing concurrency limit", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(false);
+
+			manager.updateMaxConcurrency(3);
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(true);
+		});
+
+		it("setting to null removes the limit", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(false);
+
+			manager.updateMaxConcurrency(null);
+			expect(manager.tryClaimSlot("task-2", "ws-1", "/repo")).toBe(true);
+		});
+	});
+
+	describe("notifyTaskStateChanged", () => {
+		it("releases slot when task transitions from running to idle", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+			expect(manager.isTaskActive("task-1")).toBe(false);
+			expect(manager.getStatus().active).toBe(0);
+		});
+
+		it("releases slot when task transitions from running to interrupted", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "interrupted");
+			expect(manager.isTaskActive("task-1")).toBe(false);
+		});
+
+		it("releases slot when task transitions from awaiting_review to idle", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "awaiting_review", "idle");
+			expect(manager.isTaskActive("task-1")).toBe(false);
+		});
+
+		it("does not release slot when task transitions from idle to running", () => {
+			const manager = createAgentConcurrencyManager(createMockDeps());
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			// This is not a deactivation transition
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "idle", "running");
+			expect(manager.isTaskActive("task-1")).toBe(true);
+		});
+
+		it("triggers queue processing when a slot frees up", async () => {
+			const startTaskFromQueue = vi.fn(async () => true);
+			const backlogTask = createTaskParams("task-2");
+			const getBacklogTasks = vi.fn(async () => [backlogTask]);
+
+			const manager = createAgentConcurrencyManager(
+				createMockDeps({ getBacklogTasks, startTaskFromQueue }),
+			);
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+
+			// Allow the fire-and-forget processQueue to run
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			expect(getBacklogTasks).toHaveBeenCalledWith("ws-1", "/repo");
+			expect(startTaskFromQueue).toHaveBeenCalledWith(backlogTask);
+		});
+
+		it("does not trigger queue processing in unlimited mode", async () => {
+			const getBacklogTasks = vi.fn(async () => []);
+
+			const manager = createAgentConcurrencyManager(
+				createMockDeps({ getBacklogTasks }),
+			);
+			// No concurrency limit set (unlimited mode)
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			expect(getBacklogTasks).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("queue processing", () => {
+		it("starts multiple backlog tasks when multiple slots open", async () => {
+			const started: string[] = [];
+			const startTaskFromQueue = vi.fn(async (params: QueuedTaskStartParams) => {
+				started.push(params.taskId);
+				return true;
+			});
+			const backlogTasks = [
+				createTaskParams("task-3"),
+				createTaskParams("task-4"),
+				createTaskParams("task-5"),
+			];
+			const getBacklogTasks = vi.fn(async () => backlogTasks);
+
+			const manager = createAgentConcurrencyManager(
+				createMockDeps({ getBacklogTasks, startTaskFromQueue }),
+			);
+			manager.updateMaxConcurrency(3);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+			manager.tryClaimSlot("task-2", "ws-1", "/repo");
+
+			// Free up both slots
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Should have started 2 tasks (was at 2/3, freed 1, so 1/3 available then 2 slots)
+			// Actually: after releasing task-1, we have 1 active (task-2), max 3, so 2 slots available
+			// It should start task-3 and task-4 (2 available slots)
+			expect(started).toContain("task-3");
+			expect(started).toContain("task-4");
+			expect(started).not.toContain("task-5");
+		});
+
+		it("skips tasks that fail to start and continues with the next", async () => {
+			let callCount = 0;
+			const startTaskFromQueue = vi.fn(async (params: QueuedTaskStartParams) => {
+				callCount++;
+				if (params.taskId === "task-2") {
+					throw new Error("start failed");
+				}
+				return true;
+			});
+			const getBacklogTasks = vi.fn(async () => [
+				createTaskParams("task-2"),
+				createTaskParams("task-3"),
+			]);
+
+			const manager = createAgentConcurrencyManager(
+				createMockDeps({ getBacklogTasks, startTaskFromQueue }),
+			);
+			manager.updateMaxConcurrency(2);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// task-2 failed, task-3 should have been attempted
+			expect(callCount).toBeGreaterThanOrEqual(2);
+			expect(manager.isTaskActive("task-2")).toBe(false);
+		});
+
+		it("handles empty backlog gracefully", async () => {
+			const getBacklogTasks = vi.fn(async () => []);
+			const startTaskFromQueue = vi.fn(async () => true);
+
+			const manager = createAgentConcurrencyManager(
+				createMockDeps({ getBacklogTasks, startTaskFromQueue }),
+			);
+			manager.updateMaxConcurrency(1);
+			manager.tryClaimSlot("task-1", "ws-1", "/repo");
+
+			manager.notifyTaskStateChanged("task-1", "ws-1", "/repo", "running", "idle");
+
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			expect(getBacklogTasks).toHaveBeenCalled();
+			expect(startTaskFromQueue).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the ability to configure the maximum number of concurrent agent sessions. When the limit is reached, new task starts are queued and automatically started when a slot frees up.

**Default behavior is unchanged** — `null` (unlimited) means all tasks start immediately as before.

## What this PR includes

### Core concurrency manager (`src/core/agent-concurrency-manager.ts`)
- `tryClaimSlot()` — atomic synchronous check-and-claim (race-safe in Node.js single-threaded model)
- `releaseSlot()` — release slot on failed start without triggering queue processing
- `notifyTaskStateChanged()` — release slot on task completion/interruption and auto-start next backlog task
- `updateMaxConcurrency()` — update limit at runtime (e.g. from settings UI)
- `getStatus()` — snapshot of active count, max, available slots
- Queue processing reads backlog in display order and starts tasks using a full-pipeline delegate

### Config persistence (`src/config/runtime-config.ts`)
- Added `maxConcurrentAgents: number | null` to `RuntimeConfigState` and `RuntimeConfigUpdateInput`
- Persisted in global config JSON (`~/.cline/kanban/config.json`)
- Full read/write/update support across all config code paths

### Unit tests (`test/runtime/agent-concurrency-manager.test.ts`)
- 14 test cases covering slot claiming, releasing, state transitions, queue processing, error handling, unlimited mode

## Remaining work (will be done in follow-up commits on this branch)

- [ ] Wire `AgentConcurrencyManager` into `runtime-server.ts` (create instance, connect session lifecycle events)
- [ ] Gate `startTaskSession` in `runtime-api.ts` with `tryClaimSlot` (return `{ queued: true }` when no slot available)
- [ ] Add `maxConcurrentAgents` to `api-contract.ts` Zod schemas
- [ ] Implement `getBacklogTasks` delegate (read workspace board state)
- [ ] Implement `startTaskFromQueue` delegate (full pipeline: worktree + session + board move + broadcast)
- [ ] Update CLI `task.ts` to handle queued response
- [ ] Update web-ui `use-task-sessions.ts` and `use-board-interactions.ts` for queued handling
- [ ] Add settings UI control for max concurrency in settings dialog
- [ ] Add queue status badges to board cards
- [ ] Add agent pool status indicator to top bar

## Design decisions

1. **Server-side enforcement** — the concurrency limit is enforced server-side, not client-only, because the server is the single source of truth for active sessions across all clients (browser tabs, CLI)
2. **Atomic slot claiming** — `tryClaimSlot` is synchronous, which is safe in Node.js single-threaded model (no interleaving between check and set)
3. **Queue = backlog column** — the backlog column serves as the natural queue; no separate queue data structure needed
4. **Home agent excluded** — the home agent session (chat-only) does not count against the limit
5. **Auto-start on completion** — when a task completes/stops, the manager automatically starts the next eligible backlog task in the same workspace