### PR TITLE
feat: Monaco コードブラウザ追加

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -58,6 +58,70 @@ export const runtimeWorkspaceFileSearchResponseSchema = z.object({
 });
 export type RuntimeWorkspaceFileSearchResponse = z.infer<typeof runtimeWorkspaceFileSearchResponseSchema>;
 
+export const runtimeWorkspaceDirectoryEntrySchema = z.object({
+	name: z.string(),
+	path: z.string(),
+	type: z.enum(["file", "directory"]),
+});
+export type RuntimeWorkspaceDirectoryEntry = z.infer<typeof runtimeWorkspaceDirectoryEntrySchema>;
+
+export const runtimeWorkspaceDirectoryListRequestSchema = z.object({
+	path: z.string(),
+});
+export type RuntimeWorkspaceDirectoryListRequest = z.infer<typeof runtimeWorkspaceDirectoryListRequestSchema>;
+
+export const runtimeWorkspaceDirectoryListResponseSchema = z.object({
+	entries: z.array(runtimeWorkspaceDirectoryEntrySchema),
+});
+export type RuntimeWorkspaceDirectoryListResponse = z.infer<typeof runtimeWorkspaceDirectoryListResponseSchema>;
+
+export const runtimeWorkspaceFileReadRequestSchema = z.object({
+	path: z.string(),
+});
+export type RuntimeWorkspaceFileReadRequest = z.infer<typeof runtimeWorkspaceFileReadRequestSchema>;
+
+export const runtimeWorkspaceFileReadResponseSchema = z.object({
+	path: z.string(),
+	content: z.string().nullable(),
+	size: z.number().int().nonnegative(),
+	isBinary: z.boolean(),
+	error: z.string().optional(),
+});
+export type RuntimeWorkspaceFileReadResponse = z.infer<typeof runtimeWorkspaceFileReadResponseSchema>;
+
+export const runtimeWorkspaceFileWriteRequestSchema = z.object({
+	path: z.string(),
+	content: z.string(),
+});
+export type RuntimeWorkspaceFileWriteRequest = z.infer<typeof runtimeWorkspaceFileWriteRequestSchema>;
+
+export const runtimeWorkspaceFileWriteResponseSchema = z.object({
+	ok: z.boolean(),
+	error: z.string().optional(),
+});
+export type RuntimeWorkspaceFileWriteResponse = z.infer<typeof runtimeWorkspaceFileWriteResponseSchema>;
+
+export const runtimeWorkspaceGitLineChangeTypeSchema = z.enum(["added", "modified", "deleted"]);
+export type RuntimeWorkspaceGitLineChangeType = z.infer<typeof runtimeWorkspaceGitLineChangeTypeSchema>;
+
+export const runtimeWorkspaceGitLineChangeSchema = z.object({
+	type: runtimeWorkspaceGitLineChangeTypeSchema,
+	startLine: z.number().int().positive(),
+	lineCount: z.number().int().nonnegative(),
+});
+export type RuntimeWorkspaceGitLineChange = z.infer<typeof runtimeWorkspaceGitLineChangeSchema>;
+
+export const runtimeWorkspaceFileGitLineStatusRequestSchema = z.object({
+	path: z.string(),
+});
+export type RuntimeWorkspaceFileGitLineStatusRequest = z.infer<typeof runtimeWorkspaceFileGitLineStatusRequestSchema>;
+
+export const runtimeWorkspaceFileGitLineStatusResponseSchema = z.object({
+	path: z.string(),
+	changes: z.array(runtimeWorkspaceGitLineChangeSchema),
+});
+export type RuntimeWorkspaceFileGitLineStatusResponse = z.infer<typeof runtimeWorkspaceFileGitLineStatusResponseSchema>;
+
 export const runtimeSlashCommandSchema = z.object({
 	name: z.string(),
 	instructions: z.string(),

--- a/src/trpc/app-router.ts
+++ b/src/trpc/app-router.ts
@@ -75,8 +75,16 @@ import type {
 	RuntimeTaskWorkspaceInfoResponse,
 	RuntimeWorkspaceChangesRequest,
 	RuntimeWorkspaceChangesResponse,
+	RuntimeWorkspaceDirectoryListRequest,
+	RuntimeWorkspaceDirectoryListResponse,
+	RuntimeWorkspaceFileGitLineStatusRequest,
+	RuntimeWorkspaceFileGitLineStatusResponse,
+	RuntimeWorkspaceFileReadRequest,
+	RuntimeWorkspaceFileReadResponse,
 	RuntimeWorkspaceFileSearchRequest,
 	RuntimeWorkspaceFileSearchResponse,
+	RuntimeWorkspaceFileWriteRequest,
+	RuntimeWorkspaceFileWriteResponse,
 	RuntimeWorkspaceStateNotifyResponse,
 	RuntimeWorkspaceStateResponse,
 	RuntimeWorkspaceStateSaveRequest,
@@ -155,8 +163,16 @@ import {
 	runtimeTaskWorkspaceInfoResponseSchema,
 	runtimeWorkspaceChangesRequestSchema,
 	runtimeWorkspaceChangesResponseSchema,
+	runtimeWorkspaceDirectoryListRequestSchema,
+	runtimeWorkspaceDirectoryListResponseSchema,
+	runtimeWorkspaceFileGitLineStatusRequestSchema,
+	runtimeWorkspaceFileGitLineStatusResponseSchema,
+	runtimeWorkspaceFileReadRequestSchema,
+	runtimeWorkspaceFileReadResponseSchema,
 	runtimeWorkspaceFileSearchRequestSchema,
 	runtimeWorkspaceFileSearchResponseSchema,
+	runtimeWorkspaceFileWriteRequestSchema,
+	runtimeWorkspaceFileWriteResponseSchema,
 	runtimeWorkspaceStateNotifyResponseSchema,
 	runtimeWorkspaceStateResponseSchema,
 	runtimeWorkspaceStateSaveRequestSchema,
@@ -297,6 +313,22 @@ export interface RuntimeTrpcContext {
 			scope: RuntimeTrpcWorkspaceScope,
 			input: RuntimeWorkspaceFileSearchRequest,
 		) => Promise<RuntimeWorkspaceFileSearchResponse>;
+		listDirectory: (
+			scope: RuntimeTrpcWorkspaceScope,
+			input: RuntimeWorkspaceDirectoryListRequest,
+		) => Promise<RuntimeWorkspaceDirectoryListResponse>;
+		readFile: (
+			scope: RuntimeTrpcWorkspaceScope,
+			input: RuntimeWorkspaceFileReadRequest,
+		) => Promise<RuntimeWorkspaceFileReadResponse>;
+		writeFile: (
+			scope: RuntimeTrpcWorkspaceScope,
+			input: RuntimeWorkspaceFileWriteRequest,
+		) => Promise<RuntimeWorkspaceFileWriteResponse>;
+		getFileGitLineStatus: (
+			scope: RuntimeTrpcWorkspaceScope,
+			input: RuntimeWorkspaceFileGitLineStatusRequest,
+		) => Promise<RuntimeWorkspaceFileGitLineStatusResponse>;
 		loadState: (scope: RuntimeTrpcWorkspaceScope) => Promise<RuntimeWorkspaceStateResponse>;
 		notifyStateUpdated: (scope: RuntimeTrpcWorkspaceScope) => Promise<RuntimeWorkspaceStateNotifyResponse>;
 		saveState: (
@@ -583,6 +615,30 @@ export const runtimeAppRouter = t.router({
 			.output(runtimeWorkspaceFileSearchResponseSchema)
 			.query(async ({ ctx, input }) => {
 				return await ctx.workspaceApi.searchFiles(ctx.workspaceScope, input);
+			}),
+		listDirectory: workspaceProcedure
+			.input(runtimeWorkspaceDirectoryListRequestSchema)
+			.output(runtimeWorkspaceDirectoryListResponseSchema)
+			.query(async ({ ctx, input }) => {
+				return await ctx.workspaceApi.listDirectory(ctx.workspaceScope, input);
+			}),
+		readFile: workspaceProcedure
+			.input(runtimeWorkspaceFileReadRequestSchema)
+			.output(runtimeWorkspaceFileReadResponseSchema)
+			.query(async ({ ctx, input }) => {
+				return await ctx.workspaceApi.readFile(ctx.workspaceScope, input);
+			}),
+		writeFile: workspaceProcedure
+			.input(runtimeWorkspaceFileWriteRequestSchema)
+			.output(runtimeWorkspaceFileWriteResponseSchema)
+			.mutation(async ({ ctx, input }) => {
+				return await ctx.workspaceApi.writeFile(ctx.workspaceScope, input);
+			}),
+		getFileGitLineStatus: workspaceProcedure
+			.input(runtimeWorkspaceFileGitLineStatusRequestSchema)
+			.output(runtimeWorkspaceFileGitLineStatusResponseSchema)
+			.query(async ({ ctx, input }) => {
+				return await ctx.workspaceApi.getFileGitLineStatus(ctx.workspaceScope, input);
 			}),
 		getState: workspaceProcedure.output(runtimeWorkspaceStateResponseSchema).query(async ({ ctx }) => {
 			return await ctx.workspaceApi.loadState(ctx.workspaceScope);

--- a/src/trpc/workspace-api.ts
+++ b/src/trpc/workspace-api.ts
@@ -8,7 +8,11 @@ import type {
 	RuntimeGitSyncResponse,
 	RuntimeTaskSessionSummary,
 	RuntimeWorkspaceChangesMode,
+	RuntimeWorkspaceDirectoryListResponse,
+	RuntimeWorkspaceFileGitLineStatusResponse,
+	RuntimeWorkspaceFileReadResponse,
 	RuntimeWorkspaceFileSearchResponse,
+	RuntimeWorkspaceFileWriteResponse,
 	RuntimeWorkspaceStateResponse,
 } from "../core/api-contract";
 import {
@@ -18,6 +22,12 @@ import {
 } from "../core/api-validation";
 import { saveWorkspaceState, WorkspaceStateConflictError } from "../state/workspace-state";
 import type { TerminalSessionManager } from "../terminal/session-manager";
+import {
+	getFileGitLineStatus,
+	listDirectoryEntries,
+	readWorkspaceFile,
+	writeWorkspaceFile,
+} from "../workspace/browse-workspace-files";
 import {
 	createEmptyWorkspaceChangesResponse,
 	getWorkspaceChanges,
@@ -349,6 +359,31 @@ export function createWorkspaceApi(deps: CreateWorkspaceApiDependencies): Runtim
 				query,
 				files,
 			} satisfies RuntimeWorkspaceFileSearchResponse;
+		},
+		listDirectory: async (workspaceScope, input) => {
+			return (await listDirectoryEntries(
+				workspaceScope.workspacePath,
+				input.path,
+			)) satisfies RuntimeWorkspaceDirectoryListResponse;
+		},
+		readFile: async (workspaceScope, input) => {
+			return (await readWorkspaceFile(
+				workspaceScope.workspacePath,
+				input.path,
+			)) satisfies RuntimeWorkspaceFileReadResponse;
+		},
+		writeFile: async (workspaceScope, input) => {
+			const response = await writeWorkspaceFile(workspaceScope.workspacePath, input.path, input.content);
+			if (response.ok) {
+				void deps.broadcastRuntimeWorkspaceStateUpdated(workspaceScope.workspaceId, workspaceScope.workspacePath);
+			}
+			return response satisfies RuntimeWorkspaceFileWriteResponse;
+		},
+		getFileGitLineStatus: async (workspaceScope, input) => {
+			return (await getFileGitLineStatus(
+				workspaceScope.workspacePath,
+				input.path,
+			)) satisfies RuntimeWorkspaceFileGitLineStatusResponse;
 		},
 		loadState: async (workspaceScope) => {
 			return await deps.buildWorkspaceStateSnapshot(workspaceScope.workspaceId, workspaceScope.workspacePath);

--- a/src/workspace/browse-workspace-files.ts
+++ b/src/workspace/browse-workspace-files.ts
@@ -1,0 +1,247 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import type {
+	RuntimeWorkspaceDirectoryEntry,
+	RuntimeWorkspaceDirectoryListResponse,
+	RuntimeWorkspaceFileGitLineStatusResponse,
+	RuntimeWorkspaceFileReadResponse,
+	RuntimeWorkspaceFileWriteResponse,
+	RuntimeWorkspaceGitLineChange,
+} from "../core/api-contract";
+import { createGitProcessEnv } from "../core/git-process-env";
+
+const execFileAsync = promisify(execFile);
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/;
+
+const BINARY_EXTENSIONS = new Set([
+	"7z",
+	"aac",
+	"avif",
+	"bin",
+	"bmp",
+	"bz2",
+	"class",
+	"dat",
+	"db",
+	"dll",
+	"doc",
+	"docx",
+	"dylib",
+	"eot",
+	"exe",
+	"flac",
+	"gif",
+	"gz",
+	"ico",
+	"jpeg",
+	"jpg",
+	"mp3",
+	"mp4",
+	"obj",
+	"o",
+	"otf",
+	"pdf",
+	"png",
+	"ppt",
+	"pptx",
+	"pyc",
+	"rar",
+	"so",
+	"sqlite",
+	"tar",
+	"ttf",
+	"wav",
+	"wasm",
+	"webm",
+	"webp",
+	"woff",
+	"woff2",
+	"xls",
+	"xlsx",
+	"xz",
+	"zip",
+]);
+
+function resolveWorkspacePath(workspaceRoot: string, requestedPath: string): string {
+	const normalizedRoot = resolve(workspaceRoot);
+	const resolvedPath = resolve(normalizedRoot, requestedPath);
+	const relativePath = relative(normalizedRoot, resolvedPath);
+	if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+		throw new Error("Path traversal is not allowed.");
+	}
+	return resolvedPath;
+}
+
+function isBinaryPath(filePath: string): boolean {
+	const lastDotIndex = filePath.lastIndexOf(".");
+	if (lastDotIndex === -1) {
+		return false;
+	}
+	return BINARY_EXTENSIONS.has(filePath.slice(lastDotIndex + 1).toLowerCase());
+}
+
+function isBinaryBuffer(buffer: Buffer): boolean {
+	const sample = buffer.subarray(0, Math.min(buffer.length, 8192));
+	for (const byte of sample) {
+		if (byte === 0 || byte < 7) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function isIgnoredEntry(name: string): boolean {
+	return name === ".git" || name === ".worktrees" || name === "node_modules";
+}
+
+function sortEntries(entries: RuntimeWorkspaceDirectoryEntry[]): RuntimeWorkspaceDirectoryEntry[] {
+	return [...entries].sort((left, right) => {
+		if (left.type !== right.type) {
+			return left.type === "directory" ? -1 : 1;
+		}
+		return left.name.localeCompare(right.name);
+	});
+}
+
+function parseGitDiffHunks(diffOutput: string): RuntimeWorkspaceGitLineChange[] {
+	const changes: RuntimeWorkspaceGitLineChange[] = [];
+	for (const line of diffOutput.split("\n")) {
+		const match = HUNK_HEADER_REGEX.exec(line);
+		if (!match) {
+			continue;
+		}
+		const oldCount = match[2] ? Number.parseInt(match[2], 10) : 1;
+		const newStart = Number.parseInt(match[3] ?? "1", 10);
+		const newCount = match[4] ? Number.parseInt(match[4], 10) : 1;
+
+		if (oldCount === 0 && newCount > 0) {
+			changes.push({ type: "added", startLine: newStart, lineCount: newCount });
+			continue;
+		}
+		if (newCount === 0 && oldCount > 0) {
+			changes.push({ type: "deleted", startLine: Math.max(1, newStart), lineCount: 0 });
+			continue;
+		}
+		changes.push({ type: "modified", startLine: newStart, lineCount: newCount });
+	}
+	return changes;
+}
+
+export async function listDirectoryEntries(
+	workspaceRoot: string,
+	dirPath: string,
+): Promise<RuntimeWorkspaceDirectoryListResponse> {
+	const targetDirectory = dirPath ? resolveWorkspacePath(workspaceRoot, dirPath) : resolve(workspaceRoot);
+	const directoryEntries = await readdir(targetDirectory, { withFileTypes: true });
+	const entries: RuntimeWorkspaceDirectoryEntry[] = [];
+
+	for (const entry of directoryEntries) {
+		if (isIgnoredEntry(entry.name)) {
+			continue;
+		}
+		if (!entry.isDirectory() && !entry.isFile() && !entry.isSymbolicLink()) {
+			continue;
+		}
+
+		const entryPath = relative(resolve(workspaceRoot), join(targetDirectory, entry.name));
+		entries.push({
+			name: entry.name,
+			path: entryPath,
+			type: entry.isDirectory() ? "directory" : "file",
+		});
+	}
+
+	return {
+		entries: sortEntries(entries),
+	};
+}
+
+export async function readWorkspaceFile(
+	workspaceRoot: string,
+	filePath: string,
+): Promise<RuntimeWorkspaceFileReadResponse> {
+	const resolvedPath = resolveWorkspacePath(workspaceRoot, filePath);
+
+	try {
+		const fileStat = await stat(resolvedPath);
+		if (!fileStat.isFile()) {
+			return { path: filePath, content: null, size: 0, isBinary: false, error: "Not a file." };
+		}
+		if (fileStat.size > MAX_FILE_SIZE_BYTES) {
+			return {
+				path: filePath,
+				content: null,
+				size: fileStat.size,
+				isBinary: false,
+				error: `File too large (${Math.round(fileStat.size / 1024)} KB).`,
+			};
+		}
+		if (isBinaryPath(filePath)) {
+			return { path: filePath, content: null, size: fileStat.size, isBinary: true };
+		}
+
+		const buffer = await readFile(resolvedPath);
+		if (isBinaryBuffer(buffer)) {
+			return { path: filePath, content: null, size: fileStat.size, isBinary: true };
+		}
+
+		return {
+			path: filePath,
+			content: buffer.toString("utf8"),
+			size: fileStat.size,
+			isBinary: false,
+		};
+	} catch (error) {
+		return {
+			path: filePath,
+			content: null,
+			size: 0,
+			isBinary: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export async function writeWorkspaceFile(
+	workspaceRoot: string,
+	filePath: string,
+	content: string,
+): Promise<RuntimeWorkspaceFileWriteResponse> {
+	const resolvedPath = resolveWorkspacePath(workspaceRoot, filePath);
+
+	try {
+		await writeFile(resolvedPath, content, "utf8");
+		return { ok: true };
+	} catch (error) {
+		return {
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export async function getFileGitLineStatus(
+	workspaceRoot: string,
+	filePath: string,
+): Promise<RuntimeWorkspaceFileGitLineStatusResponse> {
+	try {
+		const { stdout } = await execFileAsync("git", ["diff", "--unified=0", "--no-color", "HEAD", "--", filePath], {
+			cwd: workspaceRoot,
+			env: createGitProcessEnv(),
+			maxBuffer: 1024 * 1024,
+		});
+		return {
+			path: filePath,
+			changes: parseGitDiffHunks(stdout),
+		};
+	} catch {
+		return {
+			path: filePath,
+			changes: [],
+		};
+	}
+}

--- a/test/runtime/browse-workspace-files.test.ts
+++ b/test/runtime/browse-workspace-files.test.ts
@@ -1,0 +1,222 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+	getFileGitLineStatus,
+	listDirectoryEntries,
+	readWorkspaceFile,
+	writeWorkspaceFile,
+} from "../../src/workspace/browse-workspace-files";
+import { createGitTestEnv } from "../utilities/git-env";
+import { createTempDir } from "../utilities/temp-dir";
+
+function runGit(cwd: string, args: string[]): string {
+	const result = spawnSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		env: createGitTestEnv(),
+	});
+	if (result.status !== 0) {
+		throw new Error(result.stderr || result.stdout || `git ${args.join(" ")} failed`);
+	}
+	return result.stdout.trim();
+}
+
+function initRepository(path: string): void {
+	runGit(path, ["init", "-q"]);
+	runGit(path, ["config", "user.name", "Test User"]);
+	runGit(path, ["config", "user.email", "test@example.com"]);
+}
+
+function commitAll(cwd: string, message: string): void {
+	runGit(cwd, ["add", "."]);
+	runGit(cwd, ["commit", "-qm", message]);
+}
+
+describe.sequential("listDirectoryEntries", () => {
+	it("lists files and directories sorted with directories first", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-list-");
+		try {
+			mkdirSync(join(root, "beta"), { recursive: true });
+			mkdirSync(join(root, "alpha"), { recursive: true });
+			writeFileSync(join(root, "readme.md"), "hello", "utf8");
+			writeFileSync(join(root, "app.ts"), "code", "utf8");
+
+			const result = await listDirectoryEntries(root, "");
+
+			expect(result.entries).toEqual([
+				{ name: "alpha", path: "alpha", type: "directory" },
+				{ name: "beta", path: "beta", type: "directory" },
+				{ name: "app.ts", path: "app.ts", type: "file" },
+				{ name: "readme.md", path: "readme.md", type: "file" },
+			]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("filters out .git, node_modules, and .worktrees", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-ignore-");
+		try {
+			mkdirSync(join(root, ".git"), { recursive: true });
+			mkdirSync(join(root, "node_modules"), { recursive: true });
+			mkdirSync(join(root, ".worktrees"), { recursive: true });
+			writeFileSync(join(root, "index.ts"), "code", "utf8");
+
+			const result = await listDirectoryEntries(root, "");
+
+			expect(result.entries).toEqual([{ name: "index.ts", path: "index.ts", type: "file" }]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("lists entries in a subdirectory with relative paths from root", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-subdir-");
+		try {
+			mkdirSync(join(root, "src", "utils"), { recursive: true });
+			writeFileSync(join(root, "src", "index.ts"), "code", "utf8");
+
+			const result = await listDirectoryEntries(root, "src");
+
+			expect(result.entries).toEqual([
+				{ name: "utils", path: "src/utils", type: "directory" },
+				{ name: "index.ts", path: "src/index.ts", type: "file" },
+			]);
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe.sequential("readWorkspaceFile", () => {
+	it("reads a text file and returns its content", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-read-");
+		try {
+			writeFileSync(join(root, "hello.txt"), "world", "utf8");
+
+			const result = await readWorkspaceFile(root, "hello.txt");
+
+			expect(result.content).toBe("world");
+			expect(result.isBinary).toBe(false);
+			expect(result.size).toBe(5);
+			expect(result.error).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns isBinary true for binary extension files", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-binary-ext-");
+		try {
+			writeFileSync(join(root, "image.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+			const result = await readWorkspaceFile(root, "image.png");
+
+			expect(result.isBinary).toBe(true);
+			expect(result.content).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns error for non-existent file", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-nofile-");
+		try {
+			const result = await readWorkspaceFile(root, "missing.txt");
+
+			expect(result.content).toBeNull();
+			expect(result.error).toBeDefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rejects path traversal attempts", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-traversal-");
+		try {
+			await expect(readWorkspaceFile(root, "../../../etc/passwd")).rejects.toThrow("Path traversal");
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe.sequential("writeWorkspaceFile", () => {
+	it("writes content to a file and returns ok", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-write-");
+		try {
+			writeFileSync(join(root, "file.txt"), "old", "utf8");
+
+			const result = await writeWorkspaceFile(root, "file.txt", "new content");
+
+			expect(result.ok).toBe(true);
+
+			const readBack = await readWorkspaceFile(root, "file.txt");
+			expect(readBack.content).toBe("new content");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("rejects path traversal attempts", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-write-traversal-");
+		try {
+			await expect(writeWorkspaceFile(root, "../../evil.txt", "hack")).rejects.toThrow("Path traversal");
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe.sequential("getFileGitLineStatus", () => {
+	it("detects added lines in a new file", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-git-added-");
+		try {
+			initRepository(root);
+			writeFileSync(join(root, "initial.txt"), "first\n", "utf8");
+			commitAll(root, "initial commit");
+
+			writeFileSync(join(root, "initial.txt"), "first\nsecond\nthird\n", "utf8");
+
+			const result = await getFileGitLineStatus(root, "initial.txt");
+
+			expect(result.path).toBe("initial.txt");
+			expect(result.changes.length).toBeGreaterThan(0);
+			expect(result.changes[0]?.type).toBe("added");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns empty changes for unmodified files", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-git-clean-");
+		try {
+			initRepository(root);
+			writeFileSync(join(root, "clean.txt"), "unchanged\n", "utf8");
+			commitAll(root, "initial commit");
+
+			const result = await getFileGitLineStatus(root, "clean.txt");
+
+			expect(result.changes).toEqual([]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns empty changes when git is not available", async () => {
+		const { path: root, cleanup } = createTempDir("kanban-browse-git-nogit-");
+		try {
+			writeFileSync(join(root, "file.txt"), "no git\n", "utf8");
+
+			const result = await getFileGitLineStatus(root, "file.txt");
+
+			expect(result.changes).toEqual([]);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clinebot/shared": "^0.0.28",
         "@hello-pangea/dnd": "^18.0.1",
+        "@monaco-editor/react": "^4.7.0",
         "@posthog/react": "^1.8.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -34,6 +35,7 @@
         "diff": "^8.0.3",
         "fzf": "^0.5.2",
         "lucide-react": "^0.577.0",
+        "monaco-editor": "^0.55.1",
         "motion": "^12.38.0",
         "posthog-js": "^1.357.1",
         "prismjs": "^1.30.0",
@@ -1114,6 +1116,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -5168,6 +5193,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -6036,6 +6073,25 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/motion": {
       "version": "12.38.0",
@@ -7248,6 +7304,12 @@
         "stack-generator": "^2.0.5",
         "stacktrace-gps": "^3.0.4"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@clinebot/shared": "^0.0.28",
     "@hello-pangea/dnd": "^18.0.1",
+    "@monaco-editor/react": "^4.7.0",
     "@posthog/react": "^1.8.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -40,6 +41,7 @@
     "diff": "^8.0.3",
     "fzf": "^0.5.2",
     "lucide-react": "^0.577.0",
+    "monaco-editor": "^0.55.1",
     "motion": "^12.38.0",
     "posthog-js": "^1.357.1",
     "prismjs": "^1.30.0",

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -8,6 +8,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notifyError, showAppToast } from "@/components/app-toaster";
 import { CardDetailView } from "@/components/card-detail-view";
 import { ClearTrashDialog } from "@/components/clear-trash-dialog";
+import { type CodeBrowserOpenFileRequest, CodeBrowserPanel } from "@/components/code-browser/code-browser-panel";
+import { FileSearchDialog } from "@/components/code-browser/file-search-dialog";
 import { DebugDialog } from "@/components/debug-dialog";
 import { AgentTerminalPanel } from "@/components/detail-panels/agent-terminal-panel";
 import { GitHistoryView } from "@/components/git-history-view";
@@ -87,6 +89,11 @@ export default function App(): ReactElement {
 	const [homeSidebarSection, setHomeSidebarSection] = useState<"projects" | "agent">("projects");
 	const [isClearTrashDialogOpen, setIsClearTrashDialogOpen] = useState(false);
 	const [isGitHistoryOpen, setIsGitHistoryOpen] = useState(false);
+	const [isCodeBrowserOpen, setIsCodeBrowserOpen] = useState(false);
+	const [isGlobalFileSearchOpen, setIsGlobalFileSearchOpen] = useState(false);
+	const [codeBrowserOpenFileRequest, setCodeBrowserOpenFileRequest] = useState<CodeBrowserOpenFileRequest | null>(
+		null,
+	);
 	const [pendingTaskStartAfterEditId, setPendingTaskStartAfterEditId] = useState<string | null>(null);
 	const taskEditorResetRef = useRef<() => void>(() => {});
 	const lastStreamErrorRef = useRef<string | null>(null);
@@ -94,6 +101,9 @@ export default function App(): ReactElement {
 		setCanPersistWorkspaceState(false);
 		setSelectedTaskId(null);
 		setIsGitHistoryOpen(false);
+		setIsCodeBrowserOpen(false);
+		setIsGlobalFileSearchOpen(false);
+		setCodeBrowserOpenFileRequest(null);
 		setPendingTaskStartAfterEditId(null);
 		taskEditorResetRef.current();
 	}, []);
@@ -502,6 +512,9 @@ export default function App(): ReactElement {
 		setSelectedTaskId(null);
 		resetTaskEditorState();
 		setIsClearTrashDialogOpen(false);
+		setIsCodeBrowserOpen(false);
+		setIsGlobalFileSearchOpen(false);
+		setCodeBrowserOpenFileRequest(null);
 		resetGitActionState();
 		resetProjectNavigationState();
 		resetTerminalPanelsState();
@@ -539,6 +552,8 @@ export default function App(): ReactElement {
 	const handleBack = useCallback(() => {
 		setSelectedTaskId(null);
 		setIsGitHistoryOpen(false);
+		setIsCodeBrowserOpen(false);
+		setIsGlobalFileSearchOpen(false);
 	}, []);
 
 	const handleOpenSettings = useCallback((section?: RuntimeSettingsSection) => {
@@ -549,11 +564,37 @@ export default function App(): ReactElement {
 		if (hasNoProjects) {
 			return;
 		}
-		setIsGitHistoryOpen((current) => !current);
+		setIsGitHistoryOpen((current) => {
+			if (!current) {
+				setIsCodeBrowserOpen(false);
+			}
+			return !current;
+		});
 	}, [hasNoProjects]);
 	const handleCloseGitHistory = useCallback(() => {
 		setIsGitHistoryOpen(false);
 	}, []);
+	const handleToggleCodeBrowser = useCallback(() => {
+		if (hasNoProjects || selectedCard) {
+			return;
+		}
+		setIsCodeBrowserOpen((current) => {
+			if (!current) {
+				setIsGitHistoryOpen(false);
+			} else {
+				setIsGlobalFileSearchOpen(false);
+			}
+			return !current;
+		});
+	}, [hasNoProjects, selectedCard]);
+	const handleOpenFileSearch = useCallback(() => {
+		if (hasNoProjects || selectedCard) {
+			return;
+		}
+		setIsCodeBrowserOpen(true);
+		setIsGitHistoryOpen(false);
+		setIsGlobalFileSearchOpen(true);
+	}, [hasNoProjects, selectedCard]);
 
 	const {
 		handleProgrammaticCardMoveReady,
@@ -626,7 +667,19 @@ export default function App(): ReactElement {
 		handleToggleGitHistory,
 		handleCloseGitHistory,
 		onStartAllTasks: handleStartAllBacklogTasksFromBoard,
+		handleOpenFileSearch: hasNoProjects ? undefined : handleOpenFileSearch,
+		handleToggleCodeBrowser: hasNoProjects ? undefined : handleToggleCodeBrowser,
 	});
+
+	const handleGlobalFileSelect = useCallback((path: string) => {
+		setIsGlobalFileSearchOpen(false);
+		setIsCodeBrowserOpen(true);
+		setIsGitHistoryOpen(false);
+		setCodeBrowserOpenFileRequest({
+			path,
+			nonce: Date.now(),
+		});
+	}, []);
 
 	useEffect(() => {
 		if (!pendingTaskStartAfterEditId) {
@@ -809,6 +862,9 @@ export default function App(): ReactElement {
 						}
 						isTerminalOpen={selectedCard ? isDetailTerminalOpen : showHomeBottomTerminal}
 						isTerminalLoading={selectedCard ? isDetailTerminalStarting : isHomeTerminalStarting}
+						onToggleCodeBrowser={!selectedCard && !hasNoProjects ? handleToggleCodeBrowser : undefined}
+						isCodeBrowserOpen={isCodeBrowserOpen}
+						onOpenFileSearch={!selectedCard && !hasNoProjects ? handleOpenFileSearch : undefined}
 						onOpenSettings={handleOpenSettings}
 						showDebugButton={debugModeEnabled}
 						onOpenDebugDialog={debugModeEnabled ? handleOpenDebugDialog : undefined}
@@ -870,6 +926,11 @@ export default function App(): ReactElement {
 													void discardHomeWorkingChanges();
 												}}
 												isDiscardWorkingChangesPending={isDiscardingHomeWorkingChanges}
+											/>
+										) : isCodeBrowserOpen ? (
+											<CodeBrowserPanel
+												workspaceId={currentProjectId}
+												externalOpenFileRequest={codeBrowserOpenFileRequest}
 											/>
 										) : (
 											<KanbanBoard
@@ -1070,6 +1131,12 @@ export default function App(): ReactElement {
 					taskCount={trashTaskCount}
 					onCancel={() => setIsClearTrashDialogOpen(false)}
 					onConfirm={handleConfirmClearTrash}
+				/>
+				<FileSearchDialog
+					isOpen={isGlobalFileSearchOpen}
+					onClose={() => setIsGlobalFileSearchOpen(false)}
+					workspaceId={currentProjectId}
+					onSelectFile={handleGlobalFileSelect}
 				/>
 				<StartupOnboardingDialog
 					open={isStartupOnboardingDialogOpen}

--- a/web-ui/src/components/code-browser/code-browser-panel.tsx
+++ b/web-ui/src/components/code-browser/code-browser-panel.tsx
@@ -1,0 +1,315 @@
+import { Ellipsis, Search, X } from "lucide-react";
+import { type MouseEvent as ReactMouseEvent, useCallback, useEffect, useRef, useState } from "react";
+
+import { CodeViewer, type EditorSettings } from "@/components/code-browser/code-viewer";
+import { FileTypeIcon } from "@/components/code-browser/file-icons";
+import { FileSearchDialog } from "@/components/code-browser/file-search-dialog";
+import { FileTree } from "@/components/code-browser/file-tree";
+import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+
+const DEFAULT_SIDEBAR_WIDTH = 260;
+const MIN_SIDEBAR_WIDTH = 180;
+const MAX_SIDEBAR_WIDTH = 480;
+const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
+	fontSize: 12,
+	wordWrap: false,
+};
+
+interface OpenTab {
+	path: string;
+	isDirty: boolean;
+}
+
+export interface CodeBrowserOpenFileRequest {
+	path: string;
+	nonce: number;
+}
+
+function getFileName(path: string): string {
+	return path.slice(path.lastIndexOf("/") + 1) || path;
+}
+
+function useResizableSidebar(initialWidth: number): {
+	width: number;
+	startDrag: (event: ReactMouseEvent<HTMLDivElement>) => void;
+} {
+	const [width, setWidth] = useState(initialWidth);
+	const [isDragging, setIsDragging] = useState(false);
+	const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+	useEffect(() => {
+		if (!isDragging) {
+			return;
+		}
+
+		const handleMouseMove = (event: MouseEvent) => {
+			const dragState = dragStateRef.current;
+			if (!dragState) {
+				return;
+			}
+			const nextWidth = dragState.startWidth + (event.clientX - dragState.startX);
+			setWidth(Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, nextWidth)));
+		};
+		const handleMouseUp = () => {
+			setIsDragging(false);
+			dragStateRef.current = null;
+			document.body.style.userSelect = "";
+			document.body.style.cursor = "";
+		};
+
+		window.addEventListener("mousemove", handleMouseMove);
+		window.addEventListener("mouseup", handleMouseUp);
+		return () => {
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+		};
+	}, [isDragging]);
+
+	const startDrag = useCallback(
+		(event: ReactMouseEvent<HTMLDivElement>) => {
+			event.preventDefault();
+			dragStateRef.current = {
+				startX: event.clientX,
+				startWidth: width,
+			};
+			setIsDragging(true);
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = "ew-resize";
+		},
+		[width],
+	);
+
+	return { width, startDrag };
+}
+
+function EditorSettingsPopover({
+	settings,
+	onChange,
+}: {
+	settings: EditorSettings;
+	onChange: (settings: EditorSettings) => void;
+}): React.ReactElement {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<div className="relative">
+			<button
+				type="button"
+				className="rounded p-1 text-text-tertiary hover:bg-surface-2 hover:text-text-secondary"
+				onClick={() => setIsOpen((current) => !current)}
+				title="Editor settings"
+			>
+				<Ellipsis size={14} />
+			</button>
+			{isOpen ? (
+				<>
+					<div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+					<div className="absolute right-0 top-7 z-50 w-[200px] rounded-lg border border-border bg-surface-2 p-3 shadow-xl">
+						<div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-text-tertiary">
+							Editor
+						</div>
+						<label className="mb-2 flex items-center justify-between text-xs text-text-secondary">
+							<span>Font size</span>
+							<input
+								type="number"
+								min={10}
+								max={24}
+								value={settings.fontSize}
+								onChange={(event) =>
+									onChange({
+										...settings,
+										fontSize: Math.max(10, Math.min(24, Number(event.target.value))),
+									})
+								}
+								className="h-7 w-14 rounded border border-border bg-surface-0 px-2 text-center text-xs text-text-primary outline-none"
+							/>
+						</label>
+						<label className="flex items-center justify-between text-xs text-text-secondary">
+							<span>Word wrap</span>
+							<input
+								type="checkbox"
+								checked={settings.wordWrap}
+								onChange={() =>
+									onChange({
+										...settings,
+										wordWrap: !settings.wordWrap,
+									})
+								}
+							/>
+						</label>
+					</div>
+				</>
+			) : null}
+		</div>
+	);
+}
+
+function TabBar({
+	tabs,
+	activeTabPath,
+	onSelectTab,
+	onCloseTab,
+	onOpenSearch,
+	editorSettings,
+	onEditorSettingsChange,
+}: {
+	tabs: OpenTab[];
+	activeTabPath: string | null;
+	onSelectTab: (path: string) => void;
+	onCloseTab: (path: string) => void;
+	onOpenSearch: () => void;
+	editorSettings: EditorSettings;
+	onEditorSettingsChange: (settings: EditorSettings) => void;
+}): React.ReactElement {
+	return (
+		<div className="flex h-[34px] min-h-[34px] items-stretch overflow-hidden border-b border-border bg-surface-1">
+			<div className="flex flex-1 items-stretch overflow-x-auto overflow-y-hidden">
+				{tabs.map((tab) => {
+					const isActive = tab.path === activeTabPath;
+					const name = getFileName(tab.path);
+
+					return (
+						<div
+							key={tab.path}
+							onMouseDown={(event) => {
+								if (event.button === 1) {
+									event.preventDefault();
+									onCloseTab(tab.path);
+								}
+							}}
+							onClick={() => onSelectTab(tab.path)}
+							className={[
+								"flex shrink-0 cursor-pointer items-center gap-1.5 border-r border-border px-2.5 text-[12px]",
+								isActive ? "bg-surface-0 text-text-primary" : "text-text-tertiary hover:text-text-secondary",
+							].join(" ")}
+						>
+							<FileTypeIcon name={name} size={14} />
+							<span className="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap">
+								{tab.isDirty ? "* " : ""}
+								{name}
+							</span>
+							<button
+								type="button"
+								className="ml-0.5 bg-transparent p-0 text-text-tertiary hover:text-text-primary"
+								onClick={(event) => {
+									event.stopPropagation();
+									onCloseTab(tab.path);
+								}}
+							>
+								<X size={12} />
+							</button>
+						</div>
+					);
+				})}
+			</div>
+			<div className="flex shrink-0 items-center gap-0.5 px-1.5">
+				<Tooltip side="bottom" content="Search files (Cmd/Ctrl+Shift+P)">
+					<Button variant="ghost" size="sm" icon={<Search size={14} />} onClick={onOpenSearch} />
+				</Tooltip>
+				<EditorSettingsPopover settings={editorSettings} onChange={onEditorSettingsChange} />
+			</div>
+		</div>
+	);
+}
+
+export function CodeBrowserPanel({
+	workspaceId,
+	externalOpenFileRequest,
+}: {
+	workspaceId: string | null;
+	externalOpenFileRequest?: CodeBrowserOpenFileRequest | null;
+}): React.ReactElement {
+	const [tabs, setTabs] = useState<OpenTab[]>([]);
+	const [activeTabPath, setActiveTabPath] = useState<string | null>(null);
+	const [isSearchOpen, setIsSearchOpen] = useState(false);
+	const [editorSettings, setEditorSettings] = useState<EditorSettings>(DEFAULT_EDITOR_SETTINGS);
+	const { width: sidebarWidth, startDrag } = useResizableSidebar(DEFAULT_SIDEBAR_WIDTH);
+
+	const handleSelectFile = useCallback((path: string) => {
+		setTabs((current) => {
+			if (current.some((tab) => tab.path === path)) {
+				return current;
+			}
+			return [...current, { path, isDirty: false }];
+		});
+		setActiveTabPath(path);
+	}, []);
+
+	const handleCloseTab = useCallback(
+		(path: string) => {
+			setTabs((current) => {
+				const nextTabs = current.filter((tab) => tab.path !== path);
+				if (activeTabPath === path) {
+					const closedIndex = current.findIndex((tab) => tab.path === path);
+					const nextActivePath = nextTabs[Math.min(closedIndex, nextTabs.length - 1)]?.path ?? null;
+					setActiveTabPath(nextActivePath);
+				}
+				return nextTabs;
+			});
+		},
+		[activeTabPath],
+	);
+
+	const handleDirtyChange = useCallback((path: string, isDirty: boolean) => {
+		setTabs((current) => current.map((tab) => (tab.path === path ? { ...tab, isDirty } : tab)));
+	}, []);
+
+	useEffect(() => {
+		if (!externalOpenFileRequest) {
+			return;
+		}
+		handleSelectFile(externalOpenFileRequest.path);
+	}, [externalOpenFileRequest, handleSelectFile]);
+
+	useEffect(() => {
+		if (!workspaceId) {
+			setTabs([]);
+			setActiveTabPath(null);
+		}
+	}, [workspaceId]);
+
+	return (
+		<div className="flex min-h-0 flex-1 gap-2 bg-surface-0 p-2">
+			<div
+				className="relative flex shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-surface-1"
+				style={{ width: sidebarWidth, minWidth: MIN_SIDEBAR_WIDTH, maxWidth: MAX_SIDEBAR_WIDTH }}
+			>
+				<div className="shrink-0 border-b border-border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-text-tertiary">
+					Explorer
+				</div>
+				<FileTree workspaceId={workspaceId} selectedFilePath={activeTabPath} onSelectFile={handleSelectFile} />
+				<div
+					role="separator"
+					aria-orientation="vertical"
+					aria-label="Resize code browser sidebar"
+					onMouseDown={startDrag}
+					className="absolute inset-y-0 right-0 z-10 w-1.5 cursor-ew-resize"
+				/>
+			</div>
+			<div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border">
+				<TabBar
+					tabs={tabs}
+					activeTabPath={activeTabPath}
+					onSelectTab={setActiveTabPath}
+					onCloseTab={handleCloseTab}
+					onOpenSearch={() => setIsSearchOpen(true)}
+					editorSettings={editorSettings}
+					onEditorSettingsChange={setEditorSettings}
+				/>
+				<CodeViewer
+					workspaceId={workspaceId}
+					filePath={activeTabPath}
+					onDirtyChange={handleDirtyChange}
+					editorSettings={editorSettings}
+				/>
+			</div>
+			<FileSearchDialog
+				isOpen={isSearchOpen}
+				onClose={() => setIsSearchOpen(false)}
+				workspaceId={workspaceId}
+				onSelectFile={handleSelectFile}
+			/>
+		</div>
+	);
+}

--- a/web-ui/src/components/code-browser/code-viewer.tsx
+++ b/web-ui/src/components/code-browser/code-viewer.tsx
@@ -1,0 +1,461 @@
+import Editor, { loader, type OnMount } from "@monaco-editor/react";
+import type * as MonacoEditor from "monaco-editor";
+import * as monaco from "monaco-editor";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import CssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import HtmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Spinner } from "@/components/ui/spinner";
+import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
+
+declare global {
+	interface Window {
+		MonacoEnvironment?: {
+			getWorker: (_workerId: string, label: string) => Worker;
+		};
+	}
+}
+
+const LANGUAGE_MAP: Record<string, string> = {
+	bash: "shell",
+	c: "c",
+	cjs: "javascript",
+	cpp: "cpp",
+	cs: "csharp",
+	css: "css",
+	dockerfile: "dockerfile",
+	go: "go",
+	graphql: "graphql",
+	h: "c",
+	hpp: "cpp",
+	htm: "html",
+	html: "html",
+	java: "java",
+	js: "javascript",
+	json: "json",
+	jsonc: "json",
+	jsx: "javascript",
+	kt: "kotlin",
+	lua: "lua",
+	md: "markdown",
+	mdx: "markdown",
+	mjs: "javascript",
+	php: "php",
+	proto: "protobuf",
+	py: "python",
+	rb: "ruby",
+	rs: "rust",
+	scss: "scss",
+	sh: "shell",
+	sql: "sql",
+	svelte: "html",
+	swift: "swift",
+	toml: "ini",
+	ts: "typescript",
+	tsx: "typescript",
+	txt: "plaintext",
+	xml: "xml",
+	yaml: "yaml",
+	yml: "yaml",
+	zsh: "shell",
+};
+
+const THEME_NAME = "kanban-dark";
+let isThemeRegistered = false;
+let isLoaderConfigured = false;
+
+function configureMonacoLoader(): void {
+	if (isLoaderConfigured || typeof window === "undefined") {
+		return;
+	}
+
+	window.MonacoEnvironment = {
+		getWorker(_workerId, label) {
+			switch (label) {
+				case "css":
+				case "scss":
+				case "less":
+					return new CssWorker();
+				case "html":
+				case "handlebars":
+				case "razor":
+					return new HtmlWorker();
+				case "json":
+					return new JsonWorker();
+				case "typescript":
+				case "javascript":
+					return new TsWorker();
+				default:
+					return new EditorWorker();
+			}
+		},
+	};
+
+	loader.config({ monaco });
+	isLoaderConfigured = true;
+}
+
+function ensureTheme(monacoInstance: typeof monaco): void {
+	if (isThemeRegistered) {
+		return;
+	}
+
+	monacoInstance.editor.defineTheme(THEME_NAME, {
+		base: "vs-dark",
+		inherit: true,
+		rules: [
+			{ token: "comment", foreground: "6E7681" },
+			{ token: "keyword", foreground: "4C9AFF" },
+			{ token: "string", foreground: "3FB950" },
+			{ token: "number", foreground: "D29922" },
+			{ token: "constant", foreground: "D29922" },
+			{ token: "entity.name.function", foreground: "4C9AFF" },
+			{ token: "support.function", foreground: "4C9AFF" },
+			{ token: "entity.name.type", foreground: "4C9AFF" },
+			{ token: "type", foreground: "4C9AFF" },
+			{ token: "operator", foreground: "8B949E" },
+			{ token: "delimiter", foreground: "8B949E" },
+			{ token: "variable", foreground: "E6EDF3" },
+			{ token: "identifier", foreground: "E6EDF3" },
+			{ token: "attribute.name", foreground: "4C9AFF" },
+		],
+		colors: {
+			"editor.background": "#24292E",
+			"editor.foreground": "#E6EDF3",
+			"editorLineNumber.foreground": "#6E7681",
+			"editorLineNumber.activeForeground": "#8B949E",
+			"editor.selectionBackground": "#264F78",
+			"editor.lineHighlightBackground": "#2D3339",
+			"editorCursor.foreground": "#E6EDF3",
+			"editorIndentGuide.background": "#30363D",
+			"editorIndentGuide.activeBackground": "#444C56",
+			"editorWidget.background": "#24292E",
+			"editorWidget.border": "#30363D",
+			"editorSuggestWidget.background": "#24292E",
+			"editorSuggestWidget.border": "#30363D",
+			"editorSuggestWidget.selectedBackground": "#2D3339",
+			"editorOverviewRuler.border": "#00000000",
+			"editorBracketMatch.background": "#2D333940",
+			"editorBracketMatch.border": "#444C56",
+			"editorGutter.background": "#24292E",
+			"minimap.background": "#1F2428",
+			"scrollbarSlider.background": "#3E464E80",
+			"scrollbarSlider.hoverBackground": "#3E464EA0",
+			"scrollbarSlider.activeBackground": "#3E464EC0",
+		},
+	});
+
+	isThemeRegistered = true;
+}
+
+function getMonacoLanguage(filePath: string): string {
+	const normalizedName = filePath.slice(filePath.lastIndexOf("/") + 1).toLowerCase();
+	if (normalizedName === "dockerfile" || normalizedName.startsWith("dockerfile.")) {
+		return "dockerfile";
+	}
+	if (normalizedName === "makefile" || normalizedName === "gnumakefile") {
+		return "makefile";
+	}
+	if (normalizedName.endsWith(".d.ts")) {
+		return "typescript";
+	}
+
+	const lastDotIndex = normalizedName.lastIndexOf(".");
+	if (lastDotIndex === -1) {
+		return "plaintext";
+	}
+
+	const extension = normalizedName.slice(lastDotIndex + 1);
+	return LANGUAGE_MAP[extension] ?? "plaintext";
+}
+
+function createGitGutterDecorations(
+	changes: Awaited<
+		ReturnType<ReturnType<typeof getRuntimeTrpcClient>["workspace"]["getFileGitLineStatus"]["query"]>
+	>["changes"],
+): MonacoEditor.editor.IModelDeltaDecoration[] {
+	return changes.map((change) => {
+		const className =
+			change.type === "added"
+				? "kb-monaco-gutter-added"
+				: change.type === "deleted"
+					? "kb-monaco-gutter-deleted"
+					: "kb-monaco-gutter-modified";
+		const endLine = change.lineCount === 0 ? change.startLine : change.startLine + change.lineCount - 1;
+
+		return {
+			range: new monaco.Range(change.startLine, 1, endLine, 1),
+			options: {
+				isWholeLine: true,
+				linesDecorationsClassName: className,
+			},
+		};
+	});
+}
+
+function ensureGutterStyles(): void {
+	if (typeof document === "undefined" || document.getElementById("kb-monaco-gutter-styles")) {
+		return;
+	}
+
+	const styleElement = document.createElement("style");
+	styleElement.id = "kb-monaco-gutter-styles";
+	styleElement.textContent = `
+		.kb-monaco-gutter-added { border-left: 3px solid #3FB950 !important; margin-left: 2px; }
+		.kb-monaco-gutter-modified { border-left: 3px solid #4C9AFF !important; margin-left: 2px; }
+		.kb-monaco-gutter-deleted { border-left: 3px solid #F85149 !important; margin-left: 2px; }
+	`;
+	document.head.appendChild(styleElement);
+}
+
+function createEditorOptions(
+	settings: EditorSettings | undefined,
+	isSaving: boolean,
+): MonacoEditor.editor.IStandaloneEditorConstructionOptions {
+	return {
+		automaticLayout: true,
+		fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+		fontSize: settings?.fontSize ?? 12,
+		lineNumbersMinChars: 3,
+		minimap: { enabled: true },
+		padding: { top: 12, bottom: 12 },
+		readOnly: isSaving,
+		renderWhitespace: "selection",
+		scrollBeyondLastLine: false,
+		smoothScrolling: true,
+		tabSize: 2,
+		wordWrap: settings?.wordWrap ? "on" : "off",
+	};
+}
+
+export interface EditorSettings {
+	fontSize: number;
+	wordWrap: boolean;
+}
+
+interface FileContent {
+	path: string;
+	content: string | null;
+	size: number;
+	isBinary: boolean;
+	error?: string;
+}
+
+export function CodeViewer({
+	workspaceId,
+	filePath,
+	onDirtyChange,
+	editorSettings,
+}: {
+	workspaceId: string | null;
+	filePath: string | null;
+	onDirtyChange?: (path: string, isDirty: boolean) => void;
+	editorSettings?: EditorSettings;
+}): React.ReactElement {
+	const [fileContent, setFileContent] = useState<FileContent | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(null);
+	const decorationsRef = useRef<MonacoEditor.editor.IEditorDecorationsCollection | null>(null);
+	const loadingPathRef = useRef<string | null>(null);
+	const originalContentRef = useRef("");
+	const currentContentRef = useRef("");
+
+	configureMonacoLoader();
+
+	const loadFile = useCallback(
+		async (path: string) => {
+			if (!workspaceId) {
+				return;
+			}
+
+			loadingPathRef.current = path;
+			setIsLoading(true);
+			try {
+				const client = getRuntimeTrpcClient(workspaceId);
+				const response = await client.workspace.readFile.query({ path });
+				if (loadingPathRef.current !== path) {
+					return;
+				}
+				setFileContent(response);
+				originalContentRef.current = response.content ?? "";
+				currentContentRef.current = response.content ?? "";
+			} catch (error) {
+				if (loadingPathRef.current !== path) {
+					return;
+				}
+				setFileContent({
+					path,
+					content: null,
+					size: 0,
+					isBinary: false,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				if (loadingPathRef.current === path) {
+					setIsLoading(false);
+				}
+			}
+		},
+		[workspaceId],
+	);
+
+	const loadGitDecorations = useCallback(
+		async (path: string) => {
+			if (!workspaceId || !editorRef.current) {
+				return;
+			}
+			try {
+				ensureGutterStyles();
+				const client = getRuntimeTrpcClient(workspaceId);
+				const response = await client.workspace.getFileGitLineStatus.query({ path });
+				decorationsRef.current?.clear();
+				if (response.changes.length === 0) {
+					return;
+				}
+				decorationsRef.current = editorRef.current.createDecorationsCollection(
+					createGitGutterDecorations(response.changes),
+				);
+			} catch {
+				decorationsRef.current?.clear();
+			}
+		},
+		[workspaceId],
+	);
+
+	useEffect(() => {
+		if (!filePath) {
+			setFileContent(null);
+			loadingPathRef.current = null;
+			decorationsRef.current?.clear();
+			return;
+		}
+		void loadFile(filePath);
+		void loadGitDecorations(filePath);
+	}, [filePath, loadFile, loadGitDecorations]);
+
+	const saveFile = useCallback(async () => {
+		if (!workspaceId || !filePath || isSaving) {
+			return;
+		}
+		setIsSaving(true);
+		try {
+			const client = getRuntimeTrpcClient(workspaceId);
+			const response = await client.workspace.writeFile.mutate({
+				path: filePath,
+				content: currentContentRef.current,
+			});
+			if (response.ok) {
+				originalContentRef.current = currentContentRef.current;
+				onDirtyChange?.(filePath, false);
+				void loadGitDecorations(filePath);
+				return;
+			}
+			setFileContent((current) =>
+				current
+					? {
+							...current,
+							error: response.error ?? "Could not save file.",
+						}
+					: current,
+			);
+		} finally {
+			setIsSaving(false);
+		}
+	}, [filePath, isSaving, loadGitDecorations, onDirtyChange, workspaceId]);
+
+	const handleEditorMount: OnMount = useCallback(
+		(editorInstance, monacoInstance) => {
+			editorRef.current = editorInstance;
+			ensureTheme(monacoInstance);
+			monacoInstance.editor.setTheme(THEME_NAME);
+			monacoInstance.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+				noSemanticValidation: true,
+				noSyntaxValidation: true,
+				noSuggestionDiagnostics: true,
+			});
+			monacoInstance.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+				noSemanticValidation: true,
+				noSyntaxValidation: true,
+				noSuggestionDiagnostics: true,
+			});
+
+			editorInstance.addCommand(monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS, () => {
+				void saveFile();
+			});
+
+			if (filePath) {
+				void loadGitDecorations(filePath);
+			}
+		},
+		[filePath, loadGitDecorations, saveFile],
+	);
+
+	const handleEditorChange = useCallback(
+		(value: string | undefined) => {
+			const nextContent = value ?? "";
+			currentContentRef.current = nextContent;
+			if (!filePath) {
+				return;
+			}
+			onDirtyChange?.(filePath, nextContent !== originalContentRef.current);
+		},
+		[filePath, onDirtyChange],
+	);
+
+	if (!filePath) {
+		return (
+			<div className="flex min-h-0 flex-1 items-center justify-center text-sm text-text-tertiary">
+				Select a file to view its contents
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex min-h-0 flex-1 items-center justify-center">
+				<Spinner size={24} />
+			</div>
+		);
+	}
+
+	if (fileContent?.isBinary) {
+		return (
+			<div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-text-tertiary">
+				This file is binary and cannot be shown in the Monaco viewer.
+			</div>
+		);
+	}
+
+	if (!fileContent || fileContent.error) {
+		return (
+			<div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-status-red">
+				{fileContent?.error ?? "Could not load file."}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col bg-surface-1">
+			<div className="flex items-center justify-between border-b border-border px-3 py-1.5 text-[11px] text-text-tertiary">
+				<span className="truncate">{fileContent.path}</span>
+				<span>{Math.round(fileContent.size / 1024)} KB</span>
+			</div>
+			<div className="min-h-0 flex-1">
+				<Editor
+					height="100%"
+					path={fileContent.path}
+					defaultLanguage={getMonacoLanguage(fileContent.path)}
+					language={getMonacoLanguage(fileContent.path)}
+					value={fileContent.content ?? ""}
+					onMount={handleEditorMount}
+					onChange={handleEditorChange}
+					options={createEditorOptions(editorSettings, isSaving)}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/web-ui/src/components/code-browser/file-icons.tsx
+++ b/web-ui/src/components/code-browser/file-icons.tsx
@@ -1,0 +1,110 @@
+import type { CSSProperties, ReactElement } from "react";
+
+interface FileIconConfig {
+	label: string;
+	color: string;
+}
+
+const EXTENSION_ICONS: Record<string, FileIconConfig> = {
+	bash: { label: "SH", color: "#4EAA25" },
+	c: { label: "C", color: "#555555" },
+	cjs: { label: "JS", color: "#F0DB4F" },
+	cpp: { label: "C+", color: "#F34B7D" },
+	css: { label: "CSS", color: "#563D7C" },
+	dart: { label: "DT", color: "#00B4AB" },
+	env: { label: "ENV", color: "#ECD53F" },
+	go: { label: "GO", color: "#00ADD8" },
+	html: { label: "HT", color: "#E34C26" },
+	java: { label: "JV", color: "#B07219" },
+	js: { label: "JS", color: "#F0DB4F" },
+	json: { label: "{}", color: "#A8B1FF" },
+	jsonc: { label: "{}", color: "#A8B1FF" },
+	jsx: { label: "JX", color: "#F0DB4F" },
+	md: { label: "MD", color: "#519ABA" },
+	mdx: { label: "MX", color: "#519ABA" },
+	mjs: { label: "JS", color: "#F0DB4F" },
+	php: { label: "PH", color: "#4F5D95" },
+	proto: { label: "PB", color: "#6A9955" },
+	py: { label: "PY", color: "#3776AB" },
+	rb: { label: "RB", color: "#CC342D" },
+	rs: { label: "RS", color: "#DEA584" },
+	scss: { label: "SC", color: "#CD6799" },
+	sh: { label: "SH", color: "#4EAA25" },
+	sql: { label: "SQL", color: "#E38C00" },
+	svelte: { label: "SV", color: "#FF3E00" },
+	svg: { label: "SVG", color: "#FFB13B" },
+	swift: { label: "SW", color: "#F05138" },
+	toml: { label: "TM", color: "#9C4121" },
+	ts: { label: "TS", color: "#3178C6" },
+	tsx: { label: "TX", color: "#3178C6" },
+	txt: { label: "TX", color: "#666666" },
+	vue: { label: "VU", color: "#41B883" },
+	yaml: { label: "YM", color: "#CB171E" },
+	yml: { label: "YM", color: "#CB171E" },
+};
+
+const SPECIAL_FILE_ICONS: Record<string, FileIconConfig> = {
+	".gitignore": { label: "GI", color: "#888888" },
+	license: { label: "LC", color: "#D4A843" },
+	"package-lock.json": { label: "NP", color: "#CB3837" },
+	"package.json": { label: "NP", color: "#CB3837" },
+	"readme.md": { label: "RD", color: "#519ABA" },
+	"tsconfig.json": { label: "TS", color: "#3178C6" },
+	"vite.config.ts": { label: "VT", color: "#BD34FE" },
+};
+
+function getFileIconConfig(name: string): FileIconConfig {
+	const normalizedName = name.toLowerCase();
+	const specialConfig = SPECIAL_FILE_ICONS[normalizedName];
+	if (specialConfig) {
+		return specialConfig;
+	}
+
+	const lastDotIndex = normalizedName.lastIndexOf(".");
+	if (lastDotIndex === -1) {
+		return { label: "FI", color: "#6E7681" };
+	}
+
+	const extension = normalizedName.slice(lastDotIndex + 1);
+	return EXTENSION_ICONS[extension] ?? { label: extension.slice(0, 2).toUpperCase(), color: "#6E7681" };
+}
+
+export function FileTypeIcon({
+	name,
+	size = 16,
+	style,
+}: {
+	name: string;
+	size?: number;
+	style?: CSSProperties;
+}): ReactElement {
+	const config = getFileIconConfig(name);
+	const fontSize = config.label.length > 2 ? size * 0.48 : size * 0.62;
+
+	return (
+		<span
+			aria-hidden
+			style={{
+				display: "inline-flex",
+				alignItems: "center",
+				justifyContent: "center",
+				width: size,
+				height: size,
+				flexShrink: 0,
+				fontSize,
+				fontWeight: 700,
+				fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+				letterSpacing: "-0.02em",
+				lineHeight: 1,
+				color: config.color,
+				...style,
+			}}
+		>
+			{config.label}
+		</span>
+	);
+}
+
+export function isHiddenName(name: string): boolean {
+	return name.startsWith(".");
+}

--- a/web-ui/src/components/code-browser/file-search-dialog.tsx
+++ b/web-ui/src/components/code-browser/file-search-dialog.tsx
@@ -1,0 +1,170 @@
+import { Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { FileTypeIcon } from "@/components/code-browser/file-icons";
+import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
+
+interface FileSearchResult {
+	path: string;
+	name: string;
+}
+
+export interface FileSearchDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	workspaceId: string | null;
+	onSelectFile: (path: string) => void;
+}
+
+export function FileSearchDialog({
+	isOpen,
+	onClose,
+	workspaceId,
+	onSelectFile,
+}: FileSearchDialogProps): React.ReactElement | null {
+	const [query, setQuery] = useState("");
+	const [results, setResults] = useState<FileSearchResult[]>([]);
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	const [isSearching, setIsSearching] = useState(false);
+	const searchTimerRef = useRef<number | null>(null);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) {
+			setQuery("");
+			setResults([]);
+			setSelectedIndex(0);
+			return;
+		}
+
+		window.setTimeout(() => {
+			inputRef.current?.focus();
+		}, 50);
+	}, [isOpen]);
+
+	useEffect(() => {
+		if (!isOpen || !workspaceId) {
+			return;
+		}
+
+		if (searchTimerRef.current !== null) {
+			window.clearTimeout(searchTimerRef.current);
+		}
+
+		searchTimerRef.current = window.setTimeout(async () => {
+			setIsSearching(true);
+			try {
+				const client = getRuntimeTrpcClient(workspaceId);
+				const response = await client.workspace.searchFiles.query({
+					query,
+					limit: 50,
+				});
+				setResults(
+					response.files.map((file) => ({
+						path: file.path,
+						name: file.name,
+					})),
+				);
+				setSelectedIndex(0);
+			} catch {
+				setResults([]);
+			} finally {
+				setIsSearching(false);
+			}
+		}, 120);
+
+		return () => {
+			if (searchTimerRef.current !== null) {
+				window.clearTimeout(searchTimerRef.current);
+			}
+		};
+	}, [isOpen, query, workspaceId]);
+
+	const handleConfirm = useCallback(() => {
+		const selectedFile = results[selectedIndex];
+		if (!selectedFile) {
+			return;
+		}
+		onSelectFile(selectedFile.path);
+		onClose();
+	}, [onClose, onSelectFile, results, selectedIndex]);
+
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === "ArrowDown") {
+				event.preventDefault();
+				setSelectedIndex((current) => Math.min(current + 1, Math.max(results.length - 1, 0)));
+				return;
+			}
+			if (event.key === "ArrowUp") {
+				event.preventDefault();
+				setSelectedIndex((current) => Math.max(current - 1, 0));
+				return;
+			}
+			if (event.key === "Enter") {
+				event.preventDefault();
+				handleConfirm();
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				onClose();
+			}
+		},
+		[handleConfirm, onClose, results.length],
+	);
+
+	if (!isOpen) {
+		return null;
+	}
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]" onClick={onClose}>
+			<div
+				className="w-[min(520px,calc(100vw-32px))] overflow-hidden rounded-lg border border-border bg-surface-2 shadow-2xl"
+				onClick={(event) => event.stopPropagation()}
+			>
+				<div className="flex items-center gap-2 border-b border-border px-3">
+					<Search size={14} className="shrink-0 text-text-tertiary" />
+					<input
+						ref={inputRef}
+						type="text"
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+						onKeyDown={handleKeyDown}
+						placeholder="Search files by name"
+						className="h-11 flex-1 border-0 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary"
+					/>
+				</div>
+				<div className="max-h-[360px] overflow-y-auto">
+					{results.length > 0 ? (
+						results.map((result, index) => (
+							<button
+								key={result.path}
+								type="button"
+								className={[
+									"flex w-full cursor-pointer flex-col px-3 py-1.5 text-left",
+									index === selectedIndex ? "bg-accent/15" : "hover:bg-surface-3",
+								].join(" ")}
+								onClick={() => {
+									onSelectFile(result.path);
+									onClose();
+								}}
+							>
+								<span className="flex items-center gap-1.5 text-sm text-text-primary">
+									<FileTypeIcon name={result.name} size={14} />
+									{result.name}
+								</span>
+								<span className="ml-5 truncate font-mono text-[11px] text-text-tertiary">{result.path}</span>
+							</button>
+						))
+					) : query && !isSearching ? (
+						<div className="p-4 text-center text-sm text-text-tertiary">No files found</div>
+					) : !query ? (
+						<div className="p-4 text-center text-sm text-text-tertiary">Type to search</div>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/web-ui/src/components/code-browser/file-tree.tsx
+++ b/web-ui/src/components/code-browser/file-tree.tsx
@@ -1,0 +1,200 @@
+import { ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { FileTypeIcon, isHiddenName } from "@/components/code-browser/file-icons";
+import { Spinner } from "@/components/ui/spinner";
+import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
+
+interface FileTreeEntry {
+	name: string;
+	path: string;
+	type: "file" | "directory";
+}
+
+interface ExpandedDirectoryState {
+	entries: FileTreeEntry[] | null;
+	isLoading: boolean;
+}
+
+function TreeItem({
+	entry,
+	depth,
+	isSelected,
+	isExpanded,
+	isLoading,
+	onClickFile,
+	onToggleDirectory,
+}: {
+	entry: FileTreeEntry;
+	depth: number;
+	isSelected: boolean;
+	isExpanded: boolean;
+	isLoading: boolean;
+	onClickFile: (path: string) => void;
+	onToggleDirectory: (path: string) => void;
+}): React.ReactElement {
+	const isDirectory = entry.type === "directory";
+	const isHidden = isHiddenName(entry.name);
+
+	return (
+		<button
+			type="button"
+			className={[
+				"flex w-full items-center py-[3px] pr-2 text-left text-[12px] transition-colors",
+				isSelected ? "bg-accent/15 text-text-primary" : "text-text-secondary hover:bg-surface-2",
+				isHidden ? "opacity-50" : "",
+			].join(" ")}
+			style={{ paddingLeft: 8 + depth * 16 }}
+			onClick={() => {
+				if (isDirectory) {
+					onToggleDirectory(entry.path);
+					return;
+				}
+				onClickFile(entry.path);
+			}}
+		>
+			{isDirectory ? (
+				<ChevronRight
+					size={14}
+					className={["mr-0.5 shrink-0 transition-transform", isExpanded ? "rotate-90" : ""].join(" ")}
+				/>
+			) : (
+				<span className="mr-0.5 w-[14px] shrink-0" />
+			)}
+			{!isDirectory ? <FileTypeIcon name={entry.name} size={15} style={{ marginRight: 4 }} /> : null}
+			<span className="truncate">{entry.name}</span>
+			{isLoading ? <Spinner size={10} className="ml-1" /> : null}
+		</button>
+	);
+}
+
+export function FileTree({
+	workspaceId,
+	selectedFilePath,
+	onSelectFile,
+}: {
+	workspaceId: string | null;
+	selectedFilePath: string | null;
+	onSelectFile: (path: string) => void;
+}): React.ReactElement {
+	const [rootEntries, setRootEntries] = useState<FileTreeEntry[] | null>(null);
+	const [isRootLoading, setIsRootLoading] = useState(false);
+	const [expandedDirectories, setExpandedDirectories] = useState<Record<string, ExpandedDirectoryState>>({});
+	const loadedWorkspaceIdRef = useRef<string | null>(null);
+
+	const loadDirectory = useCallback(
+		async (path: string): Promise<FileTreeEntry[]> => {
+			if (!workspaceId) {
+				return [];
+			}
+			const client = getRuntimeTrpcClient(workspaceId);
+			const response = await client.workspace.listDirectory.query({ path });
+			return response.entries;
+		},
+		[workspaceId],
+	);
+
+	useEffect(() => {
+		if (!workspaceId) {
+			loadedWorkspaceIdRef.current = null;
+			setRootEntries(null);
+			setExpandedDirectories({});
+			return;
+		}
+		if (loadedWorkspaceIdRef.current === workspaceId) {
+			return;
+		}
+
+		loadedWorkspaceIdRef.current = workspaceId;
+		setIsRootLoading(true);
+		setExpandedDirectories({});
+
+		void loadDirectory("")
+			.then((entries) => {
+				setRootEntries(entries);
+			})
+			.catch(() => {
+				setRootEntries([]);
+			})
+			.finally(() => {
+				setIsRootLoading(false);
+			});
+	}, [loadDirectory, workspaceId]);
+
+	const handleToggleDirectory = useCallback(
+		(path: string) => {
+			if (expandedDirectories[path]) {
+				setExpandedDirectories((current) => {
+					const next = { ...current };
+					delete next[path];
+					return next;
+				});
+				return;
+			}
+
+			setExpandedDirectories((current) => ({
+				...current,
+				[path]: { entries: null, isLoading: true },
+			}));
+
+			void loadDirectory(path)
+				.then((entries) => {
+					setExpandedDirectories((current) => ({
+						...current,
+						[path]: { entries, isLoading: false },
+					}));
+				})
+				.catch(() => {
+					setExpandedDirectories((current) => ({
+						...current,
+						[path]: { entries: [], isLoading: false },
+					}));
+				});
+		},
+		[expandedDirectories, loadDirectory],
+	);
+
+	const renderEntries = useCallback(
+		(entries: FileTreeEntry[], depth: number): React.ReactElement[] =>
+			entries.map((entry) => {
+				const expandedState = expandedDirectories[entry.path];
+				const isExpanded = expandedState !== undefined;
+				return (
+					<div key={entry.path}>
+						<TreeItem
+							entry={entry}
+							depth={depth}
+							isSelected={selectedFilePath === entry.path}
+							isExpanded={isExpanded}
+							isLoading={expandedState?.isLoading ?? false}
+							onClickFile={onSelectFile}
+							onToggleDirectory={handleToggleDirectory}
+						/>
+						{isExpanded && expandedState?.entries ? renderEntries(expandedState.entries, depth + 1) : null}
+					</div>
+				);
+			}),
+		[expandedDirectories, handleToggleDirectory, onSelectFile, selectedFilePath],
+	);
+
+	const treeContent = useMemo(() => {
+		if (!rootEntries) {
+			return null;
+		}
+		return renderEntries(rootEntries, 0);
+	}, [renderEntries, rootEntries]);
+
+	if (isRootLoading) {
+		return (
+			<div className="flex flex-1 items-center justify-center p-6">
+				<Spinner size={20} />
+			</div>
+		);
+	}
+
+	if (!rootEntries || rootEntries.length === 0) {
+		return <div className="p-3 text-xs text-text-tertiary">No files found</div>;
+	}
+
+	return <div className="min-h-0 flex-1 overflow-auto">{treeContent}</div>;
+}

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -447,11 +447,13 @@ const ESSENTIAL_SHORTCUTS = [
 	{ keys: [MOD, "Shift", "S"], label: "Settings" },
 	{ keys: ["Click", MOD], label: "Hold to link tasks" },
 	{ keys: [MOD, "G"], label: "Toggle git view" },
+	{ keys: [MOD, "Shift", "E"], label: "Toggle code editor" },
 	{ keys: [MOD, "J"], label: "Toggle terminal" },
 ];
 
 const MORE_SHORTCUTS = [
 	{ keys: [MOD, "Shift", "A"], label: "Toggle plan / act" },
+	{ keys: [MOD, "Shift", "P"], label: "Search files" },
 	{ keys: [ALT, "Shift", "Enter"], label: "Start and open task" },
 	{ keys: [MOD, "M"], label: "Expand terminal" },
 	{ keys: ["Esc"], label: "Close / back" },

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -8,9 +8,11 @@ import {
 	ChevronDown,
 	CircleArrowDown,
 	Command,
+	Files,
 	GitBranch,
 	Play,
 	Plus,
+	Search,
 	Settings,
 	Terminal,
 } from "lucide-react";
@@ -290,8 +292,11 @@ export function TopBar({
 	onToggleTerminal,
 	isTerminalOpen,
 	isTerminalLoading,
+	onToggleCodeBrowser,
+	isCodeBrowserOpen,
 	onToggleGitHistory,
 	isGitHistoryOpen,
+	onOpenFileSearch,
 	onOpenSettings,
 	showDebugButton,
 	onOpenDebugDialog,
@@ -324,8 +329,11 @@ export function TopBar({
 	onToggleTerminal?: () => void;
 	isTerminalOpen?: boolean;
 	isTerminalLoading?: boolean;
+	onToggleCodeBrowser?: () => void;
+	isCodeBrowserOpen?: boolean;
 	onToggleGitHistory?: () => void;
 	isGitHistoryOpen?: boolean;
+	onOpenFileSearch?: () => void;
 	onOpenSettings?: (section?: SettingsSection) => void;
 	showDebugButton?: boolean;
 	onOpenDebugDialog?: () => void;
@@ -586,6 +594,30 @@ export function TopBar({
 								disabled={Boolean(isTerminalLoading)}
 								aria-label={isTerminalOpen ? "Close terminal" : "Open terminal"}
 								className="ml-2"
+							/>
+						</Tooltip>
+					) : null}
+					{onToggleCodeBrowser ? (
+						<Tooltip side="bottom" content="Toggle code browser (Cmd/Ctrl+Shift+E)">
+							<Button
+								variant="ghost"
+								size="sm"
+								icon={<Files size={16} />}
+								onClick={onToggleCodeBrowser}
+								aria-label={isCodeBrowserOpen ? "Close code browser" : "Open code browser"}
+								className={cn("ml-0.5", isCodeBrowserOpen ? "text-text-primary bg-surface-3" : "")}
+							/>
+						</Tooltip>
+					) : null}
+					{onOpenFileSearch ? (
+						<Tooltip side="bottom" content="Search files (Cmd/Ctrl+Shift+P)">
+							<Button
+								variant="ghost"
+								size="sm"
+								icon={<Search size={16} />}
+								onClick={onOpenFileSearch}
+								aria-label="Search files"
+								className="ml-0.5"
 							/>
 						</Tooltip>
 					) : null}

--- a/web-ui/src/hooks/use-app-hotkeys.ts
+++ b/web-ui/src/hooks/use-app-hotkeys.ts
@@ -21,6 +21,8 @@ interface UseAppHotkeysInput {
 	handleToggleGitHistory: () => void;
 	handleCloseGitHistory: () => void;
 	onStartAllTasks: () => void;
+	handleOpenFileSearch?: () => void;
+	handleToggleCodeBrowser?: () => void;
 }
 
 export function useAppHotkeys({
@@ -38,6 +40,8 @@ export function useAppHotkeys({
 	handleToggleGitHistory,
 	handleCloseGitHistory,
 	onStartAllTasks,
+	handleOpenFileSearch,
+	handleToggleCodeBrowser,
 }: UseAppHotkeysInput): void {
 	useHotkeys(
 		"mod+j",
@@ -147,5 +151,31 @@ export function useAppHotkeys({
 			preventDefault: true,
 		},
 		[handleCloseGitHistory, isHomeGitHistoryOpen, selectedCard],
+	);
+
+	useHotkeys(
+		"mod+shift+p",
+		() => {
+			handleOpenFileSearch?.();
+		},
+		{
+			enableOnFormTags: true,
+			enableOnContentEditable: true,
+			preventDefault: true,
+		},
+		[handleOpenFileSearch],
+	);
+
+	useHotkeys(
+		"mod+shift+e",
+		() => {
+			handleToggleCodeBrowser?.();
+		},
+		{
+			enableOnFormTags: true,
+			enableOnContentEditable: true,
+			preventDefault: true,
+		},
+		[handleToggleCodeBrowser],
 	);
 }


### PR DESCRIPTION
## Summary
- ワークスペース内のファイルをブラウザ上で閲覧・編集できるMonacoベースのコードブラウザを追加
- バックエンドにディレクトリ一覧、ファイル読み書き、git diff行ステータスのAPIを追加
- `browse-workspace-files.ts` のユニットテストを追加（12テスト）

## Test plan
- [x] `vitest run test/runtime/browse-workspace-files.test.ts` — 12テスト全パス
- [x] TypeScript型チェック通過
- [x] Biome lint通過