### PR TITLE
feat: add Hermes agent executor support

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -54,7 +54,7 @@ const PROJECT_CONFIG_PARENT_DIR = ".cline";
 const PROJECT_CONFIG_DIR = "kanban";
 const PROJECT_CONFIG_FILENAME = "config.json";
 const DEFAULT_AGENT_ID: RuntimeAgentId = "cline";
-const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = ["claude", "codex", "droid", "kiro"];
+const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = ["hermes", "claude", "codex", "droid", "kiro"];
 const DEFAULT_AGENT_AUTONOMOUS_MODE_ENABLED = true;
 const DEFAULT_READY_FOR_REVIEW_NOTIFICATIONS_ENABLED = true;
 const DEFAULT_COMMIT_PROMPT_TEMPLATE = `You are in a worktree on a detached HEAD. When you are finished with the task, commit the working changes onto {{base_ref}}.
@@ -124,6 +124,7 @@ function normalizeAgentId(agentId: RuntimeAgentId | string | null | undefined): 
 			agentId === "opencode" ||
 			agentId === "droid" ||
 			agentId === "kiro" ||
+			agentId === "hermes" ||
 			agentId === "cline") &&
 		isRuntimeAgentLaunchSupported(agentId)
 	) {

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -59,6 +59,14 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		installUrl: "https://kiro.dev",
 	},
 	{
+		id: "hermes",
+		label: "Hermes Agent",
+		binary: "hermes",
+		baseArgs: ["chat"],
+		autonomousArgs: ["--yolo"],
+		installUrl: "https://github.com/NousResearch/hermes-agent",
+	},
+	{
 		id: "gemini",
 		label: "Gemini CLI",
 		binary: "gemini",
@@ -72,6 +80,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 // Re-enable additional CLIs by uncommenting entries below when ready.
 export const RUNTIME_LAUNCH_SUPPORTED_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"cline",
+	"hermes",
 	"claude",
 	"codex",
 	"droid",

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -71,7 +71,16 @@ export const runtimeSlashCommandsResponseSchema = z.object({
 });
 export type RuntimeSlashCommandsResponse = z.infer<typeof runtimeSlashCommandsResponseSchema>;
 
-export const runtimeAgentIdSchema = z.enum(["claude", "codex", "gemini", "opencode", "droid", "kiro", "cline"]);
+export const runtimeAgentIdSchema = z.enum([
+	"claude",
+	"codex",
+	"gemini",
+	"opencode",
+	"droid",
+	"kiro",
+	"hermes",
+	"cline",
+]);
 export type RuntimeAgentId = z.infer<typeof runtimeAgentIdSchema>;
 
 export const runtimeBoardColumnIdSchema = z.enum(["backlog", "in_progress", "review", "trash"]);

--- a/src/prompts/append-system-prompt.ts
+++ b/src/prompts/append-system-prompt.ts
@@ -30,6 +30,7 @@ const APPEND_PROMPT_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"cline",
 	"droid",
 	"kiro",
+	"hermes",
 	"gemini",
 	"opencode",
 ];
@@ -66,6 +67,8 @@ function renderLinearSetupGuidanceForAgent(agentId: RuntimeAgentId | null): stri
 			return "- If Linear MCP is not available in the current agent (Droid), suggest running: `droid mcp add linear https://mcp.linear.app/mcp --type http`";
 		case "kiro":
 			return "- If Linear MCP is not available in the current agent (Kiro CLI), suggest running: `kiro-cli mcp add --name linear --url https://mcp.linear.app/mcp --scope global`";
