### PR TITLE
feat(web-ui): optimize terminal and diff viewer for mobile viewports

### DIFF
--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -25,7 +25,7 @@ import { LocalStorageKey, readLocalStorageItem, writeLocalStorageItem } from "@/
 import { useTaskWorkspaceStateVersionValue } from "@/stores/workspace-metadata-store";
 import { TERMINAL_THEME_COLORS } from "@/terminal/theme-colors";
 import { type BoardCard, type CardSelection, getTaskAutoReviewCancelButtonLabel } from "@/types";
-import { useUnmount, useWindowEvent } from "@/utils/react-use";
+import { useIsMobileViewport, useUnmount, useWindowEvent } from "@/utils/react-use";
 
 // We still poll the open detail diff because line content can change without changing
 // the overall file or line counts that drive the shared workspace metadata stream.
@@ -317,6 +317,7 @@ export function CardDetailView({
 	const [diffComments, setDiffComments] = useState<Map<string, DiffLineComment>>(new Map());
 	const [diffMode, setDiffMode] = useState<RuntimeWorkspaceChangesMode>("working_copy");
 	const [isDiffExpanded, setIsDiffExpanded] = useState(false);
+	const isMobile = useIsMobileViewport();
 	const [agentPanelRatio, setAgentPanelRatio] = useState(loadAgentPanelRatio);
 	const [isResizing, setIsResizing] = useState(false);
 	const resizeDragRef = useRef<{ startX: number; startRatio: number; containerWidth: number } | null>(null);
@@ -746,12 +747,14 @@ export function CardDetailView({
 												comments={diffComments}
 												onCommentsChange={setDiffComments}
 											/>
-											<FileTreePanel
-												workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
-												selectedPath={selectedPath}
-												onSelectPath={setSelectedPath}
-												panelFlex={fileTreePanelFlex}
-											/>
+											{!isMobile ? (
+												<FileTreePanel
+													workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
+													selectedPath={selectedPath}
+													onSelectPath={setSelectedPath}
+													panelFlex={fileTreePanelFlex}
+												/>
+											) : null}
 										</>
 									)}
 								</div>

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.test.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.test.tsx
@@ -40,6 +40,16 @@ describe("DiffViewerPanel", () => {
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = createRoot(container);

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -1,4 +1,14 @@
-import { ChevronDown, ChevronRight, Command, CornerDownLeft, MessageSquare, X } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	Command,
+	CornerDownLeft,
+	FileText,
+	List,
+	MessageSquare,
+	X,
+} from "lucide-react";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -19,6 +29,7 @@ import type { RuntimeWorkspaceFileChange } from "@/runtime/types";
 import { buildFileTree } from "@/utils/file-tree";
 import { isBinaryFilePath } from "@/utils/is-binary-file-path";
 import { isMacPlatform } from "@/utils/platform";
+import { useIsMobileViewport } from "@/utils/react-use";
 
 interface FileDiffGroup {
 	path: string;
@@ -534,6 +545,110 @@ function SplitDiff({
 	);
 }
 
+function MobileFileDrawer({
+	groups,
+	selectedPath,
+	onSelectPath,
+	onClose,
+}: {
+	groups: FileDiffGroup[];
+	selectedPath: string | null;
+	onSelectPath: (path: string) => void;
+	onClose: () => void;
+}): React.ReactElement {
+	return (
+		<div className="kb-mobile-file-drawer-backdrop" onClick={onClose}>
+			<div className="kb-mobile-file-drawer" onClick={(event) => event.stopPropagation()}>
+				<div className="flex items-center justify-between border-b border-border px-3 py-2">
+					<span className="text-sm font-medium text-text-primary">Files</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						icon={<X size={14} />}
+						onClick={onClose}
+						aria-label="Close file list"
+					/>
+				</div>
+				<div className="kb-mobile-file-drawer-list">
+					{groups.map((group) => {
+						const isSelected = group.path === selectedPath;
+						return (
+							<button
+								key={group.path}
+								type="button"
+								className={`kb-mobile-file-drawer-item ${isSelected ? "kb-mobile-file-drawer-item-selected" : ""}`}
+								onClick={() => {
+									onSelectPath(group.path);
+									onClose();
+								}}
+							>
+								<FileText size={14} className="shrink-0 text-text-tertiary" />
+								<span className="truncate" title={group.path}>
+									{group.path.split("/").pop() ?? group.path}
+								</span>
+								<span className="ml-auto shrink-0 font-mono text-[10px]" style={{ display: "flex", gap: 4 }}>
+									{group.added > 0 ? (
+										<span className={isSelected ? "text-white" : "text-status-green"}>+{group.added}</span>
+									) : null}
+									{group.removed > 0 ? (
+										<span className={isSelected ? "text-white" : "text-status-red"}>-{group.removed}</span>
+									) : null}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function MobileFileNavBar({
+	groups,
+	currentIndex,
+	onNavigate,
+	onOpenDrawer,
+}: {
+	groups: FileDiffGroup[];
+	currentIndex: number;
+	onNavigate: (index: number) => void;
+	onOpenDrawer: () => void;
+}): React.ReactElement {
+	const current = groups[currentIndex];
+	const fileName = current ? (current.path.split("/").pop() ?? current.path) : "";
+	return (
+		<div className="kb-mobile-file-nav-bar">
+			<Button
+				variant="ghost"
+				size="sm"
+				icon={<ChevronLeft size={14} />}
+				disabled={currentIndex <= 0}
+				onClick={() => onNavigate(currentIndex - 1)}
+				aria-label="Previous file"
+			/>
+			<button
+				type="button"
+				className="flex min-w-0 flex-1 items-center justify-center gap-1.5 text-xs text-text-primary"
+				onClick={onOpenDrawer}
+			>
+				<List size={14} className="shrink-0 text-text-secondary" />
+				<span className="truncate">{fileName}</span>
+				<span className="shrink-0 text-text-tertiary">
+					{currentIndex + 1}/{groups.length}
+				</span>
+			</button>
+			<Button
+				variant="ghost"
+				size="sm"
+				icon={<ChevronRight size={14} />}
+				disabled={currentIndex >= groups.length - 1}
+				onClick={() => onNavigate(currentIndex + 1)}
+				aria-label="Next file"
+			/>
+		</div>
+	);
+}
+
 export function DiffViewerPanel({
 	workspaceFiles,
 	selectedPath,
@@ -553,6 +668,8 @@ export function DiffViewerPanel({
 	onCommentsChange: (comments: Map<string, DiffLineComment>) => void;
 	viewMode?: DiffViewMode;
 }): React.ReactElement {
+	const isMobile = useIsMobileViewport();
+	const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 	const [expandedPaths, setExpandedPaths] = useState<Record<string, boolean>>({});
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const sectionElementsRef = useRef<Record<string, HTMLElement | null>>({});
@@ -786,6 +903,30 @@ export function DiffViewerPanel({
 	const hasAnyComments = comments.size > 0;
 	const nonEmptyCount = nonEmptyComments.length;
 
+	// Mobile: file-at-a-time navigation
+	const mobileCurrentIndex = useMemo(() => {
+		if (!isMobile || groupedByPath.length === 0) {
+			return 0;
+		}
+		const index = groupedByPath.findIndex((group) => group.path === selectedPath);
+		return index >= 0 ? index : 0;
+	}, [groupedByPath, isMobile, selectedPath]);
+
+	const handleMobileNavigate = useCallback(
+		(index: number) => {
+			const group = groupedByPath[index];
+			if (group) {
+				onSelectedPathChange(group.path);
+			}
+		},
+		[groupedByPath, onSelectedPathChange],
+	);
+
+	const mobileCurrentGroup = isMobile ? (groupedByPath[mobileCurrentIndex] ?? null) : null;
+
+	// Force unified on mobile (split is unreadable on narrow screens)
+	const resolvedViewMode = isMobile ? "unified" : viewMode;
+
 	useHotkeys(
 		"meta+enter,ctrl+enter",
 		(event) => {
@@ -824,6 +965,162 @@ export function DiffViewerPanel({
 		[handleSendComments, nonEmptyCount, onSendToTerminal],
 	);
 
+	const renderDiffEntries = (group: FileDiffGroup): React.ReactElement => (
+		<div className="rounded-b-md border-x border-b border-border bg-surface-1" style={{ overflow: "hidden" }}>
+			{group.entries.map((entry) => (
+				<div key={entry.id} className="kb-diff-entry">
+					{entry.isBinary ? null : resolvedViewMode === "split" ? (
+						<SplitDiff
+							path={group.path}
+							oldText={entry.oldText}
+							newText={entry.newText}
+							comments={comments}
+							onAddComment={(lineNumber, lineText, variant) =>
+								handleAddComment(group.path, lineNumber, lineText, variant)
+							}
+							onUpdateComment={(lineNumber, variant, text) =>
+								handleUpdateComment(group.path, lineNumber, variant, text)
+							}
+							onDeleteComment={(lineNumber, variant) => handleDeleteComment(group.path, lineNumber, variant)}
+						/>
+					) : (
+						<UnifiedDiff
+							path={group.path}
+							oldText={entry.oldText}
+							newText={entry.newText}
+							comments={comments}
+							onAddComment={(lineNumber, lineText, variant) =>
+								handleAddComment(group.path, lineNumber, lineText, variant)
+							}
+							onUpdateComment={(lineNumber, variant, text) =>
+								handleUpdateComment(group.path, lineNumber, variant, text)
+							}
+							onDeleteComment={(lineNumber, variant) => handleDeleteComment(group.path, lineNumber, variant)}
+						/>
+					)}
+				</div>
+			))}
+		</div>
+	);
+
+	const renderCommentsFooter = (): React.ReactElement | null => {
+		if (!hasAnyComments || (!onAddToTerminal && !onSendToTerminal)) {
+			return null;
+		}
+		return (
+			<div className="kb-diff-comments-footer">
+				<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+					<span className="kb-diff-comments-count text-text-secondary">
+						{nonEmptyCount} {nonEmptyCount === 1 ? "comment" : "comments"}
+					</span>
+					<Button variant="danger" size="sm" onClick={handleClearAllComments}>
+						Clear All
+					</Button>
+				</div>
+				<div style={{ display: "flex", gap: 4 }}>
+					{onAddToTerminal ? (
+						<Button variant="default" size="sm" disabled={nonEmptyCount === 0} onClick={handleAddComments}>
+							<span style={{ display: "inline-flex", alignItems: "center" }}>
+								<span>Add</span>
+								<span
+									style={{ display: "inline-flex", alignItems: "center", gap: 2, marginLeft: 6 }}
+									aria-hidden
+								>
+									{isMacPlatform ? <Command size={12} /> : <span style={{ fontSize: 12 }}>Ctrl</span>}
+									<CornerDownLeft size={12} />
+								</span>
+							</span>
+						</Button>
+					) : null}
+					{onSendToTerminal ? (
+						<Button variant="primary" size="sm" disabled={nonEmptyCount === 0} onClick={handleSendComments}>
+							<span style={{ display: "inline-flex", alignItems: "center" }}>
+								<span>Send</span>
+								<span
+									style={{ display: "inline-flex", alignItems: "center", gap: 2, marginLeft: 6 }}
+									aria-hidden
+								>
+									{isMacPlatform ? <Command size={12} /> : <span style={{ fontSize: 12 }}>Ctrl</span>}
+									<span style={{ fontSize: 12 }}>Shift</span>
+									<CornerDownLeft size={12} />
+								</span>
+							</span>
+						</Button>
+					) : null}
+				</div>
+			</div>
+		);
+	};
+
+	// ---- Mobile layout: file-at-a-time with drawer ----
+	if (isMobile) {
+		return (
+			<div
+				style={{
+					display: "flex",
+					flex: "1 1 0",
+					flexDirection: "column",
+					minWidth: 0,
+					minHeight: 0,
+					background: "var(--color-surface-0)",
+				}}
+			>
+				{groupedByPath.length === 0 ? (
+					<div className="kb-empty-state-center" style={{ flex: 1 }}>
+						<div className="flex flex-col items-center justify-center gap-3 py-12 text-text-tertiary">
+							<FileText size={40} />
+						</div>
+					</div>
+				) : (
+					<>
+						<MobileFileNavBar
+							groups={groupedByPath}
+							currentIndex={mobileCurrentIndex}
+							onNavigate={handleMobileNavigate}
+							onOpenDrawer={() => setMobileDrawerOpen(true)}
+						/>
+						<div
+							className="kb-mobile-diff-scroll-container"
+							style={{
+								flex: "1 1 0",
+								minHeight: 0,
+								overflowY: "auto",
+								WebkitOverflowScrolling: "touch",
+								overscrollBehavior: "contain",
+								padding: "0 6px 6px",
+							}}
+						>
+							{mobileCurrentGroup ? (
+								<section style={{ marginTop: 6 }}>
+									<div className="flex items-center gap-2 rounded-t-md border border-border bg-surface-1 px-2 py-1.5 text-[11px] text-text-secondary">
+										<span className="truncate" title={mobileCurrentGroup.path}>
+											{mobileCurrentGroup.path}
+										</span>
+										<span className="ml-auto shrink-0">
+											<span className="text-status-green">+{mobileCurrentGroup.added}</span>{" "}
+											<span className="text-status-red">-{mobileCurrentGroup.removed}</span>
+										</span>
+									</div>
+									{renderDiffEntries(mobileCurrentGroup)}
+								</section>
+							) : null}
+						</div>
+						{renderCommentsFooter()}
+						{mobileDrawerOpen ? (
+							<MobileFileDrawer
+								groups={groupedByPath}
+								selectedPath={selectedPath}
+								onSelectPath={onSelectedPathChange}
+								onClose={() => setMobileDrawerOpen(false)}
+							/>
+						) : null}
+					</>
+				)}
+			</div>
+		);
+	}
+
+	// ---- Desktop layout: all files scrollable with sticky headers ----
 	return (
 		<div
 			style={{
@@ -914,117 +1211,12 @@ export function DiffViewerPanel({
 											) : null}
 										</span>
 									</button>
-									{isExpanded ? (
-										<div
-											className="rounded-b-md border-x border-b border-border bg-surface-1"
-											style={{ overflow: "hidden" }}
-										>
-											{group.entries.map((entry) => (
-												<div key={entry.id} className="kb-diff-entry">
-													{entry.isBinary ? null : viewMode === "split" ? (
-														<SplitDiff
-															path={group.path}
-															oldText={entry.oldText}
-															newText={entry.newText}
-															comments={comments}
-															onAddComment={(lineNumber, lineText, variant) =>
-																handleAddComment(group.path, lineNumber, lineText, variant)
-															}
-															onUpdateComment={(lineNumber, variant, text) =>
-																handleUpdateComment(group.path, lineNumber, variant, text)
-															}
-															onDeleteComment={(lineNumber, variant) =>
-																handleDeleteComment(group.path, lineNumber, variant)
-															}
-														/>
-													) : (
-														<UnifiedDiff
-															path={group.path}
-															oldText={entry.oldText}
-															newText={entry.newText}
-															comments={comments}
-															onAddComment={(lineNumber, lineText, variant) =>
-																handleAddComment(group.path, lineNumber, lineText, variant)
-															}
-															onUpdateComment={(lineNumber, variant, text) =>
-																handleUpdateComment(group.path, lineNumber, variant, text)
-															}
-															onDeleteComment={(lineNumber, variant) =>
-																handleDeleteComment(group.path, lineNumber, variant)
-															}
-														/>
-													)}
-												</div>
-											))}
-										</div>
-									) : null}
+									{isExpanded ? renderDiffEntries(group) : null}
 								</section>
 							);
 						})}
 					</div>
-					{hasAnyComments && (onAddToTerminal || onSendToTerminal) ? (
-						<div className="kb-diff-comments-footer">
-							<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-								<span className="kb-diff-comments-count text-text-secondary">
-									{nonEmptyCount} {nonEmptyCount === 1 ? "comment" : "comments"}
-								</span>
-								<Button variant="danger" size="sm" onClick={handleClearAllComments}>
-									Clear All
-								</Button>
-							</div>
-							<div style={{ display: "flex", gap: 4 }}>
-								{onAddToTerminal ? (
-									<Button
-										variant="default"
-										size="sm"
-										disabled={nonEmptyCount === 0}
-										onClick={handleAddComments}
-									>
-										<span style={{ display: "inline-flex", alignItems: "center" }}>
-											<span>Add</span>
-											<span
-												style={{
-													display: "inline-flex",
-													alignItems: "center",
-													gap: 2,
-													marginLeft: 6,
-												}}
-												aria-hidden
-											>
-												{isMacPlatform ? <Command size={12} /> : <span style={{ fontSize: 12 }}>Ctrl</span>}
-												<CornerDownLeft size={12} />
-											</span>
-										</span>
-									</Button>
-								) : null}
-								{onSendToTerminal ? (
-									<Button
-										variant="primary"
-										size="sm"
-										disabled={nonEmptyCount === 0}
-										onClick={handleSendComments}
-									>
-										<span style={{ display: "inline-flex", alignItems: "center" }}>
-											<span>Send</span>
-											<span
-												style={{
-													display: "inline-flex",
-													alignItems: "center",
-													gap: 2,
-													marginLeft: 6,
-												}}
-												aria-hidden
-											>
-												{isMacPlatform ? <Command size={12} /> : <span style={{ fontSize: 12 }}>Ctrl</span>}
-												<span style={{ fontSize: 12 }}>Shift</span>
-												<CornerDownLeft size={12} />
-											</span>
-										</span>
-									</Button>
-								) : null}
-							</div>
-						</div>
-					) : null}
+					{renderCommentsFooter()}
 				</>
 			)}
 		</div>

--- a/web-ui/src/runtime/task-session-geometry.ts
+++ b/web-ui/src/runtime/task-session-geometry.ts
@@ -1,3 +1,5 @@
+import { MOBILE_BREAKPOINT_PX } from "@/utils/platform";
+
 const DETAIL_TERMINAL_WIDTH_FRACTION = 1 / 3;
 const APPROX_TERMINAL_CELL_WIDTH_PX = 8;
 const APPROX_TERMINAL_CELL_HEIGHT_PX = 16;
@@ -11,9 +13,11 @@ export interface TaskSessionGeometry {
 }
 
 export function estimateTaskSessionGeometry(viewportWidth: number, viewportHeight: number): TaskSessionGeometry {
+	const isMobile = viewportWidth < MOBILE_BREAKPOINT_PX;
 	const safeViewportWidth = Math.max(0, viewportWidth);
 	const safeViewportHeight = Math.max(0, viewportHeight - APP_TOP_BAR_HEIGHT_PX);
-	const terminalWidthPx = safeViewportWidth * DETAIL_TERMINAL_WIDTH_FRACTION;
+	// On mobile, the terminal occupies the full viewport width.
+	const terminalWidthPx = isMobile ? safeViewportWidth : safeViewportWidth * DETAIL_TERMINAL_WIDTH_FRACTION;
 
 	return {
 		cols: Math.max(MIN_TERMINAL_COLS, Math.floor(terminalWidthPx / APPROX_TERMINAL_CELL_WIDTH_PX)),

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -647,6 +647,107 @@ body.kb-dependency-link-mode {
 	opacity: 1;
 }
 
+/* -- Mobile diff viewer -- */
+
+.kb-mobile-file-nav-bar {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 6px;
+	border-bottom: 1px solid var(--color-border);
+	background: var(--color-surface-1);
+}
+
+.kb-mobile-diff-scroll-container {
+	-webkit-overflow-scrolling: touch;
+	touch-action: pan-y;
+}
+
+.kb-mobile-file-drawer-backdrop {
+	position: fixed;
+	inset: 0;
+	z-index: 50;
+	background: rgba(0, 0, 0, 0.5);
+}
+
+.kb-mobile-file-drawer {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	max-height: 60vh;
+	display: flex;
+	flex-direction: column;
+	background: var(--color-surface-1);
+	border-top-left-radius: var(--radius-xl);
+	border-top-right-radius: var(--radius-xl);
+	overflow: hidden;
+}
+
+.kb-mobile-file-drawer-list {
+	flex: 1 1 0;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
+	overscroll-behavior: contain;
+	padding: 4px 0;
+}
+
+.kb-mobile-file-drawer-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 10px 12px;
+	font-size: 13px;
+	color: var(--color-text-primary);
+	background: transparent;
+	border: none;
+	text-align: left;
+	cursor: pointer;
+}
+
+.kb-mobile-file-drawer-item:active {
+	background: var(--color-surface-3);
+}
+
+.kb-mobile-file-drawer-item-selected {
+	background: var(--color-accent);
+	color: #fff;
+}
+
+.kb-mobile-file-drawer-item-selected:active {
+	background: var(--color-accent-hover);
+}
+
+/* -- Mobile touch improvements -- */
+
+@media (max-width: 767px) {
+	.kb-diff-row {
+		gap: 4px;
+		padding: 2px 2px 2px 0;
+		font-size: 11px;
+	}
+
+	.kb-diff-line-number {
+		width: 1.5rem;
+	}
+
+	.kb-diff-entry {
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.kb-diff-comments-footer {
+		flex-wrap: wrap;
+		gap: 6px;
+		padding: 6px 8px;
+	}
+
+	.kb-terminal-container {
+		touch-action: pan-y pinch-zoom;
+	}
+}
+
 /* -- Git history rows -- */
 
 .kb-git-ref-row {

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -18,7 +18,7 @@ import {
 	hasInterruptAcknowledgement,
 	hasLikelyShellPrompt,
 } from "@/terminal/terminal-prompt-heuristics";
-import { isMacPlatform } from "@/utils/platform";
+import { isMacPlatform, MOBILE_BREAKPOINT_PX } from "@/utils/platform";
 
 const SHIFT_ENTER_SEQUENCE = "\n";
 const RESIZE_DEBOUNCE_MS = 50;
@@ -176,11 +176,13 @@ class PersistentTerminal {
 		this.parkingRoot.appendChild(this.hostElement);
 		const initialGeometry = estimateTaskSessionGeometry(window.innerWidth, window.innerHeight);
 
+		const isMobileViewport = window.innerWidth < MOBILE_BREAKPOINT_PX;
 		this.terminal = new Terminal({
 			...createKanbanTerminalOptions({
 				cursorColor: this.appearance.cursorColor,
 				isMacPlatform,
 				terminalBackgroundColor: this.appearance.terminalBackgroundColor,
+				isMobileViewport,
 			}),
 			cols: initialGeometry.cols,
 			rows: initialGeometry.rows,
@@ -570,6 +572,13 @@ class PersistentTerminal {
 		this.visibleContainer = null;
 		clearTerminalGeometry(this.taskId);
 		this.parkingRoot.appendChild(this.hostElement);
+	}
+
+	setFontSize(size: number): void {
+		this.terminal.options.fontSize = size;
+		if (this.visibleContainer) {
+			this.requestResize();
+		}
 	}
 
 	focus(): void {

--- a/web-ui/src/terminal/terminal-options.ts
+++ b/web-ui/src/terminal/terminal-options.ts
@@ -6,6 +6,7 @@ interface CreateKanbanTerminalOptionsInput {
 	cursorColor: string;
 	isMacPlatform: boolean;
 	terminalBackgroundColor: string;
+	isMobileViewport?: boolean;
 }
 
 const TERMINAL_WORD_SEPARATOR = " ()[]{}',\"`";
@@ -16,6 +17,7 @@ export function createKanbanTerminalOptions({
 	cursorColor,
 	isMacPlatform,
 	terminalBackgroundColor,
+	isMobileViewport = false,
 }: CreateKanbanTerminalOptionsInput): ITerminalOptions {
 	return {
 		allowProposedApi: true,
@@ -25,7 +27,7 @@ export function createKanbanTerminalOptions({
 		cursorStyle: "block",
 		disableStdin: false,
 		fontFamily: TERMINAL_FONT_FAMILY,
-		fontSize: 13,
+		fontSize: isMobileViewport ? 11 : 13,
 		fontWeight: "normal",
 		fontWeightBold: "bold",
 		letterSpacing: 0,

--- a/web-ui/src/terminal/use-persistent-terminal-session.ts
+++ b/web-ui/src/terminal/use-persistent-terminal-session.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { RuntimeTaskSessionSummary } from "@/runtime/types";
 import { disposePersistentTerminal, ensurePersistentTerminal } from "@/terminal/persistent-terminal-manager";
 import { registerTerminalController } from "@/terminal/terminal-controller-registry";
+import { useTerminalPinchZoom } from "@/terminal/use-terminal-pinch-zoom";
+import { isTouchDevice } from "@/utils/platform";
 
 interface UsePersistentTerminalSessionInput {
 	taskId: string;
@@ -148,6 +150,16 @@ export function usePersistentTerminalSession({
 			waitForLikelyPrompt: async (timeoutMs) => await (terminalRef.current?.waitForLikelyPrompt(timeoutMs) ?? false),
 		});
 	}, [taskId]);
+
+	const handlePinchZoomFontSize = useCallback((fontSize: number) => {
+		terminalRef.current?.setFontSize(fontSize);
+	}, []);
+
+	useTerminalPinchZoom({
+		containerRef,
+		enabled: isTouchDevice && enabled,
+		onFontSizeChange: handlePinchZoomFontSize,
+	});
 
 	const stopTerminal = useCallback(async () => {
 		const terminal = terminalRef.current;

--- a/web-ui/src/terminal/use-terminal-pinch-zoom.ts
+++ b/web-ui/src/terminal/use-terminal-pinch-zoom.ts
@@ -1,0 +1,75 @@
+import type { RefObject } from "react";
+import { useCallback, useEffect, useRef } from "react";
+
+const MIN_FONT_SIZE = 8;
+const MAX_FONT_SIZE = 28;
+const DEFAULT_FONT_SIZE = 13;
+const PINCH_SENSITIVITY = 0.04;
+
+interface UseTerminalPinchZoomOptions {
+	containerRef: RefObject<HTMLDivElement | null>;
+	enabled: boolean;
+	onFontSizeChange: (fontSize: number) => void;
+}
+
+function getDistance(touch1: Touch, touch2: Touch): number {
+	const dx = touch1.clientX - touch2.clientX;
+	const dy = touch1.clientY - touch2.clientY;
+	return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function useTerminalPinchZoom({ containerRef, enabled, onFontSizeChange }: UseTerminalPinchZoomOptions): void {
+	const startDistanceRef = useRef<number | null>(null);
+	const baseFontSizeRef = useRef(DEFAULT_FONT_SIZE);
+	const currentFontSizeRef = useRef(DEFAULT_FONT_SIZE);
+
+	const handleTouchStart = useCallback(
+		(event: TouchEvent) => {
+			if (!enabled || event.touches.length !== 2) {
+				return;
+			}
+			startDistanceRef.current = getDistance(event.touches[0]!, event.touches[1]!);
+			baseFontSizeRef.current = currentFontSizeRef.current;
+		},
+		[enabled],
+	);
+
+	const handleTouchMove = useCallback(
+		(event: TouchEvent) => {
+			if (!enabled || event.touches.length !== 2 || startDistanceRef.current === null) {
+				return;
+			}
+			event.preventDefault();
+			const currentDistance = getDistance(event.touches[0]!, event.touches[1]!);
+			const delta = (currentDistance - startDistanceRef.current) * PINCH_SENSITIVITY;
+			const newSize = Math.round(Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, baseFontSizeRef.current + delta)));
+			if (newSize !== currentFontSizeRef.current) {
+				currentFontSizeRef.current = newSize;
+				onFontSizeChange(newSize);
+			}
+		},
+		[enabled, onFontSizeChange],
+	);
+
+	const handleTouchEnd = useCallback(() => {
+		startDistanceRef.current = null;
+	}, []);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container || !enabled) {
+			return;
+		}
+		container.addEventListener("touchstart", handleTouchStart, { passive: true });
+		container.addEventListener("touchmove", handleTouchMove, { passive: false });
+		container.addEventListener("touchend", handleTouchEnd, { passive: true });
+		container.addEventListener("touchcancel", handleTouchEnd, { passive: true });
+
+		return () => {
+			container.removeEventListener("touchstart", handleTouchStart);
+			container.removeEventListener("touchmove", handleTouchMove);
+			container.removeEventListener("touchend", handleTouchEnd);
+			container.removeEventListener("touchcancel", handleTouchEnd);
+		};
+	}, [containerRef, enabled, handleTouchEnd, handleTouchMove, handleTouchStart]);
+}

--- a/web-ui/src/utils/platform.ts
+++ b/web-ui/src/utils/platform.ts
@@ -1,6 +1,11 @@
 export const isMacPlatform =
 	typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent);
 
+export const isTouchDevice =
+	typeof navigator !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+
+export const MOBILE_BREAKPOINT_PX = 768;
+
 export const modifierKeyLabel = isMacPlatform ? "Cmd" : "Ctrl";
 export const optionKeyLabel = isMacPlatform ? "⌥" : "Alt";
 export const pasteShortcutLabel = `${modifierKeyLabel}+V`;

--- a/web-ui/src/utils/react-use.ts
+++ b/web-ui/src/utils/react-use.ts
@@ -6,9 +6,12 @@ import {
 	useInterval as useReactUseInterval,
 	useLocalStorage as useReactUseLocalStorage,
 	useMeasure as useReactUseMeasure,
+	useMedia as useReactUseMedia,
 	useTitle as useReactUseTitle,
 	useUnmount as useReactUseUnmount,
 } from "react-use";
+
+import { MOBILE_BREAKPOINT_PX } from "@/utils/platform";
 
 type DomEventOptions = boolean | AddEventListenerOptions;
 type StateSetter<T> = Dispatch<SetStateAction<T>>;
@@ -108,4 +111,8 @@ export function useMeasure<T extends Element = Element>() {
 
 export function useUnmount(fn: () => void): void {
 	useReactUseUnmount(fn);
+}
+
+export function useIsMobileViewport(): boolean {
+	return useReactUseMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`, false);
 }


### PR DESCRIPTION
## Summary

- **Terminal mobile optimization**: Auto-sizes xterm.js to full viewport width on mobile (vs 1/3 on desktop), uses smaller 11px font, and supports pinch-to-zoom gestures on touch devices
- **Diff viewer mobile layout**: Replaces scroll-all-files + sidebar FileTreePanel with file-at-a-time navigation (prev/next buttons) and a bottom-sheet file drawer; forces unified diff mode on narrow screens
- **Touch-friendly CSS**: Adds `-webkit-overflow-scrolling: touch`, `touch-action` rules, responsive font sizing, and `overscroll-behavior: contain` for smooth mobile scrolling

## Changes

| File | Description |
|------|-------------|
| `platform.ts` | Add `isTouchDevice`, `MOBILE_BREAKPOINT_PX` constants |
| `react-use.ts` | Add `useIsMobileViewport()` hook via `react-use/useMedia` |
| `use-terminal-pinch-zoom.ts` | New hook for two-finger pinch-to-zoom on terminal |
| `persistent-terminal-manager.ts` | Add `setFontSize()` method, mobile viewport detection |
| `terminal-options.ts` | Accept `isMobileViewport` flag for font size |
| `task-session-geometry.ts` | Full-width geometry on mobile viewports |
| `use-persistent-terminal-session.ts` | Wire up pinch-to-zoom hook |
| `diff-viewer-panel.tsx` | Mobile file-at-a-time nav, file drawer, forced unified mode |
| `card-detail-view.tsx` | Hide FileTreePanel on mobile |
| `globals.css` | Mobile drawer styles, responsive diff rules, touch improvements |
| `diff-viewer-panel.test.tsx` | Add `window.matchMedia` mock for JSDOM |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 9 diff-viewer-panel and task-session-geometry tests pass
- [ ] Manual test on mobile viewport: verify file-at-a-time navigation, drawer open/close
- [ ] Manual test pinch-to-zoom on touch device
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)