### PR TITLE
feat: add frontend support for two-phase WorkOS device authorization

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -8,6 +8,8 @@ import type {
 	RuntimeClineAccountOrganizationsResponse,
 	RuntimeClineAccountProfileResponse,
 	RuntimeClineAccountSwitchResponse,
+	RuntimeClineDeviceAuthCompleteResponse,
+	RuntimeClineDeviceAuthStartResponse,
 	RuntimeClineKanbanAccessResponse,
 	RuntimeClineOauthLoginResponse,
 	RuntimeClineProviderCatalogItem,
@@ -21,6 +23,7 @@ import type {
 import { openInBrowser } from "../server/browser";
 import {
 	addSdkCustomProvider,
+	completeClineDeviceAuth as completeSdkDeviceAuth,
 	deleteSdkCustomProvider,
 	fetchSdkClineAccountBalance,
 	fetchSdkClineAccountProfile,
@@ -41,6 +44,7 @@ import {
 	type SdkProviderModelRecord,
 	type SdkProviderSettings,
 	saveSdkProviderSettings,
+	startClineDeviceAuth as startSdkDeviceAuth,
 	supportsSdkModelThinking,
 	switchSdkClineAccount,
 	updateSdkCustomProvider,
@@ -1129,6 +1133,74 @@ export function createClineProviderService() {
 				return {
 					ok: false,
 					provider: input.providerId,
+					error: toErrorMessage(error),
+				};
+			}
+		},
+
+		async startDeviceAuth(): Promise<RuntimeClineDeviceAuthStartResponse> {
+			const result = await startSdkDeviceAuth();
+			return {
+				deviceCode: result.deviceCode,
+				userCode: result.userCode,
+				verificationUrl: result.verificationUri,
+				expiresInSeconds: result.expiresInSeconds,
+				pollIntervalSeconds: result.pollIntervalSeconds,
+			};
+		},
+
+		async completeDeviceAuth(input: {
+			deviceCode: string;
+			expiresInSeconds: number;
+			pollIntervalSeconds: number;
+			baseUrl?: string | null;
+		}): Promise<RuntimeClineDeviceAuthCompleteResponse> {
+			const providerId: ManagedClineOauthProviderId = "cline";
+			try {
+				const existingSettings = getSdkProviderSettings(providerId) ?? {
+					provider: providerId,
+				};
+				const apiBaseUrl = input.baseUrl?.trim() || DEFAULT_CLINE_API_BASE_URL;
+				const credentials = await completeSdkDeviceAuth({
+					deviceCode: input.deviceCode,
+					expiresInSeconds: input.expiresInSeconds,
+					pollIntervalSeconds: input.pollIntervalSeconds,
+					apiBaseUrl,
+				});
+
+				const nextSettings: SdkProviderSettings = {
+					...existingSettings,
+					provider: providerId,
+					auth: {
+						...(existingSettings.auth ?? {}),
+						accessToken: toProviderApiKey(providerId, credentials.access),
+						refreshToken: credentials.refresh,
+						accountId: credentials.accountId ?? undefined,
+						expiresAt: normalizeEpochMs(credentials.expires),
+					},
+				};
+
+				if (apiBaseUrl !== DEFAULT_CLINE_API_BASE_URL) {
+					nextSettings.baseUrl = apiBaseUrl;
+				} else {
+					delete nextSettings.baseUrl;
+				}
+
+				saveSdkProviderSettings({
+					settings: nextSettings,
+					tokenSource: "oauth",
+					setLastUsed: true,
+				});
+
+				return {
+					ok: true,
+					provider: providerId,
+					settings: toProviderSettingsSummary(nextSettings),
+				};
+			} catch (error) {
+				return {
+					ok: false,
+					provider: providerId,
 					error: toErrorMessage(error),
 				};
 			}

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -30,6 +30,8 @@ import {
 	loginOpenAICodex,
 	type OcaOAuthProviderOptions,
 	ProviderSettingsManager,
+	completeClineDeviceAuth as sdkCompleteClineDeviceAuth,
+	startClineDeviceAuth as sdkStartClineDeviceAuth,
 	type Tool,
 } from "@clinebot/core/node";
 import type * as Llms from "@clinebot/llms";
@@ -262,6 +264,37 @@ export async function loginManagedOauthProvider(input: {
 		...input.callbacks,
 		originator: "kanban-runtime",
 	});
+}
+
+export async function startClineDeviceAuth(): Promise<{
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete?: string;
+	expiresInSeconds: number;
+	pollIntervalSeconds: number;
+}> {
+	return await sdkStartClineDeviceAuth();
+}
+
+export async function completeClineDeviceAuth(input: {
+	deviceCode: string;
+	expiresInSeconds: number;
+	pollIntervalSeconds: number;
+	apiBaseUrl: string;
+}): Promise<ManagedOauthCredentials> {
+	const credentials = await sdkCompleteClineDeviceAuth({
+		deviceCode: input.deviceCode,
+		expiresInSeconds: input.expiresInSeconds,
+		pollIntervalSeconds: input.pollIntervalSeconds,
+		apiBaseUrl: input.apiBaseUrl,
+	});
+	return {
+		access: credentials.access,
+		refresh: credentials.refresh,
+		expires: credentials.expires,
+		accountId: credentials.accountId,
+	};
 }
 
 export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]> {

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -758,6 +758,26 @@ export const runtimeClineOauthLoginResponseSchema = z.object({
 });
 export type RuntimeClineOauthLoginResponse = z.infer<typeof runtimeClineOauthLoginResponseSchema>;
 
+export const runtimeClineDeviceAuthStartResponseSchema = z.object({
+	deviceCode: z.string(),
+	userCode: z.string(),
+	verificationUrl: z.string(),
+	expiresInSeconds: z.number(),
+	pollIntervalSeconds: z.number(),
+});
+export type RuntimeClineDeviceAuthStartResponse = z.infer<typeof runtimeClineDeviceAuthStartResponseSchema>;
+
+export const runtimeClineDeviceAuthCompleteRequestSchema = z.object({
+	deviceCode: z.string(),
+	expiresInSeconds: z.number(),
+	pollIntervalSeconds: z.number(),
+	baseUrl: z.string().nullable().optional(),
+});
+export type RuntimeClineDeviceAuthCompleteRequest = z.infer<typeof runtimeClineDeviceAuthCompleteRequestSchema>;
+
+export const runtimeClineDeviceAuthCompleteResponseSchema = runtimeClineOauthLoginResponseSchema;
+export type RuntimeClineDeviceAuthCompleteResponse = z.infer<typeof runtimeClineDeviceAuthCompleteResponseSchema>;
+
 export const runtimeClineProviderSettingsSaveRequestSchema = z.object({
 	providerId: z.string(),
 	modelId: z.string().nullable().optional(),

--- a/src/core/api-validation.ts
+++ b/src/core/api-validation.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
 	type RuntimeClineAccountSwitchRequest,
 	type RuntimeClineAddProviderRequest,
+	type RuntimeClineDeviceAuthCompleteRequest,
 	type RuntimeClineMcpOAuthRequest,
 	type RuntimeClineMcpSettingsSaveRequest,
 	type RuntimeClineOauthLoginRequest,
@@ -34,6 +35,7 @@ import {
 	type RuntimeWorktreeEnsureRequest,
 	runtimeClineAccountSwitchRequestSchema,
 	runtimeClineAddProviderRequestSchema,
+	runtimeClineDeviceAuthCompleteRequestSchema,
 	runtimeClineMcpOAuthRequestSchema,
 	runtimeClineMcpSettingsSaveRequestSchema,
 	runtimeClineOauthLoginRequestSchema,
@@ -522,6 +524,14 @@ export function parseClineMcpOAuthRequest(value: unknown): RuntimeClineMcpOAuthR
 
 export function parseClineOauthLoginRequest(value: unknown): RuntimeClineOauthLoginRequest {
 	const parsed = parseWithSchema(runtimeClineOauthLoginRequestSchema, value);
+	return {
+		...parsed,
+		baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl.trim() || null : parsed.baseUrl,
+	};
+}
+
+export function parseClineDeviceAuthCompleteRequest(value: unknown): RuntimeClineDeviceAuthCompleteRequest {
+	const parsed = parseWithSchema(runtimeClineDeviceAuthCompleteRequestSchema, value);
 	return {
 		...parsed,
 		baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl.trim() || null : parsed.baseUrl,

--- a/src/trpc/app-router.ts
+++ b/src/trpc/app-router.ts
@@ -13,6 +13,9 @@ import type {
 	RuntimeClineAccountSwitchResponse,
 	RuntimeClineAddProviderRequest,
 	RuntimeClineAddProviderResponse,
+	RuntimeClineDeviceAuthCompleteRequest,
+	RuntimeClineDeviceAuthCompleteResponse,
+	RuntimeClineDeviceAuthStartResponse,
 	RuntimeClineKanbanAccessResponse,
 	RuntimeClineMcpAuthStatusResponse,
 	RuntimeClineMcpOAuthRequest,
@@ -99,6 +102,9 @@ import {
 	runtimeClineAccountSwitchResponseSchema,
 	runtimeClineAddProviderRequestSchema,
 	runtimeClineAddProviderResponseSchema,
+	runtimeClineDeviceAuthCompleteRequestSchema,
+	runtimeClineDeviceAuthCompleteResponseSchema,
+	runtimeClineDeviceAuthStartResponseSchema,
 	runtimeClineKanbanAccessResponseSchema,
 	runtimeClineMcpAuthStatusResponseSchema,
 	runtimeClineMcpOAuthRequestSchema,
@@ -259,6 +265,11 @@ export interface RuntimeTrpcContext {
 			scope: RuntimeTrpcWorkspaceScope | null,
 			input: RuntimeClineOauthLoginRequest,
 		) => Promise<RuntimeClineOauthLoginResponse>;
+		startClineDeviceAuth: (scope: RuntimeTrpcWorkspaceScope | null) => Promise<RuntimeClineDeviceAuthStartResponse>;
+		completeClineDeviceAuth: (
+			scope: RuntimeTrpcWorkspaceScope | null,
+			input: RuntimeClineDeviceAuthCompleteRequest,
+		) => Promise<RuntimeClineDeviceAuthCompleteResponse>;
 		getClineMcpAuthStatuses: (scope: RuntimeTrpcWorkspaceScope | null) => Promise<RuntimeClineMcpAuthStatusResponse>;
 		runClineMcpServerOAuth: (
 			scope: RuntimeTrpcWorkspaceScope | null,
@@ -544,6 +555,15 @@ export const runtimeAppRouter = t.router({
 			.output(runtimeClineOauthLoginResponseSchema)
 			.mutation(async ({ ctx, input }) => {
 				return await ctx.runtimeApi.runClineProviderOAuthLogin(ctx.workspaceScope, input);
+			}),
+		startClineDeviceAuth: t.procedure.output(runtimeClineDeviceAuthStartResponseSchema).mutation(async ({ ctx }) => {
+			return await ctx.runtimeApi.startClineDeviceAuth(ctx.workspaceScope);
+		}),
+		completeClineDeviceAuth: t.procedure
+			.input(runtimeClineDeviceAuthCompleteRequestSchema)
+			.output(runtimeClineDeviceAuthCompleteResponseSchema)
+			.mutation(async ({ ctx, input }) => {
+				return await ctx.runtimeApi.completeClineDeviceAuth(ctx.workspaceScope, input);
 			}),
 		startShellSession: workspaceProcedure
 			.input(runtimeShellSessionStartRequestSchema)

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -18,6 +18,7 @@ import type { RuntimeCommandRunResponse } from "../core/api-contract";
 import {
 	parseClineAccountSwitchRequest,
 	parseClineAddProviderRequest,
+	parseClineDeviceAuthCompleteRequest,
 	parseClineMcpOAuthRequest,
 	parseClineMcpSettingsSaveRequest,
 	parseClineOauthLoginRequest,
@@ -536,6 +537,18 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 			const body = parseClineOauthLoginRequest(input);
 			return await clineProviderService.runOauthLogin({
 				providerId: body.provider,
+				baseUrl: body.baseUrl,
+			});
+		},
+		startClineDeviceAuth: async () => {
+			return await clineProviderService.startDeviceAuth();
+		},
+		completeClineDeviceAuth: async (_workspaceScope, input) => {
+			const body = parseClineDeviceAuthCompleteRequest(input);
+			return await clineProviderService.completeDeviceAuth({
+				deviceCode: body.deviceCode,
+				expiresInSeconds: body.expiresInSeconds,
+				pollIntervalSeconds: body.pollIntervalSeconds,
 				baseUrl: body.baseUrl,
 			});
 		},

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -447,6 +447,25 @@ export function ClineSetupSection({
 								Expiry: <span className="text-text-primary">{formatExpiry(controller.oauthExpiresAt)}</span>
 							</p>
 						) : null}
+						{controller.isRunningOauthLogin && controller.deviceAuthInfo ? (
+							<div className="mt-2 p-3 bg-surface-secondary rounded-md">
+								<p className="text-text-primary text-[13px] font-medium mb-1">
+									Enter this code in your browser:
+								</p>
+								<p className="text-text-primary text-[18px] font-mono font-bold tracking-wider mb-2">
+									{controller.deviceAuthInfo.userCode}
+								</p>
+								<a
+									href={controller.deviceAuthInfo.verificationUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-accent text-[12px] underline"
+								>
+									{controller.deviceAuthInfo.verificationUrl}
+								</a>
+								<p className="text-text-secondary text-[11px] mt-1">Waiting for browser confirmation...</p>
+							</div>
+						) : null}
 						<div className="mt-2">
 							<Button
 								variant="default"
@@ -455,7 +474,9 @@ export function ClineSetupSection({
 								onClick={handleOauthLogin}
 							>
 								{controller.isRunningOauthLogin
-									? "Signing in..."
+									? controller.deviceAuthInfo
+										? "Waiting for confirmation..."
+										: "Signing in..."
 									: controller.oauthConfigured
 										? `Sign in again with ${controller.managedOauthProvider ?? "OAuth"}`
 										: `Sign in with ${controller.managedOauthProvider ?? "OAuth"}`}

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -1,6 +1,6 @@
 import * as RadixCheckbox from "@radix-ui/react-checkbox";
-import { Check, ExternalLink, Pencil, Plus, X } from "lucide-react";
-import { type ReactElement, type ReactNode, useMemo, useState } from "react";
+import { Check, Copy, ExternalLink, Pencil, Plus, X } from "lucide-react";
+import { type ReactElement, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import {
 	buildClineAgentModelPickerOptions,
@@ -23,6 +23,7 @@ import type { UseRuntimeSettingsClineMcpControllerResult } from "@/hooks/use-run
 import { openFileOnHost } from "@/runtime/runtime-config-query";
 import type { RuntimeClineMcpServer, RuntimeClineReasoningEffort } from "@/runtime/types";
 import { formatPathForDisplay } from "@/utils/path-display";
+import { useCopyToClipboard } from "@/utils/react-use";
 
 function formatExpiry(value: string): string {
 	const trimmed = value.trim();
@@ -71,6 +72,42 @@ export function ClineSetupSection({
 	const mcpControlsDisabled = controlsDisabled || (mcpController?.isSavingMcpSettings ?? false);
 	const [isAddProviderDialogOpen, setIsAddProviderDialogOpen] = useState(false);
 	const [providerDialogMode, setProviderDialogMode] = useState<ClineProviderDialogMode>("add");
+	const [isDeviceCodeCopied, setIsDeviceCodeCopied] = useState(false);
+	const deviceCodeCopiedResetTimerRef = useRef<number | null>(null);
+	const [copiedDeviceCodeState, copyDeviceCode] = useCopyToClipboard();
+
+	useEffect(() => {
+		return () => {
+			if (deviceCodeCopiedResetTimerRef.current !== null) {
+				window.clearTimeout(deviceCodeCopiedResetTimerRef.current);
+				deviceCodeCopiedResetTimerRef.current = null;
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		setIsDeviceCodeCopied(false);
+	}, [controller.deviceAuthInfo?.userCode]);
+
+	useEffect(() => {
+		if (!copiedDeviceCodeState.value || copiedDeviceCodeState.value !== controller.deviceAuthInfo?.userCode) {
+			return;
+		}
+		if (copiedDeviceCodeState.error) {
+			onError?.("Could not copy code automatically. Please copy it manually.");
+			setIsDeviceCodeCopied(false);
+			return;
+		}
+		onError?.(null);
+		setIsDeviceCodeCopied(true);
+		if (deviceCodeCopiedResetTimerRef.current !== null) {
+			window.clearTimeout(deviceCodeCopiedResetTimerRef.current);
+		}
+		deviceCodeCopiedResetTimerRef.current = window.setTimeout(() => {
+			setIsDeviceCodeCopied(false);
+			deviceCodeCopiedResetTimerRef.current = null;
+		}, 2000);
+	}, [copiedDeviceCodeState, controller.deviceAuthInfo?.userCode, onError]);
 
 	const clineProviderOptions = useMemo((): SearchSelectOption[] => {
 		const items: SearchSelectOption[] = controller.providerCatalog.map((provider) => ({
@@ -221,6 +258,12 @@ export function ClineSetupSection({
 			const message = error instanceof Error ? error.message : String(error);
 			onError?.(`Could not open file on host: ${message}`);
 		});
+	};
+
+	const handleCopyDeviceCode = (code: string) => {
+		setIsDeviceCodeCopied(false);
+		onError?.(null);
+		copyDeviceCode(code);
 	};
 
 	return (
@@ -448,22 +491,44 @@ export function ClineSetupSection({
 							</p>
 						) : null}
 						{controller.isRunningOauthLogin && controller.deviceAuthInfo ? (
-							<div className="mt-2 p-3 bg-surface-2 rounded-md">
-								<p className="text-text-primary text-[13px] font-medium mb-1">
-									Enter this code in your browser:
-								</p>
-								<p className="text-text-primary text-[18px] font-mono font-bold tracking-wider mb-2">
-									{controller.deviceAuthInfo.userCode}
-								</p>
-								<a
-									href={controller.deviceAuthInfo.verificationUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="text-accent text-[12px] underline"
-								>
-									{controller.deviceAuthInfo.verificationUrl}
-								</a>
-								<p className="text-text-secondary text-[11px] mt-1">Waiting for browser confirmation...</p>
+							<div className="mt-2 rounded-md border border-border bg-surface-2 p-3">
+								<p className="text-text-secondary text-[13px] font-medium mt-0 mb-2">Sign in to Cline</p>
+								<ol className="list-decimal pl-4 text-[12px] text-text-primary m-0">
+									<li>
+										Go to this URL:{" "}
+										<a
+											href={controller.deviceAuthInfo.verificationUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="break-all text-accent underline"
+										>
+											{controller.deviceAuthInfo.verificationUrl}
+										</a>
+									</li>
+									<li className="mt-2">
+										Enter this code:
+										<div className="mt-1 flex items-center gap-2">
+											<p className="text-text-primary text-[18px] font-mono font-bold tracking-wider m-0">
+												{controller.deviceAuthInfo.userCode}
+											</p>
+											<Button
+												variant="ghost"
+												size="sm"
+												icon={isDeviceCodeCopied ? <Check size={14} /> : <Copy size={14} />}
+												onClick={() => {
+													const userCode = controller.deviceAuthInfo?.userCode;
+													if (!userCode) {
+														return;
+													}
+													handleCopyDeviceCode(userCode);
+												}}
+												disabled={controlsDisabled || !controller.deviceAuthInfo}
+											>
+												{isDeviceCodeCopied ? "Copied" : "Copy"}
+											</Button>
+										</div>
+									</li>
+								</ol>
 							</div>
 						) : null}
 						<div className="mt-2">

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -448,7 +448,7 @@ export function ClineSetupSection({
 							</p>
 						) : null}
 						{controller.isRunningOauthLogin && controller.deviceAuthInfo ? (
-							<div className="mt-2 p-3 bg-surface-secondary rounded-md">
+							<div className="mt-2 p-3 bg-surface-2 rounded-md">
 								<p className="text-text-primary text-[13px] font-medium mb-1">
 									Enter this code in your browser:
 								</p>

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
@@ -13,6 +13,7 @@ const saveClineProviderSettingsMock = vi.hoisted(() => vi.fn());
 const runClineProviderOauthLoginMock = vi.hoisted(() => vi.fn());
 const startClineDeviceAuthMock = vi.hoisted(() => vi.fn());
 const completeClineDeviceAuthMock = vi.hoisted(() => vi.fn());
+const isLocalhostAccessMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/runtime/runtime-config-query", () => ({
 	addClineProvider: addClineProviderMock,
@@ -23,6 +24,10 @@ vi.mock("@/runtime/runtime-config-query", () => ({
 	runClineProviderOauthLogin: runClineProviderOauthLoginMock,
 	startClineDeviceAuth: startClineDeviceAuthMock,
 	completeClineDeviceAuth: completeClineDeviceAuthMock,
+}));
+
+vi.mock("@/utils/localhost-detection", () => ({
+	isLocalhostAccess: isLocalhostAccessMock,
 }));
 
 interface HookSnapshot {
@@ -188,6 +193,8 @@ describe("useRuntimeSettingsClineController", () => {
 		runClineProviderOauthLoginMock.mockReset();
 		startClineDeviceAuthMock.mockReset();
 		completeClineDeviceAuthMock.mockReset();
+		isLocalhostAccessMock.mockReset();
+		isLocalhostAccessMock.mockReturnValue(true);
 		fetchClineProviderCatalogMock.mockResolvedValue([]);
 		fetchClineProviderModelsMock.mockResolvedValue([]);
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -801,7 +808,8 @@ describe("useRuntimeSettingsClineController", () => {
 		expect(requireSnapshot(latestSnapshot).hasUnsavedChanges).toBe(false);
 	});
 
-	it("applies OAuth login results to the local settings state", async () => {
+	it("applies OAuth login results to the local settings state (device auth, remote)", async () => {
+		isLocalhostAccessMock.mockReturnValue(false);
 		const config = createRuntimeConfigResponse({
 			providerId: "cline",
 			oauthProvider: "cline",
@@ -865,6 +873,7 @@ describe("useRuntimeSettingsClineController", () => {
 	});
 
 	it("uses the provider default when OAuth login returns no model", async () => {
+		isLocalhostAccessMock.mockReturnValue(false);
 		const config = createRuntimeConfigResponse({
 			providerId: "cline",
 			oauthProvider: "cline",
@@ -1041,5 +1050,127 @@ describe("useRuntimeSettingsClineController", () => {
 			reasoningEffort: null,
 		});
 		expect(requireSnapshot(latestSnapshot).baseUrl).toBe("");
+	});
+
+	it("uses browser OAuth for cline provider when accessing from localhost", async () => {
+		isLocalhostAccessMock.mockReturnValue(true);
+		const config = createRuntimeConfigResponse({
+			providerId: "cline",
+			oauthProvider: "cline",
+			oauthAccessTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		});
+		let latestSnapshot: HookSnapshot | null = null;
+		runClineProviderOauthLoginMock.mockResolvedValue({
+			ok: true,
+			provider: "cline",
+			settings: {
+				providerId: "cline",
+				modelId: "claude-sonnet-4-6",
+				baseUrl: null,
+				reasoningEffort: null,
+				apiKeyConfigured: false,
+				oauthProvider: "cline",
+				oauthAccessTokenConfigured: true,
+				oauthRefreshTokenConfigured: true,
+				oauthAccountId: "acct-browser",
+				oauthExpiresAt: 123456789,
+			},
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					open={true}
+					workspaceId="workspace-1"
+					selectedAgentId="cline"
+					config={config}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			expect(await requireSnapshot(latestSnapshot).runOauthLogin()).toEqual({ ok: true });
+		});
+
+		// Should use browser OAuth, NOT device auth
+		expect(runClineProviderOauthLoginMock).toHaveBeenCalledWith("workspace-1", {
+			provider: "cline",
+		});
+		expect(startClineDeviceAuthMock).not.toHaveBeenCalled();
+		expect(completeClineDeviceAuthMock).not.toHaveBeenCalled();
+		expect(requireSnapshot(latestSnapshot).oauthConfigured).toBe(true);
+		expect(requireSnapshot(latestSnapshot).oauthAccountId).toBe("acct-browser");
+		expect(requireSnapshot(latestSnapshot).hasUnsavedChanges).toBe(false);
+	});
+
+	it("uses device auth for cline provider when accessing remotely", async () => {
+		isLocalhostAccessMock.mockReturnValue(false);
+		const config = createRuntimeConfigResponse({
+			providerId: "cline",
+			oauthProvider: "cline",
+			oauthAccessTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		});
+		let latestSnapshot: HookSnapshot | null = null;
+		startClineDeviceAuthMock.mockResolvedValue({
+			deviceCode: "device-code-headless",
+			userCode: "HEAD-LESS",
+			verificationUrl: "https://auth.cline.bot/verify",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
+		});
+		completeClineDeviceAuthMock.mockResolvedValue({
+			ok: true,
+			provider: "cline",
+			settings: {
+				providerId: "cline",
+				modelId: "claude-sonnet-4-6",
+				baseUrl: null,
+				reasoningEffort: null,
+				apiKeyConfigured: false,
+				oauthProvider: "cline",
+				oauthAccessTokenConfigured: true,
+				oauthRefreshTokenConfigured: true,
+				oauthAccountId: "acct-device",
+				oauthExpiresAt: 123456789,
+			},
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					open={true}
+					workspaceId="workspace-1"
+					selectedAgentId="cline"
+					config={config}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			expect(await requireSnapshot(latestSnapshot).runOauthLogin()).toEqual({ ok: true });
+		});
+
+		// Should use device auth, NOT browser OAuth
+		expect(startClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1");
+		expect(completeClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1", {
+			deviceCode: "device-code-headless",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
+		});
+		expect(runClineProviderOauthLoginMock).not.toHaveBeenCalled();
+		expect(requireSnapshot(latestSnapshot).oauthConfigured).toBe(true);
+		expect(requireSnapshot(latestSnapshot).oauthAccountId).toBe("acct-device");
 	});
 });

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
@@ -11,6 +11,8 @@ const addClineProviderMock = vi.hoisted(() => vi.fn());
 const updateClineProviderMock = vi.hoisted(() => vi.fn());
 const saveClineProviderSettingsMock = vi.hoisted(() => vi.fn());
 const runClineProviderOauthLoginMock = vi.hoisted(() => vi.fn());
+const startClineDeviceAuthMock = vi.hoisted(() => vi.fn());
+const completeClineDeviceAuthMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/runtime/runtime-config-query", () => ({
 	addClineProvider: addClineProviderMock,
@@ -19,6 +21,8 @@ vi.mock("@/runtime/runtime-config-query", () => ({
 	fetchClineProviderModels: fetchClineProviderModelsMock,
 	saveClineProviderSettings: saveClineProviderSettingsMock,
 	runClineProviderOauthLogin: runClineProviderOauthLoginMock,
+	startClineDeviceAuth: startClineDeviceAuthMock,
+	completeClineDeviceAuth: completeClineDeviceAuthMock,
 }));
 
 interface HookSnapshot {
@@ -182,6 +186,8 @@ describe("useRuntimeSettingsClineController", () => {
 		updateClineProviderMock.mockReset();
 		saveClineProviderSettingsMock.mockReset();
 		runClineProviderOauthLoginMock.mockReset();
+		startClineDeviceAuthMock.mockReset();
+		completeClineDeviceAuthMock.mockReset();
 		fetchClineProviderCatalogMock.mockResolvedValue([]);
 		fetchClineProviderModelsMock.mockResolvedValue([]);
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -804,7 +810,14 @@ describe("useRuntimeSettingsClineController", () => {
 			oauthExpiresAt: null,
 		});
 		let latestSnapshot: HookSnapshot | null = null;
-		runClineProviderOauthLoginMock.mockResolvedValue({
+		startClineDeviceAuthMock.mockResolvedValue({
+			deviceCode: "device-code-1",
+			userCode: "ABCD-1234",
+			verificationUrl: "https://auth.cline.bot/verify",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
+		});
+		completeClineDeviceAuthMock.mockResolvedValue({
 			ok: true,
 			provider: "cline",
 			settings: {
@@ -840,8 +853,11 @@ describe("useRuntimeSettingsClineController", () => {
 			expect(await requireSnapshot(latestSnapshot).runOauthLogin()).toEqual({ ok: true });
 		});
 
-		expect(runClineProviderOauthLoginMock).toHaveBeenCalledWith("workspace-1", {
-			provider: "cline",
+		expect(startClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1");
+		expect(completeClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1", {
+			deviceCode: "device-code-1",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
 		});
 		expect(requireSnapshot(latestSnapshot).oauthConfigured).toBe(true);
 		expect(requireSnapshot(latestSnapshot).oauthAccountId).toBe("acct-123");
@@ -868,7 +884,14 @@ describe("useRuntimeSettingsClineController", () => {
 				baseUrl: "https://api.cline.bot/api/v1",
 			},
 		]);
-		runClineProviderOauthLoginMock.mockResolvedValue({
+		startClineDeviceAuthMock.mockResolvedValue({
+			deviceCode: "device-code-2",
+			userCode: "EFGH-5678",
+			verificationUrl: "https://auth.cline.bot/verify",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
+		});
+		completeClineDeviceAuthMock.mockResolvedValue({
 			ok: true,
 			provider: "cline",
 			settings: {
@@ -908,8 +931,11 @@ describe("useRuntimeSettingsClineController", () => {
 			expect(await requireSnapshot(latestSnapshot).runOauthLogin()).toEqual({ ok: true });
 		});
 
-		expect(runClineProviderOauthLoginMock).toHaveBeenCalledWith("workspace-1", {
-			provider: "cline",
+		expect(startClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1");
+		expect(completeClineDeviceAuthMock).toHaveBeenCalledWith("workspace-1", {
+			deviceCode: "device-code-2",
+			expiresInSeconds: 300,
+			pollIntervalSeconds: 5,
 		});
 		expect(requireSnapshot(latestSnapshot).modelId).toBe("claude-sonnet-4-6");
 		expect(requireSnapshot(latestSnapshot).oauthConfigured).toBe(true);

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
@@ -5,14 +5,17 @@ import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, us
 import { getRuntimeClineProviderSettings } from "@/runtime/native-agent";
 import {
 	addClineProvider,
+	completeClineDeviceAuth,
 	fetchClineProviderCatalog,
 	fetchClineProviderModels,
 	runClineProviderOauthLogin,
 	saveClineProviderSettings,
+	startClineDeviceAuth,
 	updateClineProvider,
 } from "@/runtime/runtime-config-query";
 import type {
 	RuntimeAgentId,
+	RuntimeClineOauthLoginResponse,
 	RuntimeClineOauthProvider,
 	RuntimeClineProviderCapability,
 	RuntimeClineProviderCatalogItem,
@@ -121,6 +124,7 @@ export interface UseRuntimeSettingsClineControllerResult {
 	isLoadingProviderCatalog: boolean;
 	isLoadingProviderModels: boolean;
 	isRunningOauthLogin: boolean;
+	deviceAuthInfo: { userCode: string; verificationUrl: string } | null;
 	normalizedProviderId: string;
 	managedOauthProvider: RuntimeClineOauthProvider | null;
 	isOauthProviderSelected: boolean;
@@ -217,6 +221,10 @@ export function useRuntimeSettingsClineController(
 	const [isLoadingProviderCatalog, setIsLoadingProviderCatalog] = useState(false);
 	const [isLoadingProviderModels, setIsLoadingProviderModels] = useState(false);
 	const [isRunningOauthLogin, setIsRunningOauthLogin] = useState(false);
+	const [deviceAuthInfo, setDeviceAuthInfo] = useState<{
+		userCode: string;
+		verificationUrl: string;
+	} | null>(null);
 
 	const effectiveProviderSettings = getEffectiveProviderSettings(config, providerSettingsOverride);
 	const configProviderSettings = getRuntimeClineProviderSettings(config);
@@ -611,21 +619,33 @@ export function useRuntimeSettingsClineController(
 
 	const runOauthLogin = useCallback(async (): Promise<SaveResult> => {
 		if (!managedOauthProvider) {
-			return {
-				ok: false,
-				message: "Choose an OAuth provider from the Provider field first.",
-			};
+			return { ok: false, message: "Choose an OAuth provider from the Provider field first." };
 		}
 		setIsRunningOauthLogin(true);
+		setDeviceAuthInfo(null);
 		try {
-			const response = await runClineProviderOauthLogin(workspaceId, {
-				provider: managedOauthProvider,
-			});
+			let response: RuntimeClineOauthLoginResponse;
+			if (managedOauthProvider === "cline") {
+				// Two-phase device auth
+				const startResult = await startClineDeviceAuth(workspaceId);
+				setDeviceAuthInfo({
+					userCode: startResult.userCode,
+					verificationUrl: startResult.verificationUrl,
+				});
+				response = await completeClineDeviceAuth(workspaceId, {
+					deviceCode: startResult.deviceCode,
+					expiresInSeconds: startResult.expiresInSeconds,
+					pollIntervalSeconds: startResult.pollIntervalSeconds,
+				});
+			} else {
+				// Legacy flow for oca / openai-codex
+				response = await runClineProviderOauthLogin(workspaceId, {
+					provider: managedOauthProvider,
+				});
+			}
+			setDeviceAuthInfo(null);
 			if (!response.ok) {
-				return {
-					ok: false,
-					message: response.error ?? "OAuth login failed.",
-				};
+				return { ok: false, message: response.error ?? "OAuth login failed." };
 			}
 			const nextSettings = response.settings ?? null;
 			if (nextSettings) {
@@ -639,12 +659,10 @@ export function useRuntimeSettingsClineController(
 			setProviderSettingsOverride(nextSettings);
 			return { ok: true };
 		} catch (error) {
-			return {
-				ok: false,
-				message: error instanceof Error ? error.message : String(error),
-			};
+			return { ok: false, message: error instanceof Error ? error.message : String(error) };
 		} finally {
 			setIsRunningOauthLogin(false);
+			setDeviceAuthInfo(null);
 		}
 	}, [managedOauthProvider, providerCatalog, providerId, workspaceId]);
 
@@ -722,6 +740,7 @@ export function useRuntimeSettingsClineController(
 		isLoadingProviderCatalog,
 		isLoadingProviderModels,
 		isRunningOauthLogin,
+		deviceAuthInfo,
 		normalizedProviderId,
 		managedOauthProvider,
 		isOauthProviderSelected,

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
@@ -25,6 +25,7 @@ import type {
 	RuntimeConfigResponse,
 	RuntimeTaskClineSettings,
 } from "@/runtime/types";
+import { isLocalhostAccess } from "@/utils/localhost-detection";
 
 interface UseRuntimeSettingsClineControllerOptions {
 	open: boolean;
@@ -625,8 +626,12 @@ export function useRuntimeSettingsClineController(
 		setDeviceAuthInfo(null);
 		try {
 			let response: RuntimeClineOauthLoginResponse;
-			if (managedOauthProvider === "cline") {
-				// Two-phase device auth
+			// Local users (accessing via localhost) get the smoother browser OAuth
+			// flow. Remote/headless users fall back to the device-code flow since
+			// the server may not be able to open the user's browser.
+			const useDeviceAuth = managedOauthProvider === "cline" && !isLocalhostAccess();
+			if (useDeviceAuth) {
+				// Two-phase device auth for remote/headless environments
 				const startResult = await startClineDeviceAuth(workspaceId);
 				setDeviceAuthInfo({
 					userCode: startResult.userCode,
@@ -638,7 +643,7 @@ export function useRuntimeSettingsClineController(
 					pollIntervalSeconds: startResult.pollIntervalSeconds,
 				});
 			} else {
-				// Legacy flow for oca / openai-codex
+				// Browser OAuth flow for local sessions and non-cline providers
 				response = await runClineProviderOauthLogin(workspaceId, {
 					provider: managedOauthProvider,
 				});

--- a/web-ui/src/runtime/runtime-config-query.ts
+++ b/web-ui/src/runtime/runtime-config-query.ts
@@ -9,6 +9,9 @@ import type {
 	RuntimeClineAccountProfileResponse,
 	RuntimeClineAccountSwitchResponse,
 	RuntimeClineAddProviderResponse,
+	RuntimeClineDeviceAuthCompleteRequest,
+	RuntimeClineDeviceAuthCompleteResponse,
+	RuntimeClineDeviceAuthStartResponse,
 	RuntimeClineKanbanAccessResponse,
 	RuntimeClineMcpAuthStatusResponse,
 	RuntimeClineMcpOAuthResponse,
@@ -158,6 +161,19 @@ export async function runClineProviderOauthLogin(
 ): Promise<RuntimeClineOauthLoginResponse> {
 	const trpcClient = getRuntimeTrpcClient(workspaceId);
 	return await trpcClient.runtime.runClineProviderOAuthLogin.mutate(input);
+}
+
+export async function startClineDeviceAuth(workspaceId: string | null): Promise<RuntimeClineDeviceAuthStartResponse> {
+	const trpcClient = getRuntimeTrpcClient(workspaceId);
+	return await trpcClient.runtime.startClineDeviceAuth.mutate();
+}
+
+export async function completeClineDeviceAuth(
+	workspaceId: string | null,
+	input: RuntimeClineDeviceAuthCompleteRequest,
+): Promise<RuntimeClineDeviceAuthCompleteResponse> {
+	const trpcClient = getRuntimeTrpcClient(workspaceId);
+	return await trpcClient.runtime.completeClineDeviceAuth.mutate(input);
 }
 
 export async function fetchClineMcpSettings(workspaceId: string | null): Promise<RuntimeClineMcpSettingsResponse> {

--- a/web-ui/src/utils/react-use.ts
+++ b/web-ui/src/utils/react-use.ts
@@ -1,6 +1,7 @@
 import type { DependencyList, Dispatch, SetStateAction } from "react";
 import { useCallback } from "react";
 import {
+	useCopyToClipboard as useReactUseCopyToClipboard,
 	useDebounce as useReactUseDebounce,
 	useEvent as useReactUseEvent,
 	useInterval as useReactUseInterval,
@@ -50,6 +51,10 @@ export function useInterval(callback: () => void, delayMs: number | null): void 
 
 export function useDebouncedEffect(effect: () => void, delayMs: number, deps: DependencyList): void {
 	useReactUseDebounce(effect, delayMs, deps);
+}
+
+export function useCopyToClipboard() {
+	return useReactUseCopyToClipboard();
 }
 
 function resolveNextValue<T>(nextValue: SetStateAction<T>, currentValue: T): T {


### PR DESCRIPTION
Add device auth types, tRPC mutations, and service methods for the new
two-phase WorkOS device authorization flow. The "cline" provider now
calls startClineDeviceAuth to get a user code and verification URL,
displays them in the UI, then polls via completeClineDeviceAuth.
Other providers (oca, openai-codex) continue using the existing
single-call OAuth flow.

Backend:
- api-contract.ts: DeviceAuthStart/Complete schemas and types
- api-validation.ts: parseClineDeviceAuthCompleteRequest
- app-router.ts: startClineDeviceAuth and completeClineDeviceAuth tRPC mutations
- runtime-api.ts: delegates to cline-provider-service
- sdk-provider-boundary.ts: boundary wrappers for SDK device auth functions
- cline-provider-service.ts: startDeviceAuth and completeDeviceAuth methods

Frontend:
- runtime-config-query.ts: startClineDeviceAuth and completeClineDeviceAuth helpers
- use-runtime-settings-cline-controller.ts: two-phase runOauthLogin, deviceAuthInfo state
- cline-setup-section.tsx: device code card UI with verification URL
- controller test: updated mocks for device auth flow
