### PR TITLE
chore: use the BE lines instead of recalculating them

### DIFF
--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -6,7 +6,6 @@ import {
 	buildDisplayItems,
 	buildHighlightedLineMap,
 	buildUnifiedDiffRows,
-	countAddedRemoved,
 	DiffRowText,
 	getHighlightedLineHtml,
 	resolvePrismGrammar,
@@ -568,6 +567,8 @@ export function DiffViewerPanel({
 			isBinary: isBinaryFilePath(file.path),
 			oldText: file.oldText,
 			newText: file.newText ?? "",
+			additions: file.additions,
+			deletions: file.deletions,
 			timestamp: 0,
 			toolTitle: `${file.status} (${file.additions}+/${file.deletions}-)`,
 		}));
@@ -596,9 +597,8 @@ export function DiffViewerPanel({
 				newText: entry.newText,
 			});
 			if (!entry.isBinary) {
-				const counts = countAddedRemoved(entry.oldText, entry.newText);
-				group.added += counts.added;
-				group.removed += counts.removed;
+				group.added += entry.additions;
+				group.removed += entry.deletions;
 			}
 		}
 		return Array.from(map.values()).sort((a, b) => {

--- a/web-ui/src/components/shared/diff-renderer.tsx
+++ b/web-ui/src/components/shared/diff-renderer.tsx
@@ -438,33 +438,6 @@ export function buildDisplayItems(rows: UnifiedDiffRow[], expandedBlocks: Record
 	return items;
 }
 
-export function countAddedRemoved(
-	oldText: string | null | undefined,
-	newText: string,
-): { added: number; removed: number } {
-	let added = 0;
-	let removed = 0;
-	const changes = diffLines(oldText ?? "", newText, {
-		ignoreWhitespace: false,
-		stripTrailingCr: true,
-		ignoreNewlineAtEof: true,
-	});
-	for (const change of changes) {
-		if (!change) {
-			continue;
-		}
-		const lineCount = toLines(change.value).length;
-		if (change.added) {
-			added += lineCount;
-			continue;
-		}
-		if (change.removed) {
-			removed += lineCount;
-		}
-	}
-	return { added, removed };
-}
-
 export function truncatePathMiddle(path: string, maxLength = 64): string {
 	if (path.length <= maxLength) {
 		return path;


### PR DESCRIPTION
The data returned by the server already includes the line calculations. This PR removes the recalculation.

Post change:
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/b4d94684-271f-4d5f-a6ff-d6b4a8a7c406" />
