### PR TITLE
feat: add Alibaba Coding Plan as built-in provider

### DIFF
--- a/src/cline-sdk/builtin-providers.ts
+++ b/src/cline-sdk/builtin-providers.ts
@@ -1,0 +1,28 @@
+import { addSdkCustomProvider, type SdkCustomProviderCapability } from "./sdk-provider-boundary";
+
+const ALIBABA_PROVIDER = {
+	providerId: "alibaba",
+	name: "Alibaba Coding Plan",
+	baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+	models: [
+		"glm-5",
+		"glm-4.7",
+		"qwen3.5-plus",
+		"qwen3-max-2026-01-23",
+		"qwen3-coder-next",
+		"qwen3-coder-plus",
+		"kimi-k2.5",
+		"MiniMax-M2.5",
+	],
+	defaultModelId: "glm-5",
+	capabilities: ["streaming", "tools", "reasoning", "prompt-cache"] as SdkCustomProviderCapability[],
+};
+
+/**
+ * Register built-in custom providers at startup.
+ * This makes providers like Alibaba Coding Plan available in the dropdown
+ * without requiring manual configuration via the Add Provider dialog.
+ */
+export async function registerBuiltinCustomProviders(): Promise<void> {
+	await addSdkCustomProvider(ALIBABA_PROVIDER);
+}

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -7,6 +7,7 @@ import { rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { TRPCError } from "@trpc/server";
+import { registerBuiltinCustomProviders } from "../cline-sdk/builtin-providers";
 import { createClineMcpRuntimeService } from "../cline-sdk/cline-mcp-runtime-service";
 import { createClineMcpSettingsService } from "../cline-sdk/cline-mcp-settings-service";
 import { createClineProviderService } from "../cline-sdk/cline-provider-service";
@@ -82,6 +83,9 @@ async function resolveExistingTaskCwdOrEnsure(options: {
 }
 
 export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrpcContext["runtimeApi"] {
+	// Register built-in custom providers at startup
+	registerBuiltinCustomProviders().catch(() => {});
+
 	const clineProviderService = createClineProviderService();
 	const clineMcpSettingsService = createClineMcpSettingsService();
 	const clineMcpRuntimeService = createClineMcpRuntimeService({


### PR DESCRIPTION
## Summary
- Adds Alibaba Coding Plan as a built-in custom provider in Kanban
- Provider uses Chat Completions API endpoint (`/v1/chat/completions`) compatible with Alibaba's OpenAI-compatible API
- Includes models: GLM-5, GLM-4.7, Qwen3.5-plus, Qwen3-max, Qwen3-coder-next, Qwen3-coder-plus, Kimi K2.5, MiniMax M2.5

## Context
Alibaba Coding Plan provides access to several Chinese LLMs with 202,752 token context windows. This PR registers it as a built-in provider so users don't need to manually configure it via the Add Provider dialog.

## Technical Details
- Created `src/cline-sdk/builtin-providers.ts` to register custom providers at startup
- Modified `src/trpc/runtime-api.ts` to call registration function
- Provider base URL: `https://coding-intl.dashscope.aliyuncs.com/v1`
- Capabilities: streaming, tools, reasoning, prompt-cache

## Test plan
- [ ] Run `cline kanban`
- [ ] Navigate to Settings > API Provider
- [ ] Verify "Alibaba Coding Plan" appears in dropdown
- [ ] Configure with API key and start a task

🤖 Generated with [Claude Code](https://claude.com/claude-code)