### PR TITLE
feat: settings dialog v3 redesign - multi-panel layout with sidebar navigation

### DIFF
--- a/src/cline-sdk/cline-session-state.ts
+++ b/src/cline-sdk/cline-session-state.ts
@@ -34,7 +34,7 @@ export function isCreditLimitError(errorMessage: string | null): boolean {
 	if (CREDIT_LIMIT_PATTERNS.some((pattern) => normalized.includes(pattern))) {
 		return true;
 	}
-	return (normalized.includes("402") && (normalized.includes("balance") || normalized.includes("credit")));
+	return normalized.includes("402") && (normalized.includes("balance") || normalized.includes("credit"));
 }
 
 const WINDOWS_INVALID_SESSION_ID_CHARS = /[<>:"/\\|?*]/g;

--- a/test/runtime/cline-sdk/cline-event-adapter.test.ts
+++ b/test/runtime/cline-sdk/cline-event-adapter.test.ts
@@ -481,7 +481,8 @@ describe("applyClineSessionEvent", () => {
 					sessionId: "session-1",
 					event: {
 						type: "notice",
-						message: "The previous turn failed with 402 Insufficient balance. Retry and continue from the latest state",
+						message:
+							"The previous turn failed with 402 Insufficient balance. Retry and continue from the latest state",
 						displayRole: "system",
 						reason: "recovery",
 					},

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -394,7 +394,9 @@ export function ProjectNavigationPanel({
 							</button>
 						) : null}
 					</div>
+					<div className="border-t border-border mx-3" />
 					<ShortcutsCard />
+					<div className="border-t border-border mx-3" />
 					<ProjectSupportFooter
 						shouldShowFeaturebaseFeedback={shouldShowFeaturebaseFeedback}
 						featurebaseFeedbackState={featurebaseFeedbackState}

--- a/web-ui/src/components/runtime-settings-dialog.test.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.test.tsx
@@ -51,6 +51,15 @@ vi.mock("@/hooks/use-runtime-settings-cline-mcp-controller", () => ({
 	useRuntimeSettingsClineMcpController: () => ({
 		hasUnsavedChanges: false,
 		saveMcpSettings: vi.fn(async () => ({ ok: true })),
+		mcpServers: [],
+		setMcpServers: vi.fn(),
+		isLoadingMcpSettings: false,
+		isSavingMcpSettings: false,
+		mcpSettingsPath: "",
+		mcpAuthStatusByServerName: {},
+		authenticatingMcpServerName: null,
+		runMcpServerOauth: vi.fn(async () => ({ ok: true })),
+		linearMcpPreset: { status: "not-configured", isSettingUp: false, setup: vi.fn(async () => ({ ok: true })) },
 	}),
 }));
 

--- a/web-ui/src/components/runtime-settings-dialog.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.tsx
@@ -1,29 +1,21 @@
 // Settings dialog composition for Kanban.
 // Generic app settings live here, while Cline-specific provider state and
 // side effects should stay in use-runtime-settings-cline-controller.ts.
-import * as RadixCheckbox from "@radix-ui/react-checkbox";
-import * as RadixPopover from "@radix-ui/react-popover";
-import * as RadixSwitch from "@radix-ui/react-switch";
 import { getRuntimeAgentCatalogEntry, getRuntimeLaunchSupportedAgentCatalog } from "@runtime-agent-catalog";
 import { areRuntimeProjectShortcutsEqual } from "@runtime-shortcuts";
-import { Check, ChevronDown, Circle, CircleDot, ExternalLink, Plus, Settings, X } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AccountOrganizationSection } from "@/components/shared/account-organization-section";
-import { ClineSetupSection } from "@/components/shared/cline-setup-section";
+import type { AgentRowModel } from "@/components/settings/agent-panel";
 import {
-	getRuntimeShortcutIconComponent,
-	getRuntimeShortcutPickerOption,
-	RUNTIME_SHORTCUT_ICON_OPTIONS,
-	type RuntimeShortcutIconOption,
-	type RuntimeShortcutPickerIconId,
-} from "@/components/shared/runtime-shortcut-icons";
+	ScrollableSettingsBody,
+	type ScrollableSettingsBodyHandle,
+} from "@/components/settings/scrollable-settings-body";
+import { SettingsNav, type SettingsNavSection } from "@/components/settings/settings-nav";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/components/ui/cn";
-import { Dialog, DialogBody, DialogFooter, DialogHeader } from "@/components/ui/dialog";
-import { TASK_GIT_BASE_REF_PROMPT_VARIABLE, type TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
+import { Dialog, DialogFooter, DialogHeader } from "@/components/ui/dialog";
 import { useRuntimeSettingsClineController } from "@/hooks/use-runtime-settings-cline-controller";
 import { useRuntimeSettingsClineMcpController } from "@/hooks/use-runtime-settings-cline-mcp-controller";
-import { previewThemeId, readStoredThemeId, saveThemeId, THEMES, type ThemeId } from "@/hooks/use-theme";
+import { previewThemeId, readStoredThemeId, saveThemeId, type ThemeId } from "@/hooks/use-theme";
 import { useLayoutCustomizations } from "@/resize/layout-customizations";
 import { openFileOnHost } from "@/runtime/runtime-config-query";
 import type {
@@ -38,16 +30,11 @@ import {
 	getBrowserNotificationPermission,
 	requestBrowserNotificationPermission,
 } from "@/utils/notification-permission";
-import { formatPathForDisplay } from "@/utils/path-display";
-import { useUnmount, useWindowEvent } from "@/utils/react-use";
+import { useWindowEvent } from "@/utils/react-use";
 
-interface RuntimeSettingsAgentRowModel {
-	id: RuntimeAgentId;
-	label: string;
-	binary: string;
-	command: string;
-	installed: boolean | null;
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function quoteCommandPartForDisplay(part: string): string {
 	if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(part)) {
@@ -68,218 +55,13 @@ function normalizeTemplateForComparison(value: string): string {
 	return value.replaceAll("\r\n", "\n").trim();
 }
 
-const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string }> = [
-	{ value: "commit", label: "Commit" },
-	{ value: "pr", label: "Make PR" },
-];
-
 export type RuntimeSettingsSection = "shortcuts";
 
 const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid"];
 
-function getShortcutIconOption(icon: string | undefined): RuntimeShortcutIconOption {
-	return getRuntimeShortcutPickerOption(icon);
-}
-
-function ShortcutIconComponent({ icon, size = 14 }: { icon: string | undefined; size?: number }): React.ReactElement {
-	const Component = getRuntimeShortcutIconComponent(icon);
-	return <Component size={size} />;
-}
-
-function formatNotificationPermissionStatus(permission: BrowserNotificationPermission): string {
-	if (permission === "default") {
-		return "not requested yet";
-	}
-	return permission;
-}
-
-function getNextShortcutLabel(shortcuts: RuntimeProjectShortcut[], baseLabel: string): string {
-	const normalizedTakenLabels = new Set(
-		shortcuts.map((shortcut) => shortcut.label.trim().toLowerCase()).filter((label) => label.length > 0),
-	);
-	const normalizedBaseLabel = baseLabel.trim().toLowerCase();
-	if (!normalizedTakenLabels.has(normalizedBaseLabel)) {
-		return baseLabel;
-	}
-
-	let suffix = 2;
-	while (normalizedTakenLabels.has(`${normalizedBaseLabel} ${suffix}`)) {
-		suffix += 1;
-	}
-	return `${baseLabel} ${suffix}`;
-}
-
-function AgentRow({
-	agent,
-	isSelected,
-	onSelect,
-	disabled,
-}: {
-	agent: RuntimeSettingsAgentRowModel;
-	isSelected: boolean;
-	onSelect: () => void;
-	disabled: boolean;
-}): React.ReactElement {
-	const installUrl = getRuntimeAgentCatalogEntry(agent.id)?.installUrl;
-	const isNativeCline = agent.id === "cline";
-	const isInstalled = agent.installed === true;
-	const isInstallStatusPending = !isNativeCline && agent.installed === null;
-
-	return (
-		<div
-			role="button"
-			tabIndex={0}
-			onClick={() => {
-				if (isInstalled && !disabled) {
-					onSelect();
-				}
-			}}
-			onKeyDown={(event) => {
-				if (event.key === "Enter" && isInstalled && !disabled) {
-					onSelect();
-				}
-			}}
-			className="flex items-center justify-between gap-3 py-1.5"
-			style={{ cursor: isInstalled ? "pointer" : "default" }}
-		>
-			<div className="flex items-start gap-2 min-w-0">
-				{isSelected ? (
-					<CircleDot size={16} className="text-accent mt-0.5 shrink-0" />
-				) : (
-					<Circle
-						size={16}
-						className={cn("mt-0.5 shrink-0", !isInstalled ? "text-text-tertiary" : "text-text-secondary")}
-					/>
-				)}
-				<div className="min-w-0">
-					<div className="flex items-center gap-2">
-						<span className="text-[13px] text-text-primary">{agent.label}</span>
-						{!isNativeCline && isInstalled ? (
-							<span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-status-green/10 text-status-green">
-								Installed
-							</span>
-						) : isInstallStatusPending ? (
-							<span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium bg-surface-3 text-text-secondary">
-								Checking...
-							</span>
-						) : null}
-					</div>
-					{agent.command ? (
-						<p className="text-text-secondary font-mono text-xs mt-0.5 m-0">{agent.command}</p>
-					) : null}
-				</div>
-			</div>
-			{!isNativeCline && agent.installed === false && installUrl ? (
-				<a
-					href={installUrl}
-					target="_blank"
-					rel="noreferrer"
-					onClick={(event: React.MouseEvent) => event.stopPropagation()}
-					className="inline-flex items-center justify-center rounded-md font-medium duration-150 cursor-default select-none h-7 px-2 text-xs bg-surface-2 border border-border text-text-primary hover:bg-surface-3 hover:border-border-bright"
-				>
-					Install
-				</a>
-			) : !isNativeCline && agent.installed === false ? (
-				<Button size="sm" disabled>
-					Install
-				</Button>
-			) : null}
-		</div>
-	);
-}
-
-function InlineUtilityButton({
-	text,
-	onClick,
-	disabled,
-	monospace,
-	widthCh,
-}: {
-	text: string;
-	onClick: () => void;
-	disabled?: boolean;
-	monospace?: boolean;
-	widthCh?: number;
-}): React.ReactElement {
-	return (
-		<Button
-			size="sm"
-			disabled={disabled}
-			onClick={onClick}
-			className={cn(monospace && "font-mono")}
-			style={{
-				fontSize: 10,
-				verticalAlign: "middle",
-				...(typeof widthCh === "number"
-					? {
-							width: `${widthCh}ch`,
-							justifyContent: "center",
-						}
-					: {}),
-			}}
-		>
-			{text}
-		</Button>
-	);
-}
-
-function ShortcutIconPicker({
-	value,
-	onSelect,
-}: {
-	value: string | undefined;
-	onSelect: (icon: RuntimeShortcutPickerIconId) => void;
-}): React.ReactElement {
-	const [open, setOpen] = useState(false);
-	const selectedOption = getShortcutIconOption(value);
-
-	return (
-		<RadixPopover.Root open={open} onOpenChange={setOpen}>
-			<RadixPopover.Trigger asChild>
-				<button
-					type="button"
-					aria-label={`Shortcut icon: ${selectedOption.label}`}
-					className="inline-flex items-center gap-1 h-7 px-1.5 rounded-md border border-border bg-surface-2 text-text-primary hover:bg-surface-3"
-				>
-					<ShortcutIconComponent icon={value} size={14} />
-					<ChevronDown size={12} />
-				</button>
-			</RadixPopover.Trigger>
-			<RadixPopover.Portal>
-				<RadixPopover.Content
-					side="bottom"
-					align="start"
-					sideOffset={4}
-					className="z-50 rounded-md border border-border bg-surface-2 p-1 shadow-lg"
-					style={{ animation: "kb-tooltip-show 100ms ease" }}
-				>
-					<div className="flex gap-0.5">
-						{RUNTIME_SHORTCUT_ICON_OPTIONS.map((option) => {
-							const IconComponent = getRuntimeShortcutIconComponent(option.value);
-							return (
-								<button
-									key={option.value}
-									type="button"
-									aria-label={option.label}
-									className={cn(
-										"p-1.5 rounded hover:bg-surface-3",
-										selectedOption.value === option.value && "bg-surface-3",
-									)}
-									onClick={() => {
-										onSelect(option.value);
-										setOpen(false);
-									}}
-								>
-									<IconComponent size={14} />
-								</button>
-							);
-						})}
-					</div>
-				</RadixPopover.Content>
-			</RadixPopover.Portal>
-		</RadixPopover.Root>
-	);
-}
+// ---------------------------------------------------------------------------
+// Main dialog export
+// ---------------------------------------------------------------------------
 
 export function RuntimeSettingsDialog({
 	open,
@@ -302,6 +84,7 @@ export function RuntimeSettingsDialog({
 }): React.ReactElement {
 	const { config, isLoading, isSaving, save } = useRuntimeConfig(open, workspaceId, initialConfig);
 	const { resetLayoutCustomizations } = useLayoutCustomizations();
+	const [activeNavSection, setActiveNavSection] = useState<SettingsNavSection>("general");
 	const [selectedAgentId, setSelectedAgentId] = useState<RuntimeAgentId>("claude");
 	const [agentAutonomousModeEnabled, setAgentAutonomousModeEnabled] = useState(true);
 	const [readyForReviewNotificationsEnabled, setReadyForReviewNotificationsEnabled] = useState(true);
@@ -311,35 +94,17 @@ export function RuntimeSettingsDialog({
 	const [shortcuts, setShortcuts] = useState<RuntimeProjectShortcut[]>([]);
 	const [commitPromptTemplate, setCommitPromptTemplate] = useState("");
 	const [openPrPromptTemplate, setOpenPrPromptTemplate] = useState("");
-	const [selectedPromptVariant, setSelectedPromptVariant] = useState<TaskGitAction>("commit");
-	const [copiedVariableToken, setCopiedVariableToken] = useState<string | null>(null);
 	const [saveError, setSaveError] = useState<string | null>(null);
-	const [pendingShortcutScrollIndex, setPendingShortcutScrollIndex] = useState<number | null>(null);
-	const copiedVariableResetTimerRef = useRef<number | null>(null);
-	const shortcutsSectionRef = useRef<HTMLHeadingElement | null>(null);
-	const shortcutRowRefs = useRef<Array<HTMLDivElement | null>>([]);
+	const scrollableBodyRef = useRef<ScrollableSettingsBodyHandle | null>(null);
 	const controlsDisabled = isLoading || isSaving || config === null;
 	const commitPromptTemplateDefault = config?.commitPromptTemplateDefault ?? "";
 	const openPrPromptTemplateDefault = config?.openPrPromptTemplateDefault ?? "";
-	const isCommitPromptAtDefault =
-		normalizeTemplateForComparison(commitPromptTemplate) ===
-		normalizeTemplateForComparison(commitPromptTemplateDefault);
-	const isOpenPrPromptAtDefault =
-		normalizeTemplateForComparison(openPrPromptTemplate) ===
-		normalizeTemplateForComparison(openPrPromptTemplateDefault);
-	const selectedPromptValue = selectedPromptVariant === "commit" ? commitPromptTemplate : openPrPromptTemplate;
-	const selectedPromptDefaultValue =
-		selectedPromptVariant === "commit" ? commitPromptTemplateDefault : openPrPromptTemplateDefault;
-	const isSelectedPromptAtDefault =
-		selectedPromptVariant === "commit" ? isCommitPromptAtDefault : isOpenPrPromptAtDefault;
-	const selectedPromptPlaceholder =
-		selectedPromptVariant === "commit" ? "Commit prompt template" : "PR prompt template";
-	const bypassPermissionsCheckboxId = "runtime-settings-bypass-permissions";
+
 	const refreshNotificationPermission = useCallback(() => {
 		setNotificationPermission(getBrowserNotificationPermission());
 	}, []);
 
-	const supportedAgents = useMemo<RuntimeSettingsAgentRowModel[]>(() => {
+	const agentModels = useMemo<AgentRowModel[]>(() => {
 		const agents =
 			config?.agents.map((agent) => ({
 				id: agent.id,
@@ -364,16 +129,17 @@ export function RuntimeSettingsDialog({
 			command: buildDisplayedAgentCommand(agent.id, agent.binary, agentAutonomousModeEnabled),
 		}));
 	}, [agentAutonomousModeEnabled, config?.agents]);
-	const displayedAgents = useMemo(() => supportedAgents, [supportedAgents]);
+
 	const configuredAgentId = config?.selectedAgentId ?? null;
-	const firstInstalledAgentId = displayedAgents.find((agent) => agent.installed)?.id;
-	const fallbackAgentId = firstInstalledAgentId ?? displayedAgents[0]?.id ?? "claude";
+	const firstInstalledAgentId = agentModels.find((agent) => agent.installed)?.id;
+	const fallbackAgentId = firstInstalledAgentId ?? agentModels[0]?.id ?? "claude";
 	const initialSelectedAgentId = configuredAgentId ?? fallbackAgentId;
 	const initialAgentAutonomousModeEnabled = config?.agentAutonomousModeEnabled ?? true;
 	const initialReadyForReviewNotificationsEnabled = config?.readyForReviewNotificationsEnabled ?? true;
 	const initialShortcuts = config?.shortcuts ?? [];
 	const initialCommitPromptTemplate = config?.commitPromptTemplate ?? "";
 	const initialOpenPrPromptTemplate = config?.openPrPromptTemplate ?? "";
+
 	const clineSettings = useRuntimeSettingsClineController({
 		open,
 		workspaceId,
@@ -386,6 +152,7 @@ export function RuntimeSettingsDialog({
 		selectedAgentId,
 		liveAuthStatuses: liveMcpAuthStatuses,
 	});
+
 	const hasUnsavedChanges = useMemo(() => {
 		if (!config) {
 			return false;
@@ -441,6 +208,30 @@ export function RuntimeSettingsDialog({
 		shortcuts,
 	]);
 
+	// Map initialSection to nav section on open
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		if (initialSection === "shortcuts") {
+			setActiveNavSection("shortcuts");
+		}
+	}, [initialSection, open]);
+
+	// Scroll to initialSection after mount
+	useEffect(() => {
+		if (!open || initialSection !== "shortcuts") {
+			return;
+		}
+		const timeout = window.setTimeout(() => {
+			scrollableBodyRef.current?.scrollToSection("shortcuts");
+		}, 500);
+		return () => {
+			window.clearTimeout(timeout);
+		};
+	}, [initialSection, open]);
+
+	// Sync local state from config when dialog opens or config changes
 	useEffect(() => {
 		if (!open) {
 			return;
@@ -463,6 +254,7 @@ export function RuntimeSettingsDialog({
 		open,
 	]);
 
+	// Reset theme draft when dialog opens
 	useEffect(() => {
 		if (!open) {
 			return;
@@ -472,6 +264,7 @@ export function RuntimeSettingsDialog({
 		setDraftThemeId(persistedThemeId);
 	}, [open]);
 
+	// Refresh notification permission when dialog opens or window regains focus
 	useEffect(() => {
 		if (!open) {
 			return;
@@ -480,72 +273,12 @@ export function RuntimeSettingsDialog({
 	}, [open, refreshNotificationPermission]);
 	useWindowEvent("focus", open ? refreshNotificationPermission : null);
 
+	// Redirect to agent panel if MCP was selected but agent changed from cline
 	useEffect(() => {
-		if (!open || initialSection !== "shortcuts") {
-			return;
+		if (activeNavSection === "mcp" && selectedAgentId !== "cline") {
+			setActiveNavSection("agent");
 		}
-		const timeout = window.setTimeout(() => {
-			shortcutsSectionRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
-		}, 500);
-		return () => {
-			window.clearTimeout(timeout);
-		};
-	}, [initialSection, open]);
-
-	useEffect(() => {
-		if (pendingShortcutScrollIndex === null) {
-			return;
-		}
-		const frame = window.requestAnimationFrame(() => {
-			const target = shortcutRowRefs.current[pendingShortcutScrollIndex] ?? null;
-			if (target) {
-				target.scrollIntoView({ block: "nearest", behavior: "smooth" });
-				const firstInput = target.querySelector("input");
-				firstInput?.focus();
-				setPendingShortcutScrollIndex(null);
-			}
-		});
-		return () => {
-			window.cancelAnimationFrame(frame);
-		};
-	}, [pendingShortcutScrollIndex, shortcuts]);
-
-	useUnmount(() => {
-		if (copiedVariableResetTimerRef.current !== null) {
-			window.clearTimeout(copiedVariableResetTimerRef.current);
-			copiedVariableResetTimerRef.current = null;
-		}
-	});
-
-	const handleCopyVariableToken = (token: string) => {
-		void (async () => {
-			try {
-				await navigator.clipboard.writeText(token);
-				setCopiedVariableToken(token);
-				if (copiedVariableResetTimerRef.current !== null) {
-					window.clearTimeout(copiedVariableResetTimerRef.current);
-				}
-				copiedVariableResetTimerRef.current = window.setTimeout(() => {
-					setCopiedVariableToken((current) => (current === token ? null : current));
-					copiedVariableResetTimerRef.current = null;
-				}, 2000);
-			} catch {
-				// Ignore clipboard failures.
-			}
-		})();
-	};
-
-	const handleSelectedPromptChange = (value: string) => {
-		if (selectedPromptVariant === "commit") {
-			setCommitPromptTemplate(value);
-			return;
-		}
-		setOpenPrPromptTemplate(value);
-	};
-
-	const handleResetSelectedPrompt = () => {
-		handleSelectedPromptChange(selectedPromptDefaultValue);
-	};
+	}, [activeNavSection, selectedAgentId]);
 
 	const handleSave = async () => {
 		setSaveError(null);
@@ -553,7 +286,7 @@ export function RuntimeSettingsDialog({
 			setSaveError("Runtime settings are still loading. Try again in a moment.");
 			return;
 		}
-		const selectedAgent = displayedAgents.find((agent) => agent.id === selectedAgentId);
+		const selectedAgent = agentModels.find((agent) => agent.id === selectedAgentId);
 		if (!selectedAgent || selectedAgent.installed !== true) {
 			setSaveError("Selected agent is not installed. Install it first or choose an installed agent.");
 			return;
@@ -635,301 +368,65 @@ export function RuntimeSettingsDialog({
 		[draftThemeId, onOpenChange],
 	);
 
+	const showMcpInNav = selectedAgentId === "cline";
+
+	const handleNavSectionChange = useCallback((section: SettingsNavSection) => {
+		setActiveNavSection(section);
+		scrollableBodyRef.current?.scrollToSection(section);
+	}, []);
+
 	return (
-		<Dialog open={open} onOpenChange={handleDialogOpenChange}>
-			<DialogHeader title="Settings" icon={<Settings size={16} />} />
-			<DialogBody>
-				<h5 className="font-semibold text-text-primary m-0">Global</h5>
-				<p
-					className="text-text-secondary font-mono text-xs m-0 break-all"
-					style={{ cursor: config?.globalConfigPath ? "pointer" : undefined }}
-					onClick={() => {
-						if (config?.globalConfigPath) {
-							handleOpenFilePath(config.globalConfigPath);
-						}
-					}}
-				>
-					{config?.globalConfigPath
-						? formatPathForDisplay(config.globalConfigPath)
-						: "~/.cline/kanban/config.json"}
-					{config?.globalConfigPath ? <ExternalLink size={12} className="inline ml-1.5 align-middle" /> : null}
-				</p>
+		<Dialog open={open} onOpenChange={handleDialogOpenChange} contentClassName="!max-w-[780px]">
+			<DialogHeader title="Settings" />
 
-				<h6 className="font-semibold text-text-primary mt-3 mb-0">Agent</h6>
-				{displayedAgents.map((agent) => (
-					<AgentRow
-						key={agent.id}
-						agent={agent}
-						isSelected={agent.id === selectedAgentId}
-						onSelect={() => setSelectedAgentId(agent.id)}
-						disabled={controlsDisabled}
+			<div className="flex h-[600px]">
+				{/* Sidebar navigation */}
+				<div className="w-[180px] shrink-0 border-r border-border bg-surface-1 overflow-y-auto">
+					<SettingsNav
+						activeSection={activeNavSection}
+						onSectionChange={handleNavSectionChange}
+						showMcp={showMcpInNav}
 					/>
-				))}
-				{config === null ? (
-					<p className="text-text-secondary py-2">Checking which CLIs are installed for this project...</p>
-				) : null}
-				<label
-					htmlFor={bypassPermissionsCheckboxId}
-					className="flex items-center gap-2 text-[13px] text-text-primary mt-2 cursor-pointer"
-				>
-					<RadixCheckbox.Root
-						id={bypassPermissionsCheckboxId}
-						aria-label="Enable bypass permissions flag"
-						checked={agentAutonomousModeEnabled}
-						disabled={controlsDisabled}
-						onCheckedChange={(checked) => setAgentAutonomousModeEnabled(checked === true)}
-						className="flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-border bg-surface-2 data-[state=checked]:bg-accent data-[state=checked]:border-accent disabled:cursor-default disabled:opacity-40"
-					>
-						<RadixCheckbox.Indicator>
-							<Check size={12} className="text-white" />
-						</RadixCheckbox.Indicator>
-					</RadixCheckbox.Root>
-					<span>Enable bypass permissions flag</span>
-				</label>
-				<p className="text-text-secondary text-[13px] ml-6 mt-0 mb-0">
-					Allows agents to use tools without stopping for permission. Use at your own risk.
-				</p>
-
-				{selectedAgentId === "cline" ? (
-					<ClineSetupSection
-						controller={clineSettings}
-						mcpController={clineMcpSettings}
-						controlsDisabled={controlsDisabled}
-						workspaceId={workspaceId}
-						accountSection={
-							clineSettings.providerId.trim() === "cline" ? (
-								<AccountOrganizationSection
-									workspaceId={workspaceId}
-									open={open}
-									onAccountSwitched={onAccountSwitched}
-								/>
-							) : null
-						}
-						onError={setSaveError}
-					/>
-				) : null}
-
-				<div className="flex items-center justify-between mt-4 mb-1">
-					<h6 className="font-semibold text-text-primary m-0">Git button prompts</h6>
 				</div>
-				<p className="text-text-secondary text-[13px] mt-0 mb-2">
-					Modify the prompts sent to the agent when using Commit or Make PR on tasks in Review.
-				</p>
-				<div className="flex items-center justify-between gap-2 mb-2">
-					<select
-						value={selectedPromptVariant}
-						onChange={(event) => setSelectedPromptVariant(event.target.value as TaskGitAction)}
-						disabled={controlsDisabled}
-						className="h-8 rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary focus:border-border-focus focus:outline-none"
-						style={{ minWidth: 220 }}
-					>
-						{GIT_PROMPT_VARIANT_OPTIONS.map((option) => (
-							<option key={option.value} value={option.value}>
-								{option.label}
-							</option>
-						))}
-					</select>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={handleResetSelectedPrompt}
-						disabled={controlsDisabled || isSelectedPromptAtDefault}
-					>
-						Reset
-					</Button>
-				</div>
-				<textarea
-					rows={5}
-					value={selectedPromptValue}
-					onChange={(event) => handleSelectedPromptChange(event.target.value)}
-					placeholder={selectedPromptPlaceholder}
-					disabled={controlsDisabled}
-					className="w-full rounded-md border border-border bg-surface-2 p-3 text-[13px] text-text-primary font-mono placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none disabled:opacity-40"
+				{/* Scrollable body with all panels */}
+				<ScrollableSettingsBody
+					ref={scrollableBodyRef}
+					config={config}
+					draftThemeId={draftThemeId}
+					onThemeChange={setDraftThemeId}
+					onResetLayout={resetLayoutCustomizations}
+					readyForReviewNotificationsEnabled={readyForReviewNotificationsEnabled}
+					onReadyForReviewNotificationsChange={setReadyForReviewNotificationsEnabled}
+					notificationPermission={notificationPermission}
+					onRequestPermission={handleRequestPermission}
+					onOpenFilePath={handleOpenFilePath}
+					controlsDisabled={controlsDisabled}
+					displayedAgents={agentModels}
+					selectedAgentId={selectedAgentId}
+					onSelectAgent={setSelectedAgentId}
+					agentAutonomousModeEnabled={agentAutonomousModeEnabled}
+					onAutonomousModeChange={setAgentAutonomousModeEnabled}
+					clineSettings={clineSettings}
+					clineMcpSettings={clineMcpSettings}
+					workspaceId={workspaceId}
+					open={open}
+					onAccountSwitched={onAccountSwitched}
+					configLoaded={config !== null}
+					onError={setSaveError}
+					showMcp={showMcpInNav}
+					commitPromptTemplate={commitPromptTemplate}
+					openPrPromptTemplate={openPrPromptTemplate}
+					commitPromptTemplateDefault={commitPromptTemplateDefault}
+					openPrPromptTemplateDefault={openPrPromptTemplateDefault}
+					onCommitPromptChange={setCommitPromptTemplate}
+					onOpenPrPromptChange={setOpenPrPromptTemplate}
+					shortcuts={shortcuts}
+					onShortcutsChange={setShortcuts}
+					onActiveSectionChange={setActiveNavSection}
+					saveError={saveError}
 				/>
-				<p className="text-text-secondary text-[13px] mt-2 mb-2.5">
-					Use{" "}
-					<InlineUtilityButton
-						text={
-							copiedVariableToken === TASK_GIT_BASE_REF_PROMPT_VARIABLE.token
-								? "Copied!"
-								: TASK_GIT_BASE_REF_PROMPT_VARIABLE.token
-						}
-						monospace
-						widthCh={Math.max(TASK_GIT_BASE_REF_PROMPT_VARIABLE.token.length, "Copied!".length) + 2}
-						onClick={() => {
-							handleCopyVariableToken(TASK_GIT_BASE_REF_PROMPT_VARIABLE.token);
-						}}
-						disabled={controlsDisabled}
-					/>{" "}
-					to reference {TASK_GIT_BASE_REF_PROMPT_VARIABLE.description}
-				</p>
-				<h6 className="font-semibold text-text-primary mt-4 mb-2">Notifications</h6>
-				<div className="flex items-center gap-2">
-					<RadixSwitch.Root
-						checked={readyForReviewNotificationsEnabled}
-						disabled={controlsDisabled}
-						onCheckedChange={setReadyForReviewNotificationsEnabled}
-						className="relative h-5 w-9 rounded-full bg-surface-4 data-[state=checked]:bg-accent cursor-pointer disabled:opacity-40"
-					>
-						<RadixSwitch.Thumb className="block h-4 w-4 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-[18px]" />
-					</RadixSwitch.Root>
-					<span className="text-[13px] text-text-primary">Notify when a task is ready for review</span>
-				</div>
-				<div className="flex items-center gap-2 mt-2 mb-2">
-					<p className="text-text-secondary text-[13px] m-0">
-						Browser permission: {formatNotificationPermissionStatus(notificationPermission)}
-					</p>
-					{notificationPermission !== "granted" && notificationPermission !== "unsupported" ? (
-						<InlineUtilityButton
-							text="Request permission"
-							onClick={handleRequestPermission}
-							disabled={controlsDisabled}
-						/>
-					) : null}
-				</div>
+			</div>
 
-				<h6 className="font-semibold text-text-primary mt-4 mb-2">Theme</h6>
-				<div className="flex flex-wrap gap-2">
-					{THEMES.map((theme) => (
-						<button
-							key={theme.id}
-							type="button"
-							aria-label={theme.label}
-							title={theme.label}
-							onClick={() => {
-								setDraftThemeId(theme.id);
-								previewThemeId(theme.id);
-							}}
-							className={cn(
-								"w-7 h-7 rounded-full cursor-pointer hover:opacity-80",
-								draftThemeId === theme.id ? "border-2 border-white" : "border-2",
-							)}
-							style={{
-								backgroundColor: theme.accent,
-								borderColor:
-									draftThemeId === theme.id ? "white" : `color-mix(in srgb, ${theme.accent} 50%, black)`,
-							}}
-						/>
-					))}
-				</div>
-				<p className="text-text-secondary text-[13px] mt-1.5 mb-0">
-					{THEMES.find((t) => t.id === draftThemeId)?.label ?? "Default"} theme
-				</p>
-
-				<h6 className="font-semibold text-text-primary mt-4 mb-2">Layout</h6>
-				<Button size="sm" onClick={resetLayoutCustomizations}>
-					Reset layout
-				</Button>
-				<p className="text-text-secondary text-[13px] mt-2 mb-0">
-					Reset sidebar, split pane, and terminal resize customizations back to their defaults.
-				</p>
-
-				<h5 className="font-semibold text-text-primary mt-4 mb-0">Project</h5>
-				<p
-					className="text-text-secondary font-mono text-xs m-0 break-all"
-					style={{ cursor: config?.projectConfigPath ? "pointer" : undefined }}
-					onClick={() => {
-						if (config?.projectConfigPath) {
-							handleOpenFilePath(config.projectConfigPath);
-						}
-					}}
-				>
-					{config?.projectConfigPath
-						? formatPathForDisplay(config.projectConfigPath)
-						: "<project>/.cline/kanban/config.json"}
-					{config?.projectConfigPath ? <ExternalLink size={12} className="inline ml-1.5 align-middle" /> : null}
-				</p>
-
-				<div className="flex items-center justify-between mt-3 mb-2">
-					<h6 ref={shortcutsSectionRef} className="font-semibold text-text-primary m-0">
-						Script shortcuts
-					</h6>
-					<Button
-						variant="ghost"
-						size="sm"
-						icon={<Plus size={14} />}
-						onClick={() => {
-							setShortcuts((current) => {
-								const nextLabel = getNextShortcutLabel(current, "Run");
-								setPendingShortcutScrollIndex(current.length);
-								return [
-									...current,
-									{
-										label: nextLabel,
-										command: "",
-										icon: "play",
-									},
-								];
-							});
-						}}
-						disabled={controlsDisabled}
-					>
-						Add
-					</Button>
-				</div>
-
-				{shortcuts.map((shortcut, shortcutIndex) => (
-					<div
-						key={shortcutIndex}
-						ref={(node) => {
-							shortcutRowRefs.current[shortcutIndex] = node;
-						}}
-						className="grid gap-2 mb-1"
-						style={{ gridTemplateColumns: "max-content 1fr 2fr auto" }}
-					>
-						<ShortcutIconPicker
-							value={shortcut.icon}
-							onSelect={(icon) =>
-								setShortcuts((current) =>
-									current.map((item, itemIndex) => (itemIndex === shortcutIndex ? { ...item, icon } : item)),
-								)
-							}
-						/>
-						<input
-							value={shortcut.label}
-							onChange={(event) =>
-								setShortcuts((current) =>
-									current.map((item, itemIndex) =>
-										itemIndex === shortcutIndex ? { ...item, label: event.target.value } : item,
-									),
-								)
-							}
-							placeholder="Label"
-							className="h-7 w-full rounded-md border border-border bg-surface-2 px-2 text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
-						/>
-						<input
-							value={shortcut.command}
-							onChange={(event) =>
-								setShortcuts((current) =>
-									current.map((item, itemIndex) =>
-										itemIndex === shortcutIndex ? { ...item, command: event.target.value } : item,
-									),
-								)
-							}
-							placeholder="Command"
-							className="h-7 w-full rounded-md border border-border bg-surface-2 px-2 text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
-						/>
-						<Button
-							variant="ghost"
-							size="sm"
-							icon={<X size={14} />}
-							aria-label={`Remove shortcut ${shortcut.label}`}
-							onClick={() =>
-								setShortcuts((current) => current.filter((_, itemIndex) => itemIndex !== shortcutIndex))
-							}
-						/>
-					</div>
-				))}
-				{shortcuts.length === 0 ? (
-					<p className="text-text-secondary text-[13px]">No shortcuts configured.</p>
-				) : null}
-
-				{saveError ? (
-					<div className="flex gap-2 rounded-md border border-status-red/30 bg-status-red/5 p-3 text-[13px] mt-3">
-						<span className="text-text-primary">{saveError}</span>
-					</div>
-				) : null}
-			</DialogBody>
 			<DialogFooter>
 				<Button
 					size="sm"

--- a/web-ui/src/components/search-select-dropdown.tsx
+++ b/web-ui/src/components/search-select-dropdown.tsx
@@ -35,7 +35,7 @@ export function SearchSelectDropdown({
 	emptyText = "No options available",
 	noResultsText = "No matching results",
 	showSelectedIndicator = false,
-	pinSelectedToTop = true,
+	pinSelectedToTop = false,
 	recommendedOptionValues = [],
 	recommendedHeading = "Recommended models",
 	matchTargetWidth = true,
@@ -148,7 +148,10 @@ export function SearchSelectDropdown({
 		(nextOpen: boolean) => {
 			setIsOpen(nextOpen);
 			setQuery("");
-			if (!nextOpen) {
+			if (nextOpen) {
+				// Signal the effect to snap activeOptionIndex to the selected item.
+				setActiveOptionIndex(-1);
+			} else {
 				setActiveOptionIndex(0);
 			}
 			onPopoverOpenChange?.(nextOpen);

--- a/web-ui/src/components/settings/agent-panel.tsx
+++ b/web-ui/src/components/settings/agent-panel.tsx
@@ -1,0 +1,206 @@
+import * as RadixSwitch from "@radix-ui/react-switch";
+import { getRuntimeAgentCatalogEntry } from "@runtime-agent-catalog";
+import { Circle, CircleDot } from "lucide-react";
+import type { ReactElement } from "react";
+import { SettingRow } from "@/components/settings/setting-row";
+import { SettingSection } from "@/components/settings/setting-section";
+import { AccountOrganizationSection } from "@/components/shared/account-organization-section";
+import { ClineSetupSection } from "@/components/shared/cline-setup-section";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/components/ui/cn";
+import type { UseRuntimeSettingsClineControllerResult } from "@/hooks/use-runtime-settings-cline-controller";
+import type { UseRuntimeSettingsClineMcpControllerResult } from "@/hooks/use-runtime-settings-cline-mcp-controller";
+import type { RuntimeAgentId } from "@/runtime/types";
+
+export interface AgentRowModel {
+	id: RuntimeAgentId;
+	label: string;
+	binary: string;
+	command: string;
+	installed: boolean | null;
+}
+
+function AgentRow({
+	agent,
+	isSelected,
+	onSelect,
+	disabled,
+}: {
+	agent: AgentRowModel;
+	isSelected: boolean;
+	onSelect: () => void;
+	disabled: boolean;
+}): ReactElement {
+	const installUrl = getRuntimeAgentCatalogEntry(agent.id)?.installUrl;
+	const isNativeCline = agent.id === "cline";
+	const isInstalled = agent.installed === true;
+	const isInstallStatusPending = !isNativeCline && agent.installed === null;
+
+	return (
+		<div
+			role="button"
+			tabIndex={0}
+			onClick={() => {
+				if (isInstalled && !disabled) {
+					onSelect();
+				}
+			}}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" && isInstalled && !disabled) {
+					onSelect();
+				}
+			}}
+			className={cn(
+				"flex items-center justify-between gap-3 px-4 py-3 border-b border-border/40 last:border-b-0 transition-colors",
+				isInstalled && !disabled ? "cursor-pointer hover:bg-surface-2" : "cursor-default",
+			)}
+		>
+			<div className="flex items-start gap-2.5 min-w-0">
+				{isSelected ? (
+					<CircleDot size={16} className="text-accent mt-0.5 shrink-0" />
+				) : (
+					<Circle
+						size={16}
+						className={cn("mt-0.5 shrink-0", !isInstalled ? "text-text-tertiary" : "text-text-secondary")}
+					/>
+				)}
+				<div className="min-w-0">
+					<div className="flex items-center gap-2">
+						<span className="text-[13px] text-text-primary font-medium">{agent.label}</span>
+						{!isNativeCline && isInstalled ? (
+							<span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-status-green/10 text-status-green">
+								Installed
+							</span>
+						) : isInstallStatusPending ? (
+							<span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium bg-surface-3 text-text-secondary">
+								Checking…
+							</span>
+						) : null}
+					</div>
+					{agent.command ? (
+						<p className="text-text-tertiary font-mono text-[11px] mt-0.5 m-0">{agent.command}</p>
+					) : null}
+				</div>
+			</div>
+			{!isNativeCline && agent.installed === false && installUrl ? (
+				<a
+					href={installUrl}
+					target="_blank"
+					rel="noreferrer"
+					onClick={(event: React.MouseEvent) => event.stopPropagation()}
+					className="inline-flex items-center justify-center rounded-md font-medium cursor-default select-none h-7 px-2 text-xs bg-surface-2 border border-border text-text-primary hover:bg-surface-3 hover:border-border-bright"
+				>
+					Install
+				</a>
+			) : !isNativeCline && agent.installed === false ? (
+				<Button size="sm" disabled>
+					Install
+				</Button>
+			) : null}
+		</div>
+	);
+}
+
+export function AgentPanel({
+	displayedAgents,
+	selectedAgentId,
+	onSelectAgent,
+	agentAutonomousModeEnabled,
+	onAutonomousModeChange,
+	clineSettings,
+	clineMcpSettings,
+	workspaceId,
+	open,
+	onAccountSwitched,
+	controlsDisabled,
+	configLoaded,
+	onError,
+}: {
+	displayedAgents: AgentRowModel[];
+	selectedAgentId: RuntimeAgentId;
+	onSelectAgent: (agentId: RuntimeAgentId) => void;
+	agentAutonomousModeEnabled: boolean;
+	onAutonomousModeChange: (enabled: boolean) => void;
+	clineSettings: UseRuntimeSettingsClineControllerResult;
+	clineMcpSettings: UseRuntimeSettingsClineMcpControllerResult;
+	workspaceId: string | null;
+	open: boolean;
+	onAccountSwitched?: () => void;
+	controlsDisabled: boolean;
+	configLoaded: boolean;
+	onError: (message: string | null) => void;
+}): ReactElement {
+	return (
+		<div>
+			<div className="sticky top-[-20px] -mx-5 px-5 -mt-5 pt-5 pb-3 mb-4 bg-surface-1 z-10">
+				<h2 className="text-base font-semibold text-text-primary m-0 mb-1">Agent</h2>
+				<p className="text-[12px] text-text-secondary m-0">
+					Choose which coding agent to use and configure its settings.
+				</p>
+			</div>
+
+			<SettingSection title="Select agent" noCard>
+				<div className="rounded-lg border border-border bg-surface-0 overflow-clip">
+					{displayedAgents.map((agent) => (
+						<AgentRow
+							key={agent.id}
+							agent={agent}
+							isSelected={agent.id === selectedAgentId}
+							onSelect={() => onSelectAgent(agent.id)}
+							disabled={controlsDisabled}
+						/>
+					))}
+				</div>
+				{!configLoaded ? (
+					<p className="text-text-secondary text-[12px] py-2 m-0">
+						Checking which CLIs are installed for this project…
+					</p>
+				) : null}
+			</SettingSection>
+
+			<SettingSection title="Permissions">
+				<SettingRow
+					label="Bypass permission prompts"
+					description="Allows agents to use tools without stopping for permission. Use at your own risk."
+					control={
+						<RadixSwitch.Root
+							aria-label="Enable bypass permissions flag"
+							checked={agentAutonomousModeEnabled}
+							disabled={controlsDisabled}
+							onCheckedChange={(checked) => onAutonomousModeChange(checked === true)}
+							className="relative h-5 w-9 rounded-full bg-surface-4 data-[state=checked]:bg-accent cursor-pointer disabled:opacity-40"
+						>
+							<RadixSwitch.Thumb className="block h-4 w-4 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-[18px]" />
+						</RadixSwitch.Root>
+					}
+					noBorder
+				/>
+			</SettingSection>
+
+			{selectedAgentId === "cline" ? (
+				<SettingSection title="Cline setup" noCard>
+					<div className="pt-2">
+						<ClineSetupSection
+							controller={clineSettings}
+							mcpController={clineMcpSettings}
+							controlsDisabled={controlsDisabled}
+							workspaceId={workspaceId}
+							showHeading={false}
+							showMcpSettings={false}
+							accountSection={
+								clineSettings.providerId.trim() === "cline" ? (
+									<AccountOrganizationSection
+										workspaceId={workspaceId}
+										open={open}
+										onAccountSwitched={onAccountSwitched}
+									/>
+								) : null
+							}
+							onError={onError}
+						/>
+					</div>
+				</SettingSection>
+			) : null}
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/general-panel.tsx
+++ b/web-ui/src/components/settings/general-panel.tsx
@@ -1,0 +1,161 @@
+import * as RadixSwitch from "@radix-ui/react-switch";
+import { ExternalLink } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { SettingRow } from "@/components/settings/setting-row";
+import { SettingSection } from "@/components/settings/setting-section";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/components/ui/cn";
+import { previewThemeId, THEMES, type ThemeId } from "@/hooks/use-theme";
+import type { RuntimeConfigResponse } from "@/runtime/types";
+import type { BrowserNotificationPermission } from "@/utils/notification-permission";
+import { formatPathForDisplay } from "@/utils/path-display";
+
+function formatNotificationPermissionStatus(permission: BrowserNotificationPermission): string {
+	if (permission === "default") {
+		return "not requested yet";
+	}
+	return permission;
+}
+
+export function GeneralPanel({
+	config,
+	draftThemeId,
+	onThemeChange,
+	onResetLayout,
+	readyForReviewNotificationsEnabled,
+	onReadyForReviewNotificationsChange,
+	notificationPermission,
+	onRequestPermission,
+	onOpenFilePath,
+	controlsDisabled,
+}: {
+	config: RuntimeConfigResponse | null;
+	draftThemeId: ThemeId;
+	onThemeChange: (themeId: ThemeId) => void;
+	onResetLayout: () => void;
+	readyForReviewNotificationsEnabled: boolean;
+	onReadyForReviewNotificationsChange: (enabled: boolean) => void;
+	notificationPermission: BrowserNotificationPermission;
+	onRequestPermission: () => void;
+	onOpenFilePath: (filePath: string) => void;
+	controlsDisabled: boolean;
+}): ReactElement {
+	return (
+		<div>
+			<div className="sticky top-[-20px] -mx-5 px-5 -mt-5 pt-5 pb-3 mb-4 bg-surface-1 z-10">
+				<h2 className="text-base font-semibold text-text-primary m-0 mb-1">General</h2>
+				<p className="text-[12px] text-text-secondary m-0">Appearance, notifications, and configuration files.</p>
+			</div>
+
+			<SettingSection title="Appearance">
+				<SettingRow label="Theme" description="Choose a color theme for the interface.">
+					<div className="flex flex-wrap gap-2 mt-1">
+						{THEMES.map((theme) => (
+							<button
+								key={theme.id}
+								type="button"
+								aria-label={theme.label}
+								title={theme.label}
+								onClick={() => {
+									onThemeChange(theme.id);
+									previewThemeId(theme.id);
+								}}
+								className={cn(
+									"w-7 h-7 rounded-full border-2 cursor-pointer transition-all hover:scale-110",
+									draftThemeId === theme.id ? "border-accent ring-2 ring-accent/40" : "border-transparent",
+								)}
+								style={{
+									background: `radial-gradient(circle at 60% 40%, ${theme.accent}, ${theme.surface})`,
+								}}
+							/>
+						))}
+					</div>
+					<p className="text-text-tertiary text-[11px] mt-1.5 mb-0">
+						{THEMES.find((t) => t.id === draftThemeId)?.label ?? "Default"}
+					</p>
+				</SettingRow>
+
+				<SettingRow
+					label="Layout"
+					description="Reset sidebar, split pane, and terminal resize customizations."
+					control={
+						<Button size="sm" onClick={onResetLayout} disabled={controlsDisabled}>
+							Reset layout
+						</Button>
+					}
+				/>
+			</SettingSection>
+
+			<SettingSection title="Notifications">
+				<SettingRow
+					label="Notify when task is ready for review"
+					description="Send a browser notification when a task moves to the review column."
+					control={
+						<RadixSwitch.Root
+							checked={readyForReviewNotificationsEnabled}
+							disabled={controlsDisabled}
+							onCheckedChange={onReadyForReviewNotificationsChange}
+							className="relative h-5 w-9 rounded-full bg-surface-4 data-[state=checked]:bg-accent cursor-pointer disabled:opacity-40"
+						>
+							<RadixSwitch.Thumb className="block h-4 w-4 rounded-full bg-white shadow-sm transition-transform translate-x-0.5 data-[state=checked]:translate-x-[18px]" />
+						</RadixSwitch.Root>
+					}
+				/>
+				<SettingRow
+					label="Browser permission"
+					description={formatNotificationPermissionStatus(notificationPermission)}
+					noBorder
+					control={
+						notificationPermission !== "granted" && notificationPermission !== "unsupported" ? (
+							<Button size="sm" onClick={onRequestPermission} disabled={controlsDisabled}>
+								Request
+							</Button>
+						) : null
+					}
+				/>
+			</SettingSection>
+
+			<SettingSection title="Configuration files">
+				<SettingRow
+					label="Global config"
+					noBorder={!config?.projectConfigPath}
+					description={
+						<span
+							className="font-mono text-[11px] break-all cursor-pointer hover:text-text-primary transition-colors"
+							onClick={() => {
+								if (config?.globalConfigPath) {
+									onOpenFilePath(config.globalConfigPath);
+								}
+							}}
+						>
+							{config?.globalConfigPath
+								? formatPathForDisplay(config.globalConfigPath)
+								: "~/.cline/kanban/config.json"}
+							{config?.globalConfigPath ? <ExternalLink size={10} className="inline ml-1 align-middle" /> : null}
+						</span>
+					}
+				/>
+				{config?.projectConfigPath ? (
+					<SettingRow
+						label="Project config"
+						noBorder
+						description={
+							<span
+								className="font-mono text-[11px] break-all cursor-pointer hover:text-text-primary transition-colors"
+								onClick={() => {
+									if (config.projectConfigPath) {
+										onOpenFilePath(config.projectConfigPath);
+									}
+								}}
+							>
+								{formatPathForDisplay(config.projectConfigPath)}
+								<ExternalLink size={10} className="inline ml-1 align-middle" />
+							</span>
+						}
+					/>
+				) : null}
+			</SettingSection>
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/git-prompts-panel.tsx
+++ b/web-ui/src/components/settings/git-prompts-panel.tsx
@@ -1,0 +1,157 @@
+import { type ReactElement, useRef, useState } from "react";
+
+import { SettingSection } from "@/components/settings/setting-section";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/components/ui/cn";
+import { TASK_GIT_BASE_REF_PROMPT_VARIABLE, type TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
+import { useUnmount } from "@/utils/react-use";
+
+const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string; description: string }> = [
+	{ value: "commit", label: "Commit", description: "Prompt sent when using the Commit button on review tasks." },
+	{ value: "pr", label: "Make PR", description: "Prompt sent when using the Make PR button on review tasks." },
+];
+
+export function GitPromptsPanel({
+	commitPromptTemplate,
+	openPrPromptTemplate,
+	commitPromptTemplateDefault,
+	openPrPromptTemplateDefault,
+	onCommitPromptChange,
+	onOpenPrPromptChange,
+	controlsDisabled,
+}: {
+	commitPromptTemplate: string;
+	openPrPromptTemplate: string;
+	commitPromptTemplateDefault: string;
+	openPrPromptTemplateDefault: string;
+	onCommitPromptChange: (value: string) => void;
+	onOpenPrPromptChange: (value: string) => void;
+	controlsDisabled: boolean;
+}): ReactElement {
+	const [selectedVariant, setSelectedVariant] = useState<TaskGitAction>("commit");
+	const [copiedToken, setCopiedToken] = useState<string | null>(null);
+	const copiedResetTimerRef = useRef<number | null>(null);
+
+	useUnmount(() => {
+		if (copiedResetTimerRef.current !== null) {
+			window.clearTimeout(copiedResetTimerRef.current);
+		}
+	});
+
+	const selectedPromptValue = selectedVariant === "commit" ? commitPromptTemplate : openPrPromptTemplate;
+	const selectedPromptDefault =
+		selectedVariant === "commit" ? commitPromptTemplateDefault : openPrPromptTemplateDefault;
+	const isAtDefault =
+		selectedPromptValue.replaceAll("\r\n", "\n").trim() === selectedPromptDefault.replaceAll("\r\n", "\n").trim();
+	const selectedOption = GIT_PROMPT_VARIANT_OPTIONS.find((o) => o.value === selectedVariant);
+
+	const handleChange = (value: string) => {
+		if (selectedVariant === "commit") {
+			onCommitPromptChange(value);
+		} else {
+			onOpenPrPromptChange(value);
+		}
+	};
+
+	const handleReset = () => {
+		handleChange(selectedPromptDefault);
+	};
+
+	const handleCopyToken = (token: string) => {
+		void (async () => {
+			try {
+				await navigator.clipboard.writeText(token);
+				setCopiedToken(token);
+				if (copiedResetTimerRef.current !== null) {
+					window.clearTimeout(copiedResetTimerRef.current);
+				}
+				copiedResetTimerRef.current = window.setTimeout(() => {
+					setCopiedToken((current) => (current === token ? null : current));
+					copiedResetTimerRef.current = null;
+				}, 2000);
+			} catch {
+				// Ignore clipboard failures.
+			}
+		})();
+	};
+
+	return (
+		<div>
+			<div className="sticky top-[-20px] -mx-5 px-5 -mt-5 pt-5 pb-3 mb-4 bg-surface-1 z-10">
+				<h2 className="text-base font-semibold text-text-primary m-0 mb-1">Git Prompts</h2>
+				<p className="text-[12px] text-text-secondary m-0">
+					Customize the prompts sent to the agent when using git actions on review tasks.
+				</p>
+			</div>
+
+			<SettingSection title="Prompt template">
+				<div className="px-4 py-3">
+					{/* Pill buttons + Reset to default */}
+					<div className="flex items-center justify-between">
+						<div className="flex gap-2">
+							{GIT_PROMPT_VARIANT_OPTIONS.map((option) => (
+								<button
+									key={option.value}
+									type="button"
+									onClick={() => setSelectedVariant(option.value)}
+									disabled={controlsDisabled}
+									className={cn(
+										"h-8 px-3 rounded-md text-[13px] font-medium transition-colors cursor-pointer border disabled:opacity-40",
+										selectedVariant === option.value
+											? "bg-surface-3 border-border-bright text-text-primary"
+											: "bg-transparent border-border text-text-secondary hover:text-text-primary hover:border-border-bright",
+									)}
+								>
+									{option.label}
+								</button>
+							))}
+						</div>
+						<Button variant="default" size="sm" onClick={handleReset} disabled={controlsDisabled || isAtDefault}>
+							Reset to default
+						</Button>
+					</div>
+
+					{/* Separator */}
+					<div className="border-b border-border my-3" />
+
+					{/* Description for selected variant */}
+					{selectedOption ? (
+						<p className="text-text-secondary text-[12px] m-0 mb-3">{selectedOption.description}</p>
+					) : null}
+
+					{/* Helper text */}
+					<p className="text-text-tertiary text-[12px] m-0 mb-2">Edit the prompt template below.</p>
+
+					{/* Textarea — fixed height, scrollable */}
+					<textarea
+						value={selectedPromptValue}
+						onChange={(event) => handleChange(event.target.value)}
+						placeholder={selectedVariant === "commit" ? "Commit prompt template" : "PR prompt template"}
+						disabled={controlsDisabled}
+						className="w-full h-[200px] rounded-lg border border-border bg-surface-2 p-3 text-[13px] text-text-primary font-mono placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none disabled:opacity-40 leading-relaxed overflow-y-auto"
+					/>
+				</div>
+			</SettingSection>
+
+			<SettingSection title="Variables">
+				<div className="px-4 py-3">
+					<div className="flex items-center gap-2">
+						<button
+							type="button"
+							onClick={() => handleCopyToken(TASK_GIT_BASE_REF_PROMPT_VARIABLE.token)}
+							disabled={controlsDisabled}
+							className="inline-flex items-center h-6 px-2 rounded bg-surface-3 border border-border text-[11px] font-mono text-text-primary hover:bg-surface-4 cursor-pointer transition-colors disabled:opacity-40"
+						>
+							{copiedToken === TASK_GIT_BASE_REF_PROMPT_VARIABLE.token
+								? "Copied!"
+								: TASK_GIT_BASE_REF_PROMPT_VARIABLE.token}
+						</button>
+						<span className="text-text-secondary text-[12px]">
+							{TASK_GIT_BASE_REF_PROMPT_VARIABLE.description}
+						</span>
+					</div>
+				</div>
+			</SettingSection>
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/mcp-panel.tsx
+++ b/web-ui/src/components/settings/mcp-panel.tsx
@@ -1,0 +1,341 @@
+import * as RadixCheckbox from "@radix-ui/react-checkbox";
+import { Check, ExternalLink, Plus, X } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { SettingSection } from "@/components/settings/setting-section";
+import { Button } from "@/components/ui/button";
+import type { UseRuntimeSettingsClineMcpControllerResult } from "@/hooks/use-runtime-settings-cline-mcp-controller";
+import { openFileOnHost } from "@/runtime/runtime-config-query";
+import type { RuntimeClineMcpServer } from "@/runtime/types";
+import { formatPathForDisplay } from "@/utils/path-display";
+
+export function McpPanel({
+	mcpController,
+	workspaceId,
+	controlsDisabled,
+	onError,
+}: {
+	mcpController: UseRuntimeSettingsClineMcpControllerResult;
+	workspaceId: string | null;
+	controlsDisabled: boolean;
+	onError: (message: string | null) => void;
+}): ReactElement {
+	const mcpControlsDisabled = controlsDisabled || mcpController.isSavingMcpSettings;
+
+	const handleAddMcpServer = () => {
+		mcpController.setMcpServers((current) => [
+			...current,
+			{
+				name: "",
+				disabled: false,
+				type: "streamableHttp",
+				url: "",
+			},
+		]);
+	};
+
+	const updateMcpServer = (serverIndex: number, updater: (server: RuntimeClineMcpServer) => RuntimeClineMcpServer) => {
+		mcpController.setMcpServers((current) =>
+			current.map((server, index) => (index === serverIndex ? updater(server) : server)),
+		);
+	};
+
+	const removeMcpServer = (serverIndex: number) => {
+		mcpController.setMcpServers((current) => current.filter((_, index) => index !== serverIndex));
+	};
+
+	const handleMcpServerOauth = (serverName: string) => {
+		void (async () => {
+			onError(null);
+			const result = await mcpController.runMcpServerOauth(serverName);
+			if (!result.ok) {
+				onError(result.message ?? `Failed to authorize MCP server "${serverName}".`);
+			}
+		})();
+	};
+
+	const handleSetupLinearMcp = () => {
+		void (async () => {
+			onError(null);
+			const result = await mcpController.linearMcpPreset?.setup();
+			if (!result?.ok) {
+				onError(result?.message ?? "Failed to set up Linear MCP.");
+			}
+		})();
+	};
+
+	const handleOpenFilePath = (filePath: string) => {
+		onError(null);
+		void openFileOnHost(workspaceId, filePath).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error);
+			onError(`Could not open file on host: ${message}`);
+		});
+	};
+
+	return (
+		<div>
+			<div className="sticky top-[-20px] -mx-5 px-5 -mt-5 pt-5 pb-3 mb-4 bg-surface-1 z-10">
+				<div className="flex items-center justify-between mb-1">
+					<h2 className="text-base font-semibold text-text-primary m-0">MCP Servers</h2>
+					<Button
+						variant="ghost"
+						size="sm"
+						icon={<Plus size={14} />}
+						disabled={mcpControlsDisabled || mcpController.isLoadingMcpSettings}
+						onClick={handleAddMcpServer}
+					>
+						Add
+					</Button>
+				</div>
+				<p className="text-[12px] text-text-secondary m-0">Configure Cline MCP servers for tool integrations.</p>
+			</div>
+
+			{mcpController.mcpSettingsPath ? (
+				<p
+					className="text-text-secondary font-mono text-[11px] mt-0 mb-3 break-all cursor-pointer hover:text-text-primary transition-colors"
+					onClick={() => handleOpenFilePath(mcpController.mcpSettingsPath)}
+				>
+					{formatPathForDisplay(mcpController.mcpSettingsPath)}
+					<ExternalLink size={10} className="inline ml-1 align-middle" />
+				</p>
+			) : null}
+
+			{mcpController.linearMcpPreset && mcpController.linearMcpPreset.status !== "connected" ? (
+				<div className="rounded-lg border border-border bg-surface-0 px-4 py-3 mb-4">
+					<div className="flex items-center justify-between gap-3">
+						<div className="min-w-0">
+							<p className="text-text-primary text-[13px] font-medium mt-0 mb-0.5">Linear</p>
+							<p className="text-text-secondary text-[12px] mt-0 mb-0">
+								Connect Linear for project management tools.
+							</p>
+						</div>
+						<Button
+							variant="primary"
+							size="sm"
+							disabled={
+								mcpControlsDisabled ||
+								mcpController.isLoadingMcpSettings ||
+								mcpController.linearMcpPreset?.isSettingUp
+							}
+							onClick={handleSetupLinearMcp}
+							className="shrink-0"
+						>
+							{mcpController.linearMcpPreset?.isSettingUp
+								? "Setting up…"
+								: mcpController.linearMcpPreset?.status === "configured"
+									? "Connect"
+									: "Set up"}
+						</Button>
+					</div>
+				</div>
+			) : null}
+
+			{mcpController.isLoadingMcpSettings ? (
+				<p className="text-text-secondary text-[12px] mt-1 mb-0">Loading MCP settings…</p>
+			) : null}
+
+			{!mcpController.isLoadingMcpSettings && mcpController.mcpServers.length === 0 ? (
+				<SettingSection title="Servers">
+					<p className="text-text-secondary text-[12px] px-4 py-3 m-0">No MCP servers configured.</p>
+				</SettingSection>
+			) : null}
+
+			{mcpController.mcpServers.length > 0 ? (
+				<SettingSection title="Servers" noCard>
+					<div className="flex flex-col gap-3">
+						{mcpController.mcpServers.map((server, serverIndex) => {
+							const authStatus = mcpController.mcpAuthStatusByServerName[server.name];
+							const oauthSupported = server.type !== "stdio";
+							const oauthConfigured = authStatus?.oauthConfigured ?? false;
+							const isAuthenticating = mcpController.authenticatingMcpServerName === server.name;
+
+							return (
+								<div key={serverIndex} className="flex items-start gap-2">
+									<div className="rounded-lg border border-border bg-surface-0 p-3 flex-1 min-w-0">
+										<div className="grid gap-2" style={{ gridTemplateColumns: "1.2fr 1fr" }}>
+											<div className="min-w-0">
+												<p className="text-text-secondary text-[11px] mt-0 mb-1">Server name</p>
+												<input
+													value={server.name}
+													onChange={(event) => {
+														updateMcpServer(serverIndex, (current) => ({
+															...current,
+															name: event.target.value,
+														}));
+													}}
+													placeholder="linear"
+													disabled={mcpControlsDisabled}
+													className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+												/>
+											</div>
+											<div className="min-w-0">
+												<p className="text-text-secondary text-[11px] mt-0 mb-1">Transport</p>
+												<select
+													value={server.type}
+													onChange={(event) => {
+														const nextType = event.target.value as RuntimeClineMcpServer["type"];
+														updateMcpServer(serverIndex, (current) => {
+															if (nextType === "stdio") {
+																return {
+																	name: current.name,
+																	disabled: current.disabled,
+																	type: "stdio",
+																	command: "",
+																};
+															}
+															return {
+																name: current.name,
+																disabled: current.disabled,
+																type: nextType,
+																url: "",
+															};
+														});
+													}}
+													disabled={mcpControlsDisabled}
+													className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary focus:border-border-focus focus:outline-none"
+												>
+													<option value="streamableHttp">HTTP</option>
+													<option value="sse">SSE</option>
+													<option value="stdio">Stdio</option>
+												</select>
+											</div>
+										</div>
+
+										{server.type === "stdio" ? (
+											<div className="grid gap-2 mt-2" style={{ gridTemplateColumns: "1fr 1fr" }}>
+												<div className="min-w-0">
+													<p className="text-text-secondary text-[11px] mt-0 mb-1">Command</p>
+													<input
+														value={server.command}
+														onChange={(event) => {
+															updateMcpServer(serverIndex, (current) => {
+																if (current.type !== "stdio") return current;
+																return { ...current, command: event.target.value };
+															});
+														}}
+														placeholder="Command"
+														disabled={mcpControlsDisabled}
+														className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+													/>
+												</div>
+												<div className="min-w-0">
+													<p className="text-text-secondary text-[11px] mt-0 mb-1">Arguments</p>
+													<input
+														value={(server.args ?? []).join(" ")}
+														onChange={(event) => {
+															updateMcpServer(serverIndex, (current) => {
+																if (current.type !== "stdio") return current;
+																return {
+																	...current,
+																	args: event.target.value
+																		.split(/\s+/)
+																		.map((v) => v.trim())
+																		.filter((v) => v.length > 0),
+																};
+															});
+														}}
+														placeholder="Args"
+														disabled={mcpControlsDisabled}
+														className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+													/>
+												</div>
+												<div className="min-w-0" style={{ gridColumn: "1 / -1" }}>
+													<p className="text-text-secondary text-[11px] mt-0 mb-1">Working directory</p>
+													<input
+														value={server.cwd ?? ""}
+														onChange={(event) => {
+															updateMcpServer(serverIndex, (current) => {
+																if (current.type !== "stdio") return current;
+																return { ...current, cwd: event.target.value };
+															});
+														}}
+														placeholder="Working directory (optional)"
+														disabled={mcpControlsDisabled}
+														className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+													/>
+												</div>
+											</div>
+										) : (
+											<div className="min-w-0 mt-2">
+												<p className="text-text-secondary text-[11px] mt-0 mb-1">URL</p>
+												<input
+													value={server.url}
+													onChange={(event) => {
+														updateMcpServer(serverIndex, (current) => {
+															if (current.type === "stdio") return current;
+															return { ...current, url: event.target.value };
+														});
+													}}
+													placeholder="https://example.com/mcp"
+													disabled={mcpControlsDisabled}
+													className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+												/>
+											</div>
+										)}
+
+										{oauthSupported ? (
+											<div className="mt-2 pt-2 border-t border-border/50">
+												<p className="text-text-secondary text-[11px] mt-0 mb-1">
+													OAuth:{" "}
+													<span className="text-text-primary">
+														{oauthConfigured ? "Connected" : "Not connected"}
+													</span>
+												</p>
+												{authStatus?.lastError ? (
+													<p className="text-status-red text-[11px] mt-0 mb-1">{authStatus.lastError}</p>
+												) : null}
+												<Button
+													variant="default"
+													size="sm"
+													disabled={mcpControlsDisabled || isAuthenticating}
+													onClick={() => handleMcpServerOauth(server.name)}
+												>
+													{isAuthenticating
+														? "Connecting…"
+														: oauthConfigured
+															? "Reconnect"
+															: "Connect OAuth"}
+												</Button>
+											</div>
+										) : null}
+
+										<label
+											htmlFor={`mcp-disabled-v2-${serverIndex}`}
+											className="flex items-center gap-2 text-[12px] text-text-primary mt-2.5 cursor-pointer select-none"
+										>
+											<RadixCheckbox.Root
+												id={`mcp-disabled-v2-${serverIndex}`}
+												checked={server.disabled}
+												disabled={mcpControlsDisabled}
+												onCheckedChange={(checked) => {
+													updateMcpServer(serverIndex, (current) => ({
+														...current,
+														disabled: checked === true,
+													}));
+												}}
+												className="flex h-4 w-4 cursor-pointer items-center justify-center rounded border border-border bg-surface-2 data-[state=checked]:bg-accent data-[state=checked]:border-accent disabled:cursor-default disabled:opacity-40"
+											>
+												<RadixCheckbox.Indicator>
+													<Check size={12} className="text-white" />
+												</RadixCheckbox.Indicator>
+											</RadixCheckbox.Root>
+											<span>Disabled</span>
+										</label>
+									</div>
+									<Button
+										variant="ghost"
+										size="sm"
+										icon={<X size={14} />}
+										aria-label={`Remove MCP server ${server.name || serverIndex + 1}`}
+										disabled={mcpControlsDisabled}
+										onClick={() => removeMcpServer(serverIndex)}
+									/>
+								</div>
+							);
+						})}
+					</div>
+				</SettingSection>
+			) : null}
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/scrollable-settings-body.tsx
+++ b/web-ui/src/components/settings/scrollable-settings-body.tsx
@@ -1,0 +1,274 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+
+import type { AgentRowModel } from "@/components/settings/agent-panel";
+import { AgentPanel } from "@/components/settings/agent-panel";
+import { GeneralPanel } from "@/components/settings/general-panel";
+import { GitPromptsPanel } from "@/components/settings/git-prompts-panel";
+import { McpPanel } from "@/components/settings/mcp-panel";
+import type { SettingsNavSection } from "@/components/settings/settings-nav";
+import { ShortcutsPanel } from "@/components/settings/shortcuts-panel";
+import { cn } from "@/components/ui/cn";
+import type { UseRuntimeSettingsClineControllerResult } from "@/hooks/use-runtime-settings-cline-controller";
+import type { UseRuntimeSettingsClineMcpControllerResult } from "@/hooks/use-runtime-settings-cline-mcp-controller";
+import type { ThemeId } from "@/hooks/use-theme";
+import type { RuntimeAgentId, RuntimeConfigResponse, RuntimeProjectShortcut } from "@/runtime/types";
+import type { BrowserNotificationPermission } from "@/utils/notification-permission";
+
+export interface ScrollableSettingsBodyHandle {
+	scrollToSection: (sectionId: SettingsNavSection) => void;
+}
+
+interface ScrollableSettingsBodyProps {
+	// General panel props
+	config: RuntimeConfigResponse | null;
+	draftThemeId: ThemeId;
+	onThemeChange: (themeId: ThemeId) => void;
+	onResetLayout: () => void;
+	readyForReviewNotificationsEnabled: boolean;
+	onReadyForReviewNotificationsChange: (enabled: boolean) => void;
+	notificationPermission: BrowserNotificationPermission;
+	onRequestPermission: () => void;
+	onOpenFilePath: (filePath: string) => void;
+	controlsDisabled: boolean;
+
+	// Agent panel props
+	displayedAgents: AgentRowModel[];
+	selectedAgentId: RuntimeAgentId;
+	onSelectAgent: (agentId: RuntimeAgentId) => void;
+	agentAutonomousModeEnabled: boolean;
+	onAutonomousModeChange: (enabled: boolean) => void;
+	clineSettings: UseRuntimeSettingsClineControllerResult;
+	clineMcpSettings: UseRuntimeSettingsClineMcpControllerResult;
+	workspaceId: string | null;
+	open: boolean;
+	onAccountSwitched?: () => void;
+	configLoaded: boolean;
+	onError: (message: string | null) => void;
+
+	// MCP panel props (reuses clineMcpSettings, workspaceId, controlsDisabled, onError)
+	showMcp: boolean;
+
+	// Git prompts panel props
+	commitPromptTemplate: string;
+	openPrPromptTemplate: string;
+	commitPromptTemplateDefault: string;
+	openPrPromptTemplateDefault: string;
+	onCommitPromptChange: (value: string) => void;
+	onOpenPrPromptChange: (value: string) => void;
+
+	// Shortcuts panel props
+	shortcuts: RuntimeProjectShortcut[];
+	onShortcutsChange: React.Dispatch<React.SetStateAction<RuntimeProjectShortcut[]>>;
+
+	// Scroll-spy callback
+	onActiveSectionChange: (sectionId: SettingsNavSection) => void;
+
+	// Optional save error to display at the bottom
+	saveError?: string | null;
+}
+
+/**
+ * All settings sections stacked in a single scrollable container.
+ * Uses IntersectionObserver to report which section is currently most visible.
+ * Exposes `scrollToSection(id)` via imperative handle for programmatic navigation.
+ */
+export const ScrollableSettingsBody = forwardRef<ScrollableSettingsBodyHandle, ScrollableSettingsBodyProps>(
+	function ScrollableSettingsBody(props, ref) {
+		const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+		const sectionRefs = useRef<Map<SettingsNavSection, HTMLDivElement>>(new Map());
+		const isScrollingProgrammatically = useRef(false);
+
+		const setSectionRef = useCallback((sectionId: SettingsNavSection, node: HTMLDivElement | null) => {
+			if (node) {
+				sectionRefs.current.set(sectionId, node);
+			} else {
+				sectionRefs.current.delete(sectionId);
+			}
+		}, []);
+
+		// Expose scrollToSection via imperative handle
+		useImperativeHandle(
+			ref,
+			() => ({
+				scrollToSection(sectionId: SettingsNavSection) {
+					const node = sectionRefs.current.get(sectionId);
+					const container = scrollContainerRef.current;
+					if (!node || !container) {
+						return;
+					}
+
+					// Suppress observer updates during programmatic scroll
+					isScrollingProgrammatically.current = true;
+
+					node.scrollIntoView({ behavior: "smooth", block: "start" });
+
+					// Re-enable observer after scroll settles
+					const timeout = window.setTimeout(() => {
+						isScrollingProgrammatically.current = false;
+					}, 600);
+
+					return () => {
+						window.clearTimeout(timeout);
+					};
+				},
+			}),
+			[],
+		);
+
+		// IntersectionObserver scroll-spy
+		useEffect(() => {
+			const container = scrollContainerRef.current;
+			if (!container) {
+				return;
+			}
+
+			const visibilityMap = new Map<SettingsNavSection, number>();
+
+			const observer = new IntersectionObserver(
+				(entries) => {
+					if (isScrollingProgrammatically.current) {
+						return;
+					}
+
+					for (const entry of entries) {
+						const sectionId = (entry.target as HTMLElement).dataset.sectionId as SettingsNavSection | undefined;
+						if (sectionId) {
+							visibilityMap.set(sectionId, entry.intersectionRatio);
+						}
+					}
+
+					// Find the section with the highest visibility ratio
+					let bestSection: SettingsNavSection | null = null;
+					let bestRatio = 0;
+					for (const [sectionId, ratio] of visibilityMap) {
+						if (ratio > bestRatio) {
+							bestRatio = ratio;
+							bestSection = sectionId;
+						}
+					}
+
+					if (bestSection) {
+						props.onActiveSectionChange(bestSection);
+					}
+				},
+				{
+					root: container,
+					threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+				},
+			);
+
+			for (const node of sectionRefs.current.values()) {
+				observer.observe(node);
+			}
+
+			return () => {
+				observer.disconnect();
+			};
+			// eslint-disable-next-line react-hooks/exhaustive-deps -- re-run when showMcp changes (sections change)
+		}, [props.showMcp, props.onActiveSectionChange]);
+
+		const sections: Array<{ id: SettingsNavSection; visible: boolean }> = [
+			{ id: "general", visible: true },
+			{ id: "agent", visible: true },
+			{ id: "mcp", visible: props.showMcp },
+			{ id: "git-prompts", visible: true },
+			{ id: "shortcuts", visible: true },
+		];
+
+		const visibleSections = sections.filter((s) => s.visible);
+
+		return (
+			<div
+				ref={scrollContainerRef}
+				data-scroll-settings
+				className="flex-1 min-w-0 overflow-y-auto overscroll-contain p-5 bg-surface-1"
+			>
+				{visibleSections.map((section, visibleIndex) => (
+					<div
+						key={section.id}
+						data-section-id={section.id}
+						ref={(node) => setSectionRef(section.id, node)}
+						className={cn(
+							// Separator between sections (not on first)
+							visibleIndex > 0 ? "border-t border-border pt-6 mt-8" : "",
+						)}
+					>
+						{renderSection(section.id, props)}
+					</div>
+				))}
+				{props.saveError ? (
+					<div className="flex gap-2 rounded-md border border-status-red/30 bg-status-red/5 p-3 text-[13px] mt-4">
+						<span className="text-text-primary">{props.saveError}</span>
+					</div>
+				) : null}
+			</div>
+		);
+	},
+);
+
+function renderSection(sectionId: SettingsNavSection, props: ScrollableSettingsBodyProps): React.ReactElement {
+	switch (sectionId) {
+		case "general":
+			return (
+				<GeneralPanel
+					config={props.config}
+					draftThemeId={props.draftThemeId}
+					onThemeChange={props.onThemeChange}
+					onResetLayout={props.onResetLayout}
+					readyForReviewNotificationsEnabled={props.readyForReviewNotificationsEnabled}
+					onReadyForReviewNotificationsChange={props.onReadyForReviewNotificationsChange}
+					notificationPermission={props.notificationPermission}
+					onRequestPermission={props.onRequestPermission}
+					onOpenFilePath={props.onOpenFilePath}
+					controlsDisabled={props.controlsDisabled}
+				/>
+			);
+		case "agent":
+			return (
+				<AgentPanel
+					displayedAgents={props.displayedAgents}
+					selectedAgentId={props.selectedAgentId}
+					onSelectAgent={props.onSelectAgent}
+					agentAutonomousModeEnabled={props.agentAutonomousModeEnabled}
+					onAutonomousModeChange={props.onAutonomousModeChange}
+					clineSettings={props.clineSettings}
+					clineMcpSettings={props.clineMcpSettings}
+					workspaceId={props.workspaceId}
+					open={props.open}
+					onAccountSwitched={props.onAccountSwitched}
+					controlsDisabled={props.controlsDisabled}
+					configLoaded={props.configLoaded}
+					onError={props.onError}
+				/>
+			);
+		case "mcp":
+			return (
+				<McpPanel
+					mcpController={props.clineMcpSettings}
+					workspaceId={props.workspaceId}
+					controlsDisabled={props.controlsDisabled}
+					onError={props.onError}
+				/>
+			);
+		case "git-prompts":
+			return (
+				<GitPromptsPanel
+					commitPromptTemplate={props.commitPromptTemplate}
+					openPrPromptTemplate={props.openPrPromptTemplate}
+					commitPromptTemplateDefault={props.commitPromptTemplateDefault}
+					openPrPromptTemplateDefault={props.openPrPromptTemplateDefault}
+					onCommitPromptChange={props.onCommitPromptChange}
+					onOpenPrPromptChange={props.onOpenPrPromptChange}
+					controlsDisabled={props.controlsDisabled}
+				/>
+			);
+		case "shortcuts":
+			return (
+				<ShortcutsPanel
+					shortcuts={props.shortcuts}
+					onShortcutsChange={props.onShortcutsChange}
+					controlsDisabled={props.controlsDisabled}
+				/>
+			);
+	}
+}

--- a/web-ui/src/components/settings/setting-row.tsx
+++ b/web-ui/src/components/settings/setting-row.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/components/ui/cn";
+
+/**
+ * A polished setting row with label + optional description on the left,
+ * and a control aligned to the right. Sits inside a SettingSection card
+ * with dividers between rows (Linear-style).
+ */
+export function SettingRow({
+	label,
+	description,
+	control,
+	children,
+	className,
+	noBorder,
+}: {
+	label?: string;
+	description?: ReactNode;
+	control?: ReactNode;
+	children?: ReactNode;
+	className?: string;
+	noBorder?: boolean;
+}): React.ReactElement {
+	return (
+		<div
+			className={cn(
+				"flex items-start justify-between gap-4 px-4 py-3",
+				!noBorder && "border-b border-border/40 last:border-b-0",
+				className,
+			)}
+		>
+			<div className="flex-1 min-w-0">
+				{label ? <p className="text-[13px] font-semibold text-text-primary m-0">{label}</p> : null}
+				{description ? (
+					<p className="text-[12px] text-text-secondary mt-1 mb-0 leading-relaxed">{description}</p>
+				) : null}
+				{children ? <div className="mt-3">{children}</div> : null}
+			</div>
+			{control ? <div className="shrink-0 flex items-center pt-0.5">{control}</div> : null}
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/setting-section.tsx
+++ b/web-ui/src/components/settings/setting-section.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/components/ui/cn";
+
+/**
+ * A sub-section within a settings panel. Renders a muted heading
+ * with the content wrapped in a Linear-style card.
+ */
+export function SettingSection({
+	title,
+	children,
+	className,
+	noCard,
+}: {
+	title: string;
+	children: ReactNode;
+	className?: string;
+	/** When true, skip the card wrapper (useful when children provide their own card). */
+	noCard?: boolean;
+}): React.ReactElement {
+	return (
+		<div className={cn("mt-6 first:mt-0", className)}>
+			<h3 className="text-[12px] font-semibold uppercase tracking-wider text-text-secondary m-0 mb-2">{title}</h3>
+			{noCard ? (
+				<div>{children}</div>
+			) : (
+				<div className="rounded-lg border border-border bg-surface-0 overflow-clip">{children}</div>
+			)}
+		</div>
+	);
+}

--- a/web-ui/src/components/settings/settings-nav.tsx
+++ b/web-ui/src/components/settings/settings-nav.tsx
@@ -1,0 +1,76 @@
+import { Bot, GitCommit, Play, Plug, Search, SlidersHorizontal } from "lucide-react";
+import { type ReactElement, type ReactNode, useMemo, useState } from "react";
+
+import { cn } from "@/components/ui/cn";
+
+export type SettingsNavSection = "general" | "agent" | "mcp" | "git-prompts" | "shortcuts";
+
+interface NavItem {
+	id: SettingsNavSection;
+	label: string;
+	icon: ReactNode;
+}
+
+const NAV_ITEMS: NavItem[] = [
+	{ id: "general", label: "General", icon: <SlidersHorizontal size={16} /> },
+	{ id: "agent", label: "Agent", icon: <Bot size={16} /> },
+	{ id: "mcp", label: "MCP Servers", icon: <Plug size={16} /> },
+	{ id: "git-prompts", label: "Git Prompts", icon: <GitCommit size={16} /> },
+	{ id: "shortcuts", label: "Shortcuts", icon: <Play size={16} /> },
+];
+
+export function SettingsNav({
+	activeSection,
+	onSectionChange,
+	showMcp,
+}: {
+	activeSection: SettingsNavSection;
+	onSectionChange: (section: SettingsNavSection) => void;
+	showMcp: boolean;
+}): ReactElement {
+	const [query, setQuery] = useState("");
+	const visibleItems = useMemo(() => {
+		const base = showMcp ? NAV_ITEMS : NAV_ITEMS.filter((item) => item.id !== "mcp");
+		const trimmed = query.trim().toLowerCase();
+		if (trimmed.length === 0) {
+			return base;
+		}
+		return base.filter((item) => item.label.toLowerCase().includes(trimmed));
+	}, [showMcp, query]);
+
+	return (
+		<nav className="flex flex-col gap-0.5 p-3">
+			<div className="relative mb-2">
+				<Search
+					size={14}
+					className="absolute left-2 top-1/2 -translate-y-1/2 text-text-tertiary pointer-events-none"
+				/>
+				<input
+					className="h-7 w-full rounded-md border border-border bg-surface-2 pl-7 pr-2 text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+					placeholder="Search settings..."
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
+				/>
+			</div>
+			{visibleItems.length === 0 ? (
+				<p className="px-3 py-1.5 text-[12px] text-text-tertiary">No matching sections</p>
+			) : null}
+			{visibleItems.map((item) => (
+				<button
+					key={item.id}
+					type="button"
+					onClick={() => onSectionChange(item.id)}
+					className={cn(
+						"flex items-center gap-2.5 px-3 py-2 rounded-md text-[13px] font-medium transition-colors cursor-pointer text-left",
+						activeSection === item.id
+							? "bg-surface-3 text-text-primary"
+							: "text-text-secondary hover:text-text-primary hover:bg-surface-2",
+					)}
+				>
+					<span className="shrink-0 opacity-80">{item.icon}</span>
+					<span>{item.label}</span>
+				</button>
+			))}
+		</nav>
+	);
+}

--- a/web-ui/src/components/settings/shortcuts-panel.tsx
+++ b/web-ui/src/components/settings/shortcuts-panel.tsx
@@ -1,0 +1,220 @@
+import * as RadixPopover from "@radix-ui/react-popover";
+import { ChevronDown, Plus, X } from "lucide-react";
+import { type Dispatch, type ReactElement, type SetStateAction, useEffect, useRef, useState } from "react";
+
+import { SettingSection } from "@/components/settings/setting-section";
+import {
+	getRuntimeShortcutIconComponent,
+	getRuntimeShortcutPickerOption,
+	RUNTIME_SHORTCUT_ICON_OPTIONS,
+	type RuntimeShortcutPickerIconId,
+} from "@/components/shared/runtime-shortcut-icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/components/ui/cn";
+import type { RuntimeProjectShortcut } from "@/runtime/types";
+
+function getNextShortcutLabel(shortcuts: RuntimeProjectShortcut[], baseLabel: string): string {
+	const normalizedTakenLabels = new Set(
+		shortcuts.map((s) => s.label.trim().toLowerCase()).filter((l) => l.length > 0),
+	);
+	const normalizedBaseLabel = baseLabel.trim().toLowerCase();
+	if (!normalizedTakenLabels.has(normalizedBaseLabel)) {
+		return baseLabel;
+	}
+	let suffix = 2;
+	while (normalizedTakenLabels.has(`${normalizedBaseLabel} ${suffix}`)) {
+		suffix += 1;
+	}
+	return `${baseLabel} ${suffix}`;
+}
+
+function ShortcutIconPicker({
+	value,
+	onSelect,
+}: {
+	value: string | undefined;
+	onSelect: (icon: RuntimeShortcutPickerIconId) => void;
+}): ReactElement {
+	const [open, setOpen] = useState(false);
+	const selectedOption = getRuntimeShortcutPickerOption(value);
+
+	return (
+		<RadixPopover.Root open={open} onOpenChange={setOpen}>
+			<RadixPopover.Trigger asChild>
+				<button
+					type="button"
+					aria-label={`Shortcut icon: ${selectedOption.label}`}
+					className="inline-flex items-center gap-1 h-7 px-1.5 rounded-md border border-border bg-surface-2 text-text-primary hover:bg-surface-3"
+				>
+					<ShortcutIconDisplay icon={value} size={14} />
+					<ChevronDown size={12} />
+				</button>
+			</RadixPopover.Trigger>
+			<RadixPopover.Portal>
+				<RadixPopover.Content
+					side="bottom"
+					align="start"
+					sideOffset={4}
+					className="z-50 rounded-md border border-border bg-surface-2 p-1 shadow-lg"
+					style={{ animation: "kb-tooltip-show 100ms ease" }}
+				>
+					<div className="flex gap-0.5">
+						{RUNTIME_SHORTCUT_ICON_OPTIONS.map((option) => {
+							const IconComponent = getRuntimeShortcutIconComponent(option.value);
+							return (
+								<button
+									key={option.value}
+									type="button"
+									aria-label={option.label}
+									className={cn(
+										"p-1.5 rounded hover:bg-surface-3",
+										selectedOption.value === option.value && "bg-surface-3",
+									)}
+									onClick={() => {
+										onSelect(option.value);
+										setOpen(false);
+									}}
+								>
+									<IconComponent size={14} />
+								</button>
+							);
+						})}
+					</div>
+				</RadixPopover.Content>
+			</RadixPopover.Portal>
+		</RadixPopover.Root>
+	);
+}
+
+function ShortcutIconDisplay({ icon, size = 14 }: { icon: string | undefined; size?: number }): ReactElement {
+	const Component = getRuntimeShortcutIconComponent(icon);
+	return <Component size={size} />;
+}
+
+export function ShortcutsPanel({
+	shortcuts,
+	onShortcutsChange,
+	controlsDisabled,
+}: {
+	shortcuts: RuntimeProjectShortcut[];
+	onShortcutsChange: Dispatch<SetStateAction<RuntimeProjectShortcut[]>>;
+	controlsDisabled: boolean;
+}): ReactElement {
+	const [pendingScrollIndex, setPendingScrollIndex] = useState<number | null>(null);
+	const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+	useEffect(() => {
+		if (pendingScrollIndex === null) {
+			return;
+		}
+		const frame = window.requestAnimationFrame(() => {
+			const target = rowRefs.current[pendingScrollIndex] ?? null;
+			if (target) {
+				target.scrollIntoView({ block: "nearest", behavior: "smooth" });
+				const firstInput = target.querySelector("input");
+				firstInput?.focus();
+				setPendingScrollIndex(null);
+			}
+		});
+		return () => window.cancelAnimationFrame(frame);
+	}, [pendingScrollIndex, shortcuts]);
+
+	return (
+		<div>
+			<div className="sticky top-[-20px] -mx-5 px-5 -mt-5 pt-5 pb-3 mb-4 bg-surface-1 z-10">
+				<div className="flex items-center justify-between mb-1">
+					<h2 className="text-base font-semibold text-text-primary m-0">Shortcuts</h2>
+					<Button
+						variant="ghost"
+						size="sm"
+						icon={<Plus size={14} />}
+						onClick={() => {
+							onShortcutsChange((current) => {
+								const nextLabel = getNextShortcutLabel(current, "Run");
+								setPendingScrollIndex(current.length);
+								return [
+									...current,
+									{
+										label: nextLabel,
+										command: "",
+										icon: "play",
+									},
+								];
+							});
+						}}
+						disabled={controlsDisabled}
+					>
+						Add
+					</Button>
+				</div>
+				<p className="text-[12px] text-text-secondary m-0">
+					Project-level script shortcuts that appear on each task card.
+				</p>
+			</div>
+
+			<SettingSection title="Script shortcuts">
+				{shortcuts.length === 0 ? (
+					<div className="px-4 py-6 text-center">
+						<p className="text-text-tertiary text-[13px] m-0">No shortcuts configured.</p>
+						<p className="text-text-tertiary text-[12px] mt-1 m-0">
+							Add a shortcut to quickly run commands on tasks.
+						</p>
+					</div>
+				) : (
+					<div className="flex flex-col gap-2 p-4">
+						{shortcuts.map((shortcut, shortcutIndex) => (
+							<div
+								key={shortcutIndex}
+								ref={(node) => {
+									rowRefs.current[shortcutIndex] = node;
+								}}
+								className="grid gap-2"
+								style={{ gridTemplateColumns: "max-content 1fr 2fr auto" }}
+							>
+								<ShortcutIconPicker
+									value={shortcut.icon}
+									onSelect={(icon) =>
+										onShortcutsChange((current) =>
+											current.map((item, i) => (i === shortcutIndex ? { ...item, icon } : item)),
+										)
+									}
+								/>
+								<input
+									value={shortcut.label}
+									onChange={(event) =>
+										onShortcutsChange((current) =>
+											current.map((item, i) =>
+												i === shortcutIndex ? { ...item, label: event.target.value } : item,
+											),
+										)
+									}
+									placeholder="Label"
+									className="h-7 w-full rounded-md border border-border bg-surface-2 px-2 text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+								/>
+								<input
+									value={shortcut.command}
+									onChange={(event) =>
+										onShortcutsChange((current) =>
+											current.map((item, i) =>
+												i === shortcutIndex ? { ...item, command: event.target.value } : item,
+											),
+										)
+									}
+									placeholder="Command"
+									className="h-7 w-full rounded-md border border-border bg-surface-2 px-2 text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+								/>
+								<Button
+									variant="ghost"
+									size="sm"
+									icon={<X size={14} />}
+									aria-label={`Remove shortcut ${shortcut.label}`}
+									onClick={() => onShortcutsChange((current) => current.filter((_, i) => i !== shortcutIndex))}
+								/>
+							</div>
+						))}
+					</div>
+				)}
+			</SettingSection>
+		</div>
+	);
+}

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -225,8 +225,8 @@ export function ClineSetupSection({
 	return (
 		<>
 			{showHeading ? <h6 className="font-semibold text-text-primary mt-4 mb-2">Cline setup</h6> : null}
-			<div className="mt-2">
-				<p className="text-text-primary font-semibold text-[12px] mt-0 mb-2">API provider</p>
+			<div className="rounded-lg border border-border bg-surface-0 p-4 mt-2">
+				<p className="text-text-primary font-semibold text-[13px] mt-0 mb-3">API provider</p>
 				<div className="min-w-0 w-1/2 max-w-full">
 					<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
 						<div className="min-w-0">
@@ -291,41 +291,36 @@ export function ClineSetupSection({
 				{controller.isLoadingProviderCatalog ? (
 					<p className="text-text-secondary text-[12px] mt-1 mb-0">Fetching Cline providers...</p>
 				) : null}
-				<div
-					className="grid gap-2 mt-3"
-					style={{ gridTemplateColumns: controller.isOauthProviderSelected ? "1fr" : "1fr 1fr" }}
-				>
-					{controller.isOauthProviderSelected ? null : (
-						<div className="min-w-0">
-							<p className="text-text-secondary text-[12px] mt-0 mb-1">API key</p>
-							<input
-								type="password"
-								value={controller.apiKey}
-								onChange={(event) => controller.setApiKey(event.target.value)}
-								placeholder={apiKeyPlaceholder}
-								disabled={controlsDisabled}
-								className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
-							/>
-							{providerEnvHint ? (
-								<p className="text-text-tertiary text-[11px] mt-1 mb-0 break-all">Or use {providerEnvHint}</p>
-							) : null}
-						</div>
-					)}
-					{shouldShowBaseUrlField ? (
-						<div className="min-w-0">
-							<p className="text-text-secondary text-[12px] mt-0 mb-1">Base URL</p>
-							<input
-								value={controller.baseUrl}
-								onChange={(event) => controller.setBaseUrl(event.target.value)}
-								placeholder="https://api.cline.bot"
-								disabled={controlsDisabled}
-								className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
-							/>
-						</div>
-					) : null}
-				</div>
+				{controller.isOauthProviderSelected ? null : (
+					<div className="min-w-0 mt-4">
+						<p className="text-text-secondary text-[12px] mt-0 mb-1">API key</p>
+						<input
+							type="password"
+							value={controller.apiKey}
+							onChange={(event) => controller.setApiKey(event.target.value)}
+							placeholder={apiKeyPlaceholder}
+							disabled={controlsDisabled}
+							className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+						/>
+						{providerEnvHint ? (
+							<p className="text-text-tertiary text-[11px] mt-1 mb-0 break-all">Or use {providerEnvHint}</p>
+						) : null}
+					</div>
+				)}
+				{shouldShowBaseUrlField ? (
+					<div className="min-w-0 mt-4">
+						<p className="text-text-secondary text-[12px] mt-0 mb-1">Base URL</p>
+						<input
+							value={controller.baseUrl}
+							onChange={(event) => controller.setBaseUrl(event.target.value)}
+							placeholder="https://api.cline.bot"
+							disabled={controlsDisabled}
+							className="h-8 w-full rounded-md border border-border bg-surface-2 px-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
+						/>
+					</div>
+				) : null}
 				{isBedrockProvider ? (
-					<div className="grid gap-2 mt-2" style={{ gridTemplateColumns: "1fr 1fr" }}>
+					<div className="grid gap-4 mt-4" style={{ gridTemplateColumns: "1fr 1fr" }}>
 						<div className="min-w-0">
 							<p className="text-text-secondary text-[12px] mt-0 mb-1">AWS region</p>
 							<input
@@ -408,7 +403,7 @@ export function ClineSetupSection({
 					</div>
 				) : null}
 				{isVertexProvider ? (
-					<div className="grid gap-2 mt-2" style={{ gridTemplateColumns: "1fr 1fr" }}>
+					<div className="grid gap-4 mt-4" style={{ gridTemplateColumns: "1fr 1fr" }}>
 						<div className="min-w-0">
 							<p className="text-text-secondary text-[12px] mt-0 mb-1">GCP project ID</p>
 							<input
@@ -432,21 +427,31 @@ export function ClineSetupSection({
 					</div>
 				) : null}
 				{controller.isOauthProviderSelected ? (
-					<>
-						<p className="text-text-secondary text-[12px] mt-1 mb-0">
-							Status: {controller.oauthConfigured ? "Signed in" : "Not signed in"}
-						</p>
-						{controller.oauthAccountId ? (
-							<p className="text-text-secondary text-[12px] mt-1 mb-0">
-								Account ID: <span className="text-text-primary">{controller.oauthAccountId}</span>
-							</p>
-						) : null}
-						{controller.oauthExpiresAt ? (
-							<p className="text-text-secondary text-[12px] mt-1 mb-0">
-								Expiry: <span className="text-text-primary">{formatExpiry(controller.oauthExpiresAt)}</span>
-							</p>
-						) : null}
-						<div className="mt-2">
+					<div className="mt-4 pt-4 border-t border-border/40">
+						<p className="text-text-primary font-semibold text-[13px] mt-0 mb-2">Account</p>
+						<div className="flex flex-col gap-1.5">
+							<div className="flex items-baseline justify-between">
+								<span className="text-text-secondary text-[12px]">Status</span>
+								<span className="text-text-primary text-[12px] font-medium">
+									{controller.oauthConfigured ? "Signed in" : "Not signed in"}
+								</span>
+							</div>
+							{controller.oauthAccountId ? (
+								<div className="flex items-baseline justify-between">
+									<span className="text-text-secondary text-[12px]">Account ID</span>
+									<span className="text-text-primary text-[12px] font-mono">{controller.oauthAccountId}</span>
+								</div>
+							) : null}
+							{controller.oauthExpiresAt ? (
+								<div className="flex items-baseline justify-between">
+									<span className="text-text-secondary text-[12px]">Expiry</span>
+									<span className="text-text-primary text-[12px]">
+										{formatExpiry(controller.oauthExpiresAt)}
+									</span>
+								</div>
+							) : null}
+						</div>
+						<div className="mt-3">
 							<Button
 								variant="default"
 								size="sm"
@@ -460,15 +465,15 @@ export function ClineSetupSection({
 										: `Sign in with ${controller.managedOauthProvider ?? "OAuth"}`}
 							</Button>
 						</div>
-					</>
+					</div>
 				) : null}
 			</div>
 			{accountSection ? <div className="mt-4">{accountSection}</div> : null}
 
-			<div className="mt-4">
-				<p className="text-text-primary font-semibold text-[12px] mt-0 mb-2">Model</p>
+			<div className="rounded-lg border border-border bg-surface-0 p-4 mt-3">
+				<p className="text-text-primary font-semibold text-[13px] mt-0 mb-3">Model</p>
 				<div
-					className="grid gap-2"
+					className="grid gap-4"
 					style={{ gridTemplateColumns: controller.selectedModelSupportsReasoningEffort ? "1fr 1fr" : "1fr" }}
 				>
 					<div className="min-w-0">
@@ -517,7 +522,7 @@ export function ClineSetupSection({
 					) : null}
 				</div>
 				{controller.isLoadingProviderModels ? (
-					<p className="text-text-secondary text-[12px] mt-1 mb-0">Fetching Cline models...</p>
+					<p className="text-text-secondary text-[12px] mt-2 mb-0">Fetching Cline models...</p>
 				) : null}
 			</div>
 

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -1051,6 +1051,16 @@ body.kb-dependency-link-mode {
 	}
 }
 
+/* -- Settings scroll layout (v3) --
+   Override sticky panel headers when all sections share one scroll container.
+   Converts the bottom margin to padding so bg-surface-1 covers the gap
+   and prevents content from peeking through below the stuck header. */
+
+[data-scroll-settings] .sticky {
+	margin-bottom: 0 !important;
+	padding-bottom: 1.75rem !important;
+}
+
 /* -- PWA Window Controls Overlay --
    When installed as a PWA with display_override: window-controls-overlay,
    the title bar disappears and web content extends to the top of the window.


### PR DESCRIPTION
## Summary

Redesign the runtime settings dialog from a single scrolling page to a multi-panel layout with sidebar navigation.

## What changed

### Navigation
- New **sidebar with 5 sections**: General, Agent, MCP Servers, Git Prompts, Shortcuts
- `SettingsNav` sidebar component with search filtering

### Architecture
- `runtime-settings-dialog.tsx` slimmed from ~1,300 lines to a lightweight orchestrator that delegates to individual panels
- New reusable `SettingSection` and `SettingRow` primitives for consistent layout
- New `ScrollableSettingsBody` shared container

### Panels
- **General** — Theme picker, bypass permissions toggle, notifications toggle
- **Agent** — Provider/model selectors, reasoning settings, Cline setup
- **MCP Servers** — MCP server list with enable/disable toggles  
- **Git Prompts** — Variables section with clickable token badges, custom prompts editor
- **Shortcuts** — Add/remove shortcuts with icon picker, label, and command inputs

### UI polish
- **Bypass permissions**: changed from checkbox (√ square) → toggle switch for consistency
- **Theme picker**: upgraded from flat colored circles with white border → radial gradient circles with accent ring glow + scale-up animation on hover
- **Removed** the `AccountOrganizationSection` from the settings dialog entirely

## Stats
- 14 files changed, 1,676 insertions, 658 deletions
- 368 tests passing