### PR TITLE
chore: move full test suite from pre-commit to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,10 +9,17 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-echo "Running type checking and tests..."
-npm run typecheck && npm run test
+echo "Running type checking..."
+npm run typecheck
 if [ $? -ne 0 ]; then
-	echo "Checks failed."
+	echo "Root type checking failed."
+	exit 1
+fi
+
+echo "Running web-ui type checking..."
+npm run web:typecheck
+if [ $? -ne 0 ]; then
+	echo "Web UI type checking failed."
 	exit 1
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+echo "Running root tests..."
+npm run test
+if [ $? -ne 0 ]; then
+	echo "Root tests failed. Push aborted."
+	exit 1
+fi
+
+echo "Running web-ui tests..."
+npm run web:test
+if [ $? -ne 0 ]; then
+	echo "Web UI tests failed. Push aborted."
+	exit 1
+fi
+
+echo "Pre-push checks passed."


### PR DESCRIPTION
## Summary

Removes the need for `--no-verify` on everyday commits by splitting the hook workload.

### pre-commit (fast, local-safe)
- ✅ Biome staged check (unchanged)
- ✅ Root TypeScript typecheck (`npm run typecheck`)
- ✅ Web UI TypeScript typecheck (`npm run web:typecheck`)
- ✅ Re-stage auto-fixed files (unchanged)
- ❌ ~~`npm run test`~~ (moved to pre-push)

### pre-push (full test suites, matches CI)
- ✅ Root tests — `npm run test` (Vitest, includes localhost-binding integration tests)
- ✅ Web UI tests — `npm run web:test` (Vitest/jsdom)

Both hooks now cover their respective root and web-ui counterparts, mirroring the steps in `.github/workflows/test.yml`.

## Why

The full Vitest suite (including integration tests that bind to localhost) was running on every commit via `pre-commit`, making `--no-verify` a common workaround. Moving both test suites to `pre-push` keeps commits snappy while still ensuring all tests pass before code reaches the remote.

## Coverage parity

| Step | CI | pre-commit | pre-push |
|------|:--:|:----------:|:--------:|
| Biome lint | ✅ | ✅ (staged) | — |
| Root typecheck | ✅ | ✅ | — |
| Web UI typecheck | ✔️\* | ✅ | — |
| Root tests | ✅ | — | ✅ |
| Web UI tests | ✅ | — | ✅ |
| Build | ✅ | — | — |

\*CI runs web-ui typecheck implicitly via the build step.

## Files changed

| File | Change |
|------|--------|
| `.husky/pre-commit` | Removed `npm run test`, added `npm run web:typecheck` |
| `.husky/pre-push` | **New** — runs `npm run test` then `npm run web:test` |