+		case "hermes":
+			return "- If Linear MCP is not available in the current agent (Hermes Agent), suggest running: `hermes mcp add linear --url https://mcp.linear.app/mcp --auth oauth`";
 		default:
 			return "- If Linear MCP is not available, provide setup instructions for the active agent only, then continue once OAuth is complete.";
 	}

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -2,13 +2,13 @@ import { access, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-
 import type {
 	RuntimeAgentId,
 	RuntimeHookEvent,
 	RuntimeTaskImage,
 	RuntimeTaskSessionSummary,
 } from "../core/api-contract";
+import { isHomeAgentSessionId } from "../core/home-agent-session";
 import { buildKanbanCommandParts } from "../core/kanban-command";
 import { quoteShellArg } from "../core/shell";
 import { lockedFileSystem } from "../fs/locked-file-system";
@@ -618,6 +618,16 @@ function withPrompt(args: string[], prompt: string, mode: "append" | "flag", fla
 
 function toBracketedPasteSubmission(command: string): string {
 	return `\u001b[200~${command}\u001b[201~\r`;
+}
+
+function buildSoftPlanPrompt(prompt: string): string {
+	const trimmedPrompt = prompt.trim();
+	return [
+		"First, inspect the codebase and produce a clear implementation plan only.",
+		"Do not modify files, do not use write tools, and do not implement anything yet.",
+		"After you present the plan, ask for approval before making changes.",
+		trimmedPrompt ? `\n\nTask:\n${trimmedPrompt}` : " Ask the user what they want planned if the task is unclear.",
+	].join(" ");
 }
 
 const claudeAdapter: AgentSessionAdapter = {
@@ -1373,18 +1383,50 @@ const kiroAdapter: AgentSessionAdapter = {
 			}
 		}
 
-		const trimmedPrompt = input.prompt.trim();
-		const planPrompt = input.startInPlanMode
-			? [
-					"First, inspect the codebase and produce a clear implementation plan only.",
-					"Do not modify files, do not use write tools, and do not implement anything yet.",
-					"After you present the plan, ask for approval before making changes.",
-					trimmedPrompt
-						? `\n\nTask:\n${trimmedPrompt}`
-						: " Ask the user what they want planned if the task is unclear.",
-				].join(" ")
-			: input.prompt;
+		const planPrompt = input.startInPlanMode ? buildSoftPlanPrompt(input.prompt) : input.prompt;
 		const withPromptLaunch = withPrompt(args, planPrompt, "append");
+		return {
+			...withPromptLaunch,
+			env: {
+				...withPromptLaunch.env,
+				...env,
+			},
+		};
+	},
+};
+
+const hermesAdapter: AgentSessionAdapter = {
+	async prepare(input) {
+		const args = [...input.args];
+		const env: Record<string, string | undefined> = {};
+		const appendedSystemPrompt = resolveHomeAgentAppendSystemPrompt(input.taskId);
+		const isHomeSession = isHomeAgentSessionId(input.taskId);
+
+		if (input.autonomousModeEnabled && !hasCliOption(args, "--yolo")) {
+			args.push("--yolo");
+		}
+
+		if (!hasCliOption(args, "--source")) {
+			args.push("--source", "tool");
+		}
+
+		if (appendedSystemPrompt) {
+			env.HERMES_EPHEMERAL_SYSTEM_PROMPT = appendedSystemPrompt;
+		}
+
+		if (isHomeSession) {
+			return {
+				args,
+				env,
+			};
+		}
+
+		if (!hasCliOption(args, "--quiet") && !hasCliOption(args, "-Q")) {
+			args.push("--quiet");
+		}
+
+		const prompt = input.startInPlanMode ? buildSoftPlanPrompt(input.prompt) : input.prompt;
+		const withPromptLaunch = withPrompt(args, prompt, "flag", "-q");
 		return {
 			...withPromptLaunch,
 			env: {
@@ -1459,6 +1501,7 @@ const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	opencode: opencodeAdapter,
 	droid: droidAdapter,
 	kiro: kiroAdapter,
+	hermes: hermesAdapter,
 	cline: clineAdapter,
 };
 

--- a/web-ui/src/components/runtime-settings-dialog.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.tsx
@@ -76,8 +76,12 @@ function buildDisplayedAgentCommand(agentId: RuntimeAgentId, binary: string, aut
 	if (agentId === "cline") {
 		return "";
 	}
-	const args = autonomousModeEnabled ? (getRuntimeAgentCatalogEntry(agentId)?.autonomousArgs ?? []) : [];
-	return [binary, ...args.map(quoteCommandPartForDisplay)].join(" ");
+	const catalogEntry = getRuntimeAgentCatalogEntry(agentId);
+	const baseArgs = catalogEntry?.baseArgs ?? [];
+	const autonomousArgs = autonomousModeEnabled ? (catalogEntry?.autonomousArgs ?? []) : [];
+	return [binary, ...baseArgs.map(quoteCommandPartForDisplay), ...autonomousArgs.map(quoteCommandPartForDisplay)].join(
+		" ",
+	);
 }
 
 function normalizeTemplateForComparison(value: string): string {
@@ -91,7 +95,7 @@ const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string }>
 
 export type RuntimeSettingsSection = "shortcuts";
 
-const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "hermes", "claude", "codex", "droid", "kiro"];
 
 type SettingsNavId = "general" | "cline" | "git-prompts" | "notifications" | "appearance" | "project";
 

--- a/web-ui/src/components/task-agent-model-picker.tsx
+++ b/web-ui/src/components/task-agent-model-picker.tsx
@@ -22,6 +22,8 @@ import type {
 	RuntimeTaskClineSettings,
 } from "@/runtime/types";
 
+const TASK_AGENT_PICKER_ORDER: readonly RuntimeAgentId[] = ["cline", "hermes", "claude", "codex", "droid", "kiro"];
+
 // ---------------------------------------------------------------------------
 // Hook: manages fetch state for Cline provider catalog + model lists
 // ---------------------------------------------------------------------------
@@ -128,7 +130,12 @@ export function useTaskAgentModelPicker({
 	}, [active, effectiveAgentId, effectiveProviderId, workspaceId]);
 
 	const agentOptions = useMemo(() => {
-		const catalog = getRuntimeLaunchSupportedAgentCatalog();
+		const orderIndexByAgentId = new Map(TASK_AGENT_PICKER_ORDER.map((agentId, index) => [agentId, index] as const));
+		const catalog = [...getRuntimeLaunchSupportedAgentCatalog()].sort((left, right) => {
+			const leftOrderIndex = orderIndexByAgentId.get(left.id) ?? Number.MAX_SAFE_INTEGER;
+			const rightOrderIndex = orderIndexByAgentId.get(right.id) ?? Number.MAX_SAFE_INTEGER;
+			return leftOrderIndex - rightOrderIndex;
+		});
 		let firstLabel = "Default";
 		if (defaultAgentId) {
 			const defaultAgent = catalog.find((a) => a.id === defaultAgentId);

--- a/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
+++ b/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
@@ -83,7 +83,7 @@ export const TASK_START_ONBOARDING_SLIDES: OnboardingSlide[] = [
 	},
 ];
 
-const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = ["cline", "hermes", "claude", "codex", "droid", "kiro"];
 const FALLBACK_ONBOARDING_SLIDE: OnboardingSlide = {
 	kind: "agent-selection",
 	title: "",


### PR DESCRIPTION
## Summary
- add Hermes Agent as a first-class runtime executor option
- wire Hermes into runtime config, agent catalog, launch resolution, and sidebar prompt guidance
- expose Hermes in settings, onboarding, and task agent selection with improved ordering and command display

## Implementation details
- detect Hermes via the `hermes` binary and launch it with `hermes chat`
- use one-shot quiet query mode for task execution and a planning-only prompt rewrite for plan mode
- keep home/sidebar Hermes sessions interactive via an ephemeral system prompt
- add Hermes-specific Linear MCP setup guidance for sidebar sessions

## Validation
- ran backend and web typecheck
- ran lint successfully
- verified the focused Hermes integration tests earlier during implementation

## Notes
- this PR is opened from the fork branch `cvvix:feat/hermes-agent-executor` into the upstream `cline/kanban` repository