### PR TITLE
refactor: extract shared runtime boundaries for desktop reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ playwright-report
 web-ui/.env
 web-ui/.env.*
 !web-ui/.env.example
+packages/desktop/out
+packages/desktop/*.tgz
+*.tgz

--- a/docs/desktop-runtime-simplification-checklist.md
+++ b/docs/desktop-runtime-simplification-checklist.md
@@ -1,0 +1,199 @@
+## Desktop runtime simplification checklist
+
+Goal: simplify `feature/desktop-app` to a **single-runtime model** where the desktop app is just a native shell around one known Kanban runtime endpoint.
+
+### Target behavior
+- On launch, desktop checks the configured/local runtime endpoint (default `127.0.0.1:3484`).
+- If healthy, desktop attaches to it.
+- If not healthy, desktop starts the Kanban runtime process and waits for health.
+- If runtime disconnects, desktop shows a recovery UI instead of doing failover/election.
+- Multi-window is just multiple BrowserWindows pointed at the same runtime URL.
+
+### Product rule to adopt explicitly
+- There is **one local runtime authority**.
+- Desktop does **not** do runtime discovery/election/failover across multiple runtimes.
+- Desktop and CLI both target the same configured endpoint.
+
+---
+
+## File-by-file checklist
+
+### `packages/desktop/src/main.ts`
+- [x] Remove runtime descriptor watcher logic.
+- [x] Remove runtime authority negotiation / attach-to-descriptor logic.
+- [x] Replace boot flow with:
+  - [x] check configured runtime health
+  - [x] attach if healthy
+  - [x] otherwise start runtime process
+  - [x] wait for health, then load windows
+- [x] Replace disconnect handling with recovery UI flow:
+  - [x] RuntimeChildManager auto-restarts (up to 3x)
+  - [x] renderer recovery shows reload/dismiss dialog on crash/fail
+  - [x] dedicated `disconnected.html` page shown when max restarts exceeded
+  - [x] terminal command hint (`kanban`) displayed in disconnected state
+  - [x] Restart button wired via `window.desktop.restartRuntime()` → IPC → `restartRuntime()`
+- [x] Keep multi-window behavior loading the same runtime URL.
+
+### `packages/desktop/src/connection-manager.ts`
+- [x] **Deleted.** No longer needed — the simplified main.ts handles the single-endpoint flow directly.
+
+### `packages/desktop/src/connection-store.ts`
+- [x] **Deleted.** Desktop no longer supports multiple saved/manual connections.
+
+### `packages/desktop/src/connection-menu.ts`
+- [x] **Deleted.** Desktop no longer exposes connection switching.
+
+### `packages/desktop/src/connection-utils.ts`
+- [x] **Deleted.** `isInsecureRemoteUrl` helper only served the connection manager.
+
+### `packages/desktop/src/auth.ts`
+- [x] **Deleted.** Auth header interceptor replaced by simple cookie set in main.ts.
+
+### `packages/desktop/src/desktop-boot-state.ts`
+- [x] **Deleted.** Complex boot state machine replaced by simple `runtimeUrl` null check.
+
+### `packages/desktop/src/desktop-failure-codes.ts`
+- [x] **Deleted.** Failure code enum only served the boot state machine.
+
+### `packages/desktop/src/desktop-failure.ts`
+- [x] **Deleted.** Failure dialog only served the boot state machine.
+
+### `packages/desktop/src/orphan-cleanup.ts`
+- [x] **Deleted.** Orphan process cleanup only served the descriptor trust system.
+
+### `packages/desktop/src/renderer-recovery.ts`
+- [x] **Deleted.** Inlined as `attachSimpleRecovery()` in main.ts — just reloads the URL, no ConnectionManager dependency.
+
+### `packages/desktop/src/runtime-child.ts`
+- [x] **Kept as-is.** Desktop still forks the bundled runtime child entry point. Works well for the single-runtime model.
+
+### `packages/desktop/src/kanban.d.ts`
+- [x] Remove declarations for deleted shared runtime-discovery/takeover APIs.
+- [x] Keep only imports actually used by simplified desktop main process.
+
+---
+
+### `src/core/runtime-descriptor.ts`
+- [ ] **Deferred.** Still used by CLI-side resolution. Desktop no longer imports it. Can be simplified further when CLI adopts the same single-endpoint model.
+
+### `src/core/runtime-takeover.ts`
+- [ ] **Deferred.** Desktop no longer imports it. Still exists for CLI failover use cases. Can be removed when product rule is fully adopted.
+
+### `src/core/runtime-endpoint.ts`
+- [ ] **Deferred.** Descriptor-first resolution still exists for CLI clients. Desktop bypasses it entirely (direct health check on known port). Can be simplified when CLI drops descriptor usage.
+
+### `src/runtime-start.ts`
+- [x] **Kept.** Desktop's runtime-child-entry.ts still uses `startRuntime()` from this module. The API surface is already minimal.
+
+### `src/cli.ts`
+- [ ] **Deferred.** CLI still uses descriptor-based attach. Not blocking desktop simplification.
+
+### `src/server/runtime-server.ts`
+- [ ] **Deferred.** Auth bootstrap and workspace watcher are server-side concerns. Not blocking desktop simplification.
+
+### `src/server/workspace-state-watcher.ts`
+- [ ] **Deferred.** Still useful if CLI and desktop runtimes coexist on the same machine writing to shared state directories. Not blocking desktop simplification.
+
+### `src/server/auth-middleware.ts`
+- [ ] **Deferred.** Localhost auth simplification is a server-side concern. Desktop works around it via cookie injection. Passcode protections for remote mode preserved.
+
+### `src/core/kanban-command.ts`
+- [x] **Kept.** Desktop uses the CLI shim path for the runtime child's `KANBAN_CLI_COMMAND` env var.
+
+### `src/core/scoped-command.ts`
+- [ ] **Deferred.** Not related to desktop simplification.
+
+### `src/core/shell.ts`
+- [x] **Kept.** Not directly used by desktop but still needed by runtime internals.
+
+---
+
+## Tests to remove/update
+
+### Deleted tests for removed architecture
+- [x] `packages/desktop/test/auth.test.ts`
+- [x] `packages/desktop/test/connection-manager.test.ts`
+- [x] `packages/desktop/test/connection-menu.test.ts`
+- [x] `packages/desktop/test/connection-store.test.ts`
+- [x] `packages/desktop/test/descriptor-trust.test.ts`
+- [x] `packages/desktop/test/desktop-boot-state.test.ts`
+- [x] `packages/desktop/test/desktop-failure.test.ts`
+- [x] `packages/desktop/test/main-connection-integration.test.ts`
+- [x] `packages/desktop/test/menu-gating.test.ts`
+- [x] `packages/desktop/test/orphan-cleanup.test.ts`
+- [x] `packages/desktop/test/renderer-recovery.test.ts`
+
+### Tests kept (still valid)
+- [x] `packages/desktop/test/cli-shim.test.ts`
+- [x] `packages/desktop/test/desktop-preflight.test.ts`
+- [x] `packages/desktop/test/ipc-protocol.test.ts`
+- [x] `packages/desktop/test/main.test.ts` (window state persistence)
+- [x] `packages/desktop/test/notarize.test.ts`
+- [x] `packages/desktop/test/oauth-relay.test.ts`
+- [x] `packages/desktop/test/protocol-handler.test.ts`
+- [x] `packages/desktop/test/runtime-child-manager.test.ts`
+- [x] `packages/desktop/test/runtime-child.test.ts`
+- [x] `packages/desktop/test/window-registry.test.ts`
+- [x] `packages/desktop/test/window-state.test.ts`
+
+### Deferred — shared runtime tests
+- [ ] `test/runtime/core/resolve-runtime-connection.test.ts` — still valid for CLI resolution
+- [ ] `test/runtime/workspace-state-watcher.test.ts` — still valid for server-side sync
+- [ ] `test/runtime/core/runtime-takeover.test.ts` — still valid for CLI failover
+
+### TODO — new tests for simplified model
+- [ ] desktop attaches to existing runtime on configured endpoint
+- [ ] desktop starts runtime if endpoint is down
+- [ ] desktop does not spawn duplicate runtime when one is already healthy
+- [ ] desktop multi-window loads same runtime URL
+- [ ] runtime disconnect shows recovery UI
+- [ ] restart/retry action reconnects successfully
+
+---
+
+## Implementation order (updated)
+
+1. [x] Decide final product rule for endpoint config (`3484` only vs shared configurable endpoint). → Default `127.0.0.1:3484`.
+2. [x] Simplify desktop boot flow in `main.ts`.
+3. [x] Replace connection manager with direct health check + child start in main.ts.
+4. [x] Remove connection switching / descriptor / takeover usage from desktop.
+5. [x] Delete desktop-side multi-runtime coordination files (10 source + 11 test files).
+6. [ ] Simplify server auth/bootstrap/watcher code made obsolete by single-runtime model.
+7. [ ] Add new tests for simplified desktop model.
+8. [ ] Do one end-to-end smoke pass:
+   - [ ] existing runtime attach
+   - [ ] cold start
+   - [ ] disconnect + restart
+   - [ ] multi-window
+
+---
+
+## Non-goals
+- No runtime authority election.
+- No descriptor-based discovery.
+- No automatic failover/takeover between desktop and CLI runtimes.
+- No multi-connection management in desktop unless product scope explicitly keeps it.
+
+---
+
+## Summary of changes (2026-04-14)
+
+**Deleted 10 source files, 11 test files. Rewrote main.ts from 1254 → ~760 lines. Added disconnected screen.**
+
+Net: +671 / -5,511 lines across 27 changed files.
+
+Desktop `packages/desktop/src/` went from 21 files → 12 files:
+- `desktop-preflight.ts` — kept (startup validation)
+- `disconnected.html` — **new** (styled "Runtime Disconnected" page with Restart button and `kanban` terminal hint)
+- `ipc-protocol.ts` — kept (parent↔child message types)
+- `kanban.d.ts` — trimmed (removed descriptor/takeover types)
+- `main.ts` — **rewritten** (lean health-check-or-start flow + `showDisconnectedScreen()` + `restart-runtime` IPC)
+- `oauth-relay.ts` — kept (OAuth callback forwarding)
+- `preload.ts` — updated (added `restartRuntime()` IPC bridge for disconnected screen)
+- `protocol-handler.ts` — kept (kanban:// deep links)
+- `runtime-child-entry.ts` — kept (child process bootstrap)
+- `runtime-child.ts` — kept (RuntimeChildManager)
+- `window-registry.ts` — kept (multi-window management)
+- `window-state.ts` — kept (window persistence)
+
+Build: `npm run build:ts` compiles TypeScript + bundles preload + copies `disconnected.html` to `dist/`. All 579 existing tests pass (4 pre-existing failures from missing `@clinebot/rpc` dependency unrelated to this work).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.1.61",
+  "version": "0.1.60",
   "description": "A kanban foundation for coding agents",
   "publishConfig": {
     "access": "public",
@@ -33,6 +33,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./runtime-start": {
+      "types": "./dist/runtime-start.d.ts",
+      "import": "./dist/runtime-start.js"
+    },
+    "./server/directory-picker": {
+      "types": "./dist/server/directory-picker.d.ts",
+      "import": "./dist/server/directory-picker.js"
+    },
+    "./core/runtime-descriptor": {
+      "types": "./dist/core/runtime-descriptor.d.ts",
+      "import": "./dist/core/runtime-descriptor.js"
     }
   },
   "files": [
@@ -42,7 +54,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "clean": "shx rm -rf dist coverage",
@@ -91,10 +103,10 @@
     "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9"
   },
   "dependencies": {
-    "@clinebot/agents": "^0.0.34",
-    "@clinebot/core": "^0.0.34",
-    "@clinebot/llms": "^0.0.34",
-    "@clinebot/shared": "^0.0.34",
+    "@clinebot/agents": "^0.0.33",
+    "@clinebot/core": "^0.0.33",
+    "@clinebot/llms": "^0.0.33",
+    "@clinebot/shared": "^0.0.33",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@sentry/node": "^10.45.0",
     "@trpc/client": "^11.11.0",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -63,6 +63,12 @@ await Promise.all([
 		entryPoints: ["src/index.ts"],
 		outfile: "dist/index.js",
 	}),
+	// Runtime start — standalone entry for Electron desktop embedding
+	esbuild.build({
+		...shared,
+		entryPoints: ["src/runtime-start.ts"],
+		outfile: "dist/runtime-start.js",
+	}),
 ]);
 
-console.log("esbuild: bundled dist/cli.js and dist/index.js");
+console.log("esbuild: bundled dist/cli.js, dist/index.js, and dist/runtime-start.js");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import packageJson from "../package.json" with { type: "json" };
 import { disposeCliTelemetryService } from "./cline-sdk/cline-telemetry-service.js";
 import { registerHooksCommand } from "./commands/hooks";
 import { registerTaskCommand } from "./commands/task";
+import { registerTokenCommand } from "./commands/token";
 import { loadGlobalRuntimeConfig, loadRuntimeConfig } from "./config/runtime-config";
 import type { RuntimeCommandRunResponse } from "./core/api-contract";
 import { createGitProcessEnv } from "./core/git-process-env";
@@ -16,6 +17,12 @@ import {
 	installGracefulShutdownHandlers,
 	shouldSuppressImmediateDuplicateShutdownSignals,
 } from "./core/graceful-shutdown";
+import {
+	clearRuntimeDescriptor,
+	isDescriptorStale,
+	readRuntimeDescriptor,
+	writeRuntimeDescriptor,
+} from "./core/runtime-descriptor";
 import {
 	buildKanbanRuntimeUrl,
 	clearKanbanRuntimeTls,
@@ -417,6 +424,8 @@ async function startServer(): Promise<{
 	});
 	runtimeStateHub = createRuntimeStateHub({
 		workspaceRegistry,
+		isLocal: !isKanbanRemoteHost(),
+		runtimeVersion: KANBAN_VERSION,
 	});
 	const runtimeHub = runtimeStateHub;
 	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
@@ -451,6 +460,7 @@ async function startServer(): Promise<{
 		disposeWorkspace: disposeTrackedWorkspace,
 		collectProjectWorktreeTaskIdsForRemoval,
 		pickDirectoryPathFromSystemDialog,
+		version: KANBAN_VERSION,
 	});
 
 	const close = async () => {
@@ -535,6 +545,58 @@ async function runMainCommand(options: CliOptions, shouldAutoOpenBrowser: boolea
 		currentVersion: KANBAN_VERSION,
 	});
 
+	// ── Attach-first: reuse existing healthy runtime ──────────────────
+	// If another runtime (CLI or desktop) is already serving, open the
+	// browser to it instead of spawning a second server. For desktop
+	// runtimes, we append ?auth=TOKEN to the URL so the server sets a
+	// session cookie and the browser can authenticate.
+	const existingDescriptor = await readRuntimeDescriptor();
+	if (existingDescriptor && !isDescriptorStale(existingDescriptor)) {
+		// Verify the runtime actually responds before attaching.
+		// Use origin only — the descriptor URL may include a workspace path
+		// (e.g. /cline) that would break the /api/health endpoint.
+		let reachable = false;
+		const descriptorOrigin = new URL(existingDescriptor.url).origin;
+		try {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), 2000);
+			const healthUrl = `${descriptorOrigin}/api/health`;
+			const resp = await fetch(healthUrl, { signal: controller.signal });
+			clearTimeout(timer);
+			reachable = resp.ok;
+		} catch {
+			// unreachable
+		}
+
+		if (reachable) {
+			console.log(
+				`Kanban runtime already running (${existingDescriptor.source}, pid ${existingDescriptor.pid}) at ${existingDescriptor.url}`,
+			);
+			if (!options.noOpen && shouldAutoOpenBrowser) {
+				// For desktop runtimes, append the auth token as a query param
+				// so the server can set a session cookie for the browser.
+				let browserUrl = existingDescriptor.url;
+				if (existingDescriptor.source === "desktop" && existingDescriptor.authToken) {
+					const parsed = new URL(existingDescriptor.url);
+					parsed.searchParams.set("auth", existingDescriptor.authToken);
+					browserUrl = parsed.toString();
+				}
+				try {
+					openInBrowser(browserUrl, {
+						warn: (message) => {
+							console.warn(message);
+						},
+					});
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					console.warn(`Could not open browser automatically: ${message}`);
+				}
+			}
+			return;
+		}
+		// Descriptor exists but runtime isn't reachable — start fresh.
+	}
+
 	let runtime: Awaited<ReturnType<typeof startServer>>;
 	try {
 		runtime = await startServerWithAutoPortRetry(options);
@@ -548,6 +610,19 @@ async function runMainCommand(options: CliOptions, shouldAutoOpenBrowser: boolea
 		}
 		throw error;
 	}
+
+	// Publish runtime descriptor so the desktop app (and other CLI
+	// invocations) can discover and attach to this runtime.
+	await writeRuntimeDescriptor({
+		url: runtime.url,
+		authToken: process.env.KANBAN_AUTH_TOKEN ?? "",
+		pid: process.pid,
+		updatedAt: new Date().toISOString(),
+		source: "cli",
+	}).catch(() => {
+		// Best effort — descriptor is a convenience, not critical.
+	});
+
 	console.log(`Cline Kanban running at ${runtime.url}`);
 	if (!options.noOpen && shouldAutoOpenBrowser) {
 		try {
@@ -574,6 +649,9 @@ async function runMainCommand(options: CliOptions, shouldAutoOpenBrowser: boolea
 		if (options.skipShutdownCleanup) {
 			console.warn("Skipping shutdown task cleanup for this instance.");
 		}
+		// Clear descriptor before shutting down the server so other
+		// processes see the descriptor disappear atomically.
+		await clearRuntimeDescriptor().catch(() => {});
 		await runtime.shutdown({
 			skipSessionCleanup: options.skipShutdownCleanup,
 		});
@@ -653,6 +731,7 @@ function createProgram(invocationArgs: string[]): Command {
 
 	registerTaskCommand(program);
 	registerHooksCommand(program);
+	registerTokenCommand(program);
 
 	program
 		.command("mcp")

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -5,7 +5,7 @@ import { createTRPCProxyClient, httpBatchLink, TRPCClientError } from "@trpc/cli
 import type { Command } from "commander";
 import type { RuntimeHookEvent, RuntimeTaskHookActivity } from "../core/api-contract";
 import { buildKanbanCommandParts } from "../core/kanban-command";
-import { buildKanbanRuntimeUrl, getRuntimeFetch } from "../core/runtime-endpoint";
+import { getRuntimeFetch, resolveRuntimeConnection } from "../core/runtime-endpoint";
 import { buildWindowsCmdArgsArray, resolveWindowsComSpec, shouldUseWindowsCmdLaunch } from "../core/windows-cmd-launch";
 import { parseHookRuntimeContextFromEnv } from "../terminal/hook-runtime-context";
 import type { RuntimeAppRouter } from "../trpc/app-router";
@@ -376,11 +376,13 @@ function parseHooksIngestArgs(
 }
 
 async function ingestHookEvent(args: HooksIngestArgs): Promise<void> {
+	const conn = await resolveRuntimeConnection();
 	const trpcClient = createTRPCProxyClient<RuntimeAppRouter>({
 		links: [
 			httpBatchLink({
-				url: buildKanbanRuntimeUrl("/api/trpc"),
+				url: `${conn.origin}/api/trpc`,
 				maxItems: 1,
+				headers: () => (conn.authToken ? { authorization: `Bearer ${conn.authToken}` } : {}),
 				fetch: async (url, options) => {
 					const runtimeFetch = await getRuntimeFetch();
 					return runtimeFetch(url, options);

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -11,7 +11,13 @@ import type {
 	RuntimeWorkspaceStateResponse,
 } from "../core/api-contract";
 import { runtimeAgentIdSchema, runtimeClineReasoningEffortSchema } from "../core/api-contract";
-import { buildKanbanRuntimeUrl, getKanbanRuntimeOrigin, getRuntimeFetch } from "../core/runtime-endpoint";
+import {
+	buildKanbanRuntimeUrl,
+	getKanbanRuntimeOrigin,
+	getRuntimeFetch,
+	type ResolvedRuntimeConnection,
+	resolveRuntimeConnection,
+} from "../core/runtime-endpoint";
 import {
 	addTaskDependency,
 	addTaskToColumn,
@@ -241,12 +247,29 @@ function resolveTaskCommandTarget(input: TaskCommandTarget, commandName: string)
 	throw new Error(`${commandName} requires either --task-id or --column.`);
 }
 
+// ---------------------------------------------------------------------------
+// Module-level resolved connection — set once per command invocation by
+// runTaskCommand() before calling any handler.  This keeps the rest of the
+// module unchanged while adding desktop descriptor fallback.
+// ---------------------------------------------------------------------------
+
+let _resolvedConnection: ResolvedRuntimeConnection | null = null;
+
 function createRuntimeTrpcClient(workspaceId: string | null) {
+	const conn = _resolvedConnection;
+	const baseUrl = conn ? `${conn.origin}/api/trpc` : buildKanbanRuntimeUrl("/api/trpc");
+	const authToken = conn?.authToken ?? null;
+
 	return createTRPCProxyClient<RuntimeAppRouter>({
 		links: [
 			httpBatchLink({
-				url: buildKanbanRuntimeUrl("/api/trpc"),
-				headers: () => (workspaceId ? { "x-kanban-workspace-id": workspaceId } : {}),
+				url: baseUrl,
+				headers: () => {
+					const h: Record<string, string> = {};
+					if (workspaceId) h["x-kanban-workspace-id"] = workspaceId;
+					if (authToken) h.authorization = `Bearer ${authToken}`;
+					return h;
+				},
 				fetch: async (url, options) => {
 					const runtimeFetch = await getRuntimeFetch();
 					return runtimeFetch(url, options);
@@ -1079,11 +1102,17 @@ function parseOptionalBooleanOption(value: unknown, flagName: string): boolean |
 
 async function runTaskCommand(handler: () => Promise<JsonRecord>): Promise<void> {
 	try {
-		printJson(await handler());
+		// Resolve the runtime connection once, before calling the handler.
+		// This populates _resolvedConnection so all createRuntimeTrpcClient()
+		// calls within the handler use the correct URL and auth token.
+		_resolvedConnection = await resolveRuntimeConnection();
+		const result = await handler();
+		printJson(result);
 	} catch (error) {
+		const origin = _resolvedConnection?.origin ?? getKanbanRuntimeOrigin();
 		printJson({
 			ok: false,
-			error: `Task command failed at ${getKanbanRuntimeOrigin()}: ${toErrorMessage(error)}`,
+			error: `Task command failed at ${origin}: ${toErrorMessage(error)}`,
 		});
 		process.exitCode = 1;
 	}

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -1,0 +1,18 @@
+import { randomBytes } from "node:crypto";
+
+import type { Command } from "commander";
+
+export function generateToken(): string {
+	return randomBytes(32).toString("hex");
+}
+
+export function registerTokenCommand(program: Command): void {
+	const token = program.command("token").description("Auth token utilities.");
+
+	token
+		.command("generate")
+		.description("Generate a random auth token and print it to stdout.")
+		.action(() => {
+			process.stdout.write(`${generateToken()}\n`);
+		});
+}

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -368,6 +368,8 @@ export type RuntimeClineMcpServerAuthStatus = z.infer<typeof runtimeClineMcpServ
 
 export const runtimeStateStreamSnapshotMessageSchema = z.object({
 	type: z.literal("snapshot"),
+	isLocal: z.boolean(),
+	runtimeVersion: z.string(),
 	currentProjectId: z.string().nullable(),
 	projects: z.array(runtimeProjectSummarySchema),
 	workspaceState: runtimeWorkspaceStateResponseSchema.nullable(),
@@ -758,26 +760,6 @@ export const runtimeClineOauthLoginResponseSchema = z.object({
 });
 export type RuntimeClineOauthLoginResponse = z.infer<typeof runtimeClineOauthLoginResponseSchema>;
 
-export const runtimeClineDeviceAuthStartResponseSchema = z.object({
-	deviceCode: z.string(),
-	userCode: z.string(),
-	verificationUrl: z.string(),
-	expiresInSeconds: z.number(),
-	pollIntervalSeconds: z.number(),
-});
-export type RuntimeClineDeviceAuthStartResponse = z.infer<typeof runtimeClineDeviceAuthStartResponseSchema>;
-
-export const runtimeClineDeviceAuthCompleteRequestSchema = z.object({
-	deviceCode: z.string(),
-	expiresInSeconds: z.number(),
-	pollIntervalSeconds: z.number(),
-	baseUrl: z.string().nullable().optional(),
-});
-export type RuntimeClineDeviceAuthCompleteRequest = z.infer<typeof runtimeClineDeviceAuthCompleteRequestSchema>;
-
-export const runtimeClineDeviceAuthCompleteResponseSchema = runtimeClineOauthLoginResponseSchema;
-export type RuntimeClineDeviceAuthCompleteResponse = z.infer<typeof runtimeClineDeviceAuthCompleteResponseSchema>;
-
 export const runtimeClineProviderSettingsSaveRequestSchema = z.object({
 	providerId: z.string(),
 	modelId: z.string().nullable().optional(),
@@ -923,6 +905,7 @@ export const runtimeConfigResponseSchema = z.object({
 	openPrPromptTemplate: z.string(),
 	commitPromptTemplateDefault: z.string(),
 	openPrPromptTemplateDefault: z.string(),
+	homeAgentPromptHash: z.string(),
 });
 export type RuntimeConfigResponse = z.infer<typeof runtimeConfigResponseSchema>;
 

--- a/src/core/kanban-command.ts
+++ b/src/core/kanban-command.ts
@@ -33,6 +33,17 @@ function looksLikeEntrypointPath(value: string): boolean {
 	return /kanban(?:\.(?:cmd|ps1|exe))?$/iu.test(value);
 }
 
+/**
+ * Resolve the shell command parts needed to invoke the Kanban CLI.
+ *
+ * Resolution priority:
+ *   1. KANBAN_CLI_COMMAND env var — set explicitly by the desktop app or by
+ *      the user.  This is the single source of truth for packaged desktop
+ *      builds and avoids any inference from process.execPath / argv, which
+ *      are unreliable inside Electron.
+ *   2. Standard Node.js inference from process.execPath and argv — works for
+ *      CLI-launched runtimes, tsx dev servers, and npm global installs.
+ */
 export function resolveKanbanCommandParts(
 	context: RuntimeInvocationContext = {
 		execPath: process.execPath,
@@ -40,6 +51,15 @@ export function resolveKanbanCommandParts(
 		execArgv: process.execArgv,
 	},
 ): string[] {
+	// Priority 1: explicit env var — set by the desktop app or by the user.
+	// This completely bypasses process-path inference, which is the right
+	// thing to do inside Electron where execPath is the helper binary.
+	const envOverride = process.env.KANBAN_CLI_COMMAND?.trim();
+	if (envOverride) {
+		return envOverride.split(/\s+/);
+	}
+
+	// Priority 2: infer from process.execPath / argv (CLI context).
 	const commandPrefix = resolveNodeCommandPrefix(context);
 	const entrypoint = context.argv[1];
 	if (!entrypoint || !looksLikeEntrypointPath(entrypoint)) {

--- a/src/core/runtime-descriptor.ts
+++ b/src/core/runtime-descriptor.ts
@@ -1,0 +1,197 @@
+/**
+ * Runtime descriptor — a per-user file that each runtime (CLI or desktop)
+ * writes when it becomes the active authority.  Other processes read this as
+ * the **primary** connection target, preventing split-brain when multiple
+ * runtimes are running on different ports.
+ *
+ * File location: ~/.cline/kanban/runtime.json
+ *
+ * Resolution priority (see resolveRuntimeConnection in runtime-endpoint.ts):
+ *   1. Explicit env vars: KANBAN_RUNTIME_HOST / KANBAN_RUNTIME_PORT
+ *   2. Healthy runtime descriptor (this file) — the shared authority pointer
+ *   3. Default localhost:3484 — fallback when no descriptor exists
+ *
+ * Staleness: the descriptor records the PID of the owning process.
+ * Consumers check PID liveness to avoid connecting to a stale descriptor
+ * from a crashed process.  This is a best-effort heuristic — PID reuse is
+ * theoretically possible but extremely unlikely on short timescales.
+ */
+
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+export interface RuntimeDescriptor {
+	/** Full URL the runtime is listening on, e.g. "http://127.0.0.1:52341". */
+	url: string;
+	/** Ephemeral auth token required for all API requests. */
+	authToken: string;
+	/** PID of the process that owns the runtime (Electron main or child). */
+	pid: number;
+	/** ISO-8601 timestamp when the descriptor was written. */
+	updatedAt: string;
+	/** Where the runtime was launched from: "desktop" or "cli". */
+	source: "desktop" | "cli";
+	/** Unique ID per desktop app launch — used to detect stale descriptors from prior sessions. */
+	desktopSessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path
+// ---------------------------------------------------------------------------
+
+const DESCRIPTOR_FILENAME = "runtime.json";
+
+export function getRuntimeDescriptorDir(): string {
+	return process.env.KANBAN_DESKTOP_RUNTIME_DESCRIPTOR_DIR || join(homedir(), ".cline", "kanban");
+}
+
+export function getRuntimeDescriptorPath(): string {
+	return join(getRuntimeDescriptorDir(), DESCRIPTOR_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Write — called by any runtime (CLI or desktop) to claim authority
+// ---------------------------------------------------------------------------
+
+export async function writeRuntimeDescriptor(descriptor: RuntimeDescriptor): Promise<void> {
+	await mkdir(getRuntimeDescriptorDir(), { recursive: true });
+	const content = JSON.stringify(descriptor, null, "\t");
+	await writeFile(getRuntimeDescriptorPath(), content, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Read — called by any process to discover the current runtime authority
+// ---------------------------------------------------------------------------
+
+export async function readRuntimeDescriptor(): Promise<RuntimeDescriptor | null> {
+	try {
+		const raw = await readFile(getRuntimeDescriptorPath(), "utf-8");
+		const parsed: unknown = JSON.parse(raw);
+		if (!isValidDescriptor(parsed)) {
+			return null;
+		}
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Clear — called by the desktop app on shutdown
+// ---------------------------------------------------------------------------
+
+export async function clearRuntimeDescriptor(): Promise<void> {
+	try {
+		await rm(getRuntimeDescriptorPath(), { force: true });
+	} catch {
+		// Best effort — if the file doesn't exist or can't be removed, move on.
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function isValidDescriptor(value: unknown): value is RuntimeDescriptor {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as Record<string, unknown>;
+	return (
+		typeof obj.url === "string" &&
+		typeof obj.authToken === "string" &&
+		typeof obj.pid === "number" &&
+		typeof obj.updatedAt === "string" &&
+		(obj.source === "desktop" || obj.source === "cli") &&
+		(obj.desktopSessionId === undefined || typeof obj.desktopSessionId === "string")
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Staleness check — if the owning PID is no longer running, the descriptor
+// is stale and should be ignored.
+// ---------------------------------------------------------------------------
+
+export function isDescriptorStale(descriptor: RuntimeDescriptor): boolean {
+	try {
+		// process.kill(pid, 0) checks if the process exists without sending a signal.
+		// It throws if the process does not exist.
+		process.kill(descriptor.pid, 0);
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Desktop session matching — checks whether a desktop-owned descriptor
+// belongs to the currently running desktop session.
+// ---------------------------------------------------------------------------
+
+export function isDesktopDescriptorFromCurrentSession(
+	descriptor: RuntimeDescriptor,
+	currentSessionId: string,
+): boolean {
+	return descriptor.source === "desktop" && descriptor.desktopSessionId === currentSessionId;
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor trust evaluation — structured decision about whether a
+// persisted descriptor should be trusted by the current desktop session.
+// ---------------------------------------------------------------------------
+
+export type DescriptorTrustReason =
+	| "current-session"
+	| "cli-owned"
+	| "pid-dead"
+	| "prior-desktop-session"
+	| "no-descriptor";
+
+export interface DescriptorTrustResult {
+	trusted: boolean;
+	reason: DescriptorTrustReason;
+	descriptor: RuntimeDescriptor | null;
+}
+
+/**
+ * Read the runtime descriptor and decide whether the current desktop session
+ * should trust it.
+ *
+ * - **no-descriptor** — file absent or invalid → not trusted (nothing to trust).
+ * - **cli-owned** — source is "cli" → trusted (never interfere with CLI runtimes).
+ * - **current-session** — desktop descriptor with matching session ID → trusted.
+ * - **pid-dead** — desktop descriptor from a prior session whose PID is dead →
+ *   cleaned up and not trusted.
+ * - **prior-desktop-session** — desktop descriptor from a different session whose
+ *   PID is still alive → not trusted (orphan policy deferred to Task 6).
+ */
+export async function evaluateDescriptorTrust(currentSessionId: string): Promise<DescriptorTrustResult> {
+	const descriptor = await readRuntimeDescriptor();
+
+	if (!descriptor) {
+		return { trusted: false, reason: "no-descriptor", descriptor: null };
+	}
+
+	// CLI-owned descriptors are always trusted — desktop never interferes.
+	if (descriptor.source === "cli") {
+		return { trusted: true, reason: "cli-owned", descriptor };
+	}
+
+	// Desktop descriptor from the current session — trust it.
+	if (isDesktopDescriptorFromCurrentSession(descriptor, currentSessionId)) {
+		return { trusted: true, reason: "current-session", descriptor };
+	}
+
+	// Desktop descriptor from a prior session — check PID liveness.
+	if (isDescriptorStale(descriptor)) {
+		// Dead PID: clean up the stale descriptor.
+		await clearRuntimeDescriptor();
+		return { trusted: false, reason: "pid-dead", descriptor };
+	}
+
+	// PID is still alive but belongs to a different desktop session — orphan.
+	return { trusted: false, reason: "prior-desktop-session", descriptor };
+}

--- a/src/core/runtime-endpoint.ts
+++ b/src/core/runtime-endpoint.ts
@@ -1,6 +1,7 @@
 import { rootCertificates } from "node:tls";
 import { Agent } from "undici";
 import { getInternalToken } from "../security/passcode-manager";
+import { isDescriptorStale, readRuntimeDescriptor } from "./runtime-descriptor";
 
 export const DEFAULT_KANBAN_RUNTIME_HOST = "127.0.0.1";
 export const DEFAULT_KANBAN_RUNTIME_PORT = 3484;
@@ -23,8 +24,8 @@ export function parseRuntimePort(rawPort: string | undefined): number {
 		return DEFAULT_KANBAN_RUNTIME_PORT;
 	}
 	const parsed = Number.parseInt(rawPort, 10);
-	if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
-		throw new Error(`Invalid KANBAN_RUNTIME_PORT value "${rawPort}". Expected an integer from 1-65535.`);
+	if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+		throw new Error(`Invalid KANBAN_RUNTIME_PORT value "${rawPort}". Expected an integer from 0-65535.`);
 	}
 	return parsed;
 }
@@ -164,4 +165,125 @@ export function getRuntimeFetch(): Promise<typeof globalThis.fetch> {
 		}) as typeof globalThis.fetch;
 	})();
 	return _runtimeFetchPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved runtime connection — async, descriptor-first
+// ---------------------------------------------------------------------------
+
+export interface ResolvedRuntimeConnection {
+	/** Base URL of the runtime (e.g. "http://127.0.0.1:3484" or "http://127.0.0.1:52341"). */
+	origin: string;
+	/** Auth token to attach as Authorization header, or null if none required. */
+	authToken: string | null;
+	/** Where the connection was resolved from. */
+	source: "env" | "default" | "descriptor";
+}
+
+/** Whether env vars explicitly configure the runtime endpoint. */
+function hasExplicitEnvConfig(): boolean {
+	return !!(process.env.KANBAN_RUNTIME_HOST?.trim() || process.env.KANBAN_RUNTIME_PORT?.trim());
+}
+
+/** Read KANBAN_AUTH_TOKEN from environment (set by the runtime for PTY children). */
+function getEnvAuthToken(): string | null {
+	return process.env.KANBAN_AUTH_TOKEN?.trim() || null;
+}
+
+/**
+ * Extract just the origin (scheme + host + port) from a descriptor URL.
+ *
+ * Descriptor URLs may include a workspace path (e.g.
+ * "http://127.0.0.1:62929/cline") that is useful for browser navigation
+ * but must NOT be included in the API base URL — otherwise TRPC calls
+ * get routed to the wrong path.
+ */
+export function descriptorOriginFromUrl(descriptorUrl: string): string {
+	return new URL(descriptorUrl).origin;
+}
+
+/**
+ * Quick connectivity check — try to reach the runtime with a short timeout.
+ * Returns true if the server responds to a simple HTTP request.
+ *
+ * Uses /api/health as the probe endpoint.  Any HTTP response (including
+ * 401/404) means the server process is alive.  If the runtime renames or
+ * relocates that path in the future, update this probe to match.
+ */
+async function isRuntimeReachable(origin: string, timeoutMs = 1500): Promise<boolean> {
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		const response = await fetch(`${origin}/api/health`, {
+			method: "GET",
+			signal: controller.signal,
+		});
+		clearTimeout(timer);
+		// Any HTTP response (even 401/404) means the server is up.
+		return response.status > 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Resolve the runtime connection — descriptor-first policy.
+ *
+ * The runtime descriptor (~/.cline/kanban/runtime.json) is the single
+ * shared authority pointer. All non-explicit clients should connect to
+ * whatever runtime the descriptor points at, preventing split-brain
+ * when multiple runtimes are running on different ports.
+ *
+ * Resolution priority:
+ *   1. Explicit env vars (KANBAN_RUNTIME_HOST / PORT) → use configured endpoint, no fallback.
+ *   2. Healthy runtime descriptor → the authority runtime, wherever it lives.
+ *   3. Default localhost:3484 → fallback when no descriptor exists.
+ */
+export async function resolveRuntimeConnection(): Promise<ResolvedRuntimeConnection> {
+	// Priority 1: explicit env config — use it, no fallback.
+	// KANBAN_AUTH_TOKEN is read alongside host/port so that PTY child
+	// processes spawned by the desktop app can authenticate against
+	// the same runtime without needing the descriptor file.
+	if (hasExplicitEnvConfig()) {
+		return {
+			origin: getKanbanRuntimeOrigin(),
+			authToken: getEnvAuthToken(),
+			source: "env",
+		};
+	}
+
+	// Priority 2: runtime descriptor — the shared authority pointer.
+	// Both CLI and desktop publish descriptors when they start a runtime.
+	// Clients should connect to the descriptor authority first; the default
+	// port is only a fallback when no authority has been established.
+	const descriptor = await readRuntimeDescriptor();
+	if (descriptor && !isDescriptorStale(descriptor)) {
+		const descriptorOrigin = descriptorOriginFromUrl(descriptor.url);
+		if (await isRuntimeReachable(descriptorOrigin)) {
+			return {
+				origin: descriptorOrigin,
+				authToken: descriptor.authToken,
+				source: "descriptor",
+			};
+		}
+		// Descriptor exists but runtime is unreachable — fall through to default.
+	}
+
+	// Priority 3: default endpoint — fallback when no authority descriptor exists.
+	const defaultOrigin = getKanbanRuntimeOrigin();
+	if (await isRuntimeReachable(defaultOrigin)) {
+		return {
+			origin: defaultOrigin,
+			authToken: null,
+			source: "default",
+		};
+	}
+
+	// Nothing reachable — return default anyway so callers get a clear error
+	// from the actual HTTP call rather than an opaque "no runtime found" message.
+	return {
+		origin: defaultOrigin,
+		authToken: null,
+		source: "default",
+	};
 }

--- a/src/core/runtime-takeover.ts
+++ b/src/core/runtime-takeover.ts
@@ -1,0 +1,301 @@
+/**
+ * Runtime takeover — coordinates failover when the runtime authority dies.
+ *
+ * Algorithm (exact flow on disconnect):
+ *   1. Grace window: retry health checks for GRACE_MS. If runtime recovers → reconnect, done.
+ *   2. Re-read descriptor: if it now points to a healthy runtime (someone else took over) → attach, done.
+ *   3. Acquire lock: atomically create runtime.takeover.lock. If lock fails → wait for winner.
+ *   4. Winner starts runtime + writes descriptor → releases lock.
+ *   5. All other clients poll descriptor → detect new authority → reattach.
+ *
+ * Why this works:
+ *   - Grace window prevents unnecessary failover on short blips.
+ *   - Lock prevents both apps starting runtimes simultaneously.
+ *   - Re-read-before-takeover avoids stale assumptions.
+ */
+
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import { join } from "node:path";
+import {
+	getRuntimeDescriptorDir,
+	isDescriptorStale,
+	type RuntimeDescriptor,
+	readRuntimeDescriptor,
+} from "./runtime-descriptor";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** How long to retry health checks before attempting takeover (ms). */
+const GRACE_MS = 4_000;
+
+/** Interval between health check retries during grace window (ms). */
+const HEALTH_RETRY_INTERVAL_MS = 800;
+
+/** Health check timeout per attempt (ms). */
+const HEALTH_CHECK_TIMEOUT_MS = 2_000;
+
+/**
+ * How long the lock file is considered valid (ms). Prevents permanent lock
+ * from crashed processes.  This is a time-based heuristic — under unusual
+ * crash/timing scenarios a lock could theoretically be removed before its
+ * holder finishes.  Acceptable because the double-check-under-lock (step 4)
+ * prevents duplicate runtime starts even if the lock is contested.
+ */
+const LOCK_TTL_MS = 30_000;
+
+/** How long to wait for another process to finish takeover before retrying (ms). */
+const WAIT_FOR_WINNER_MS = 10_000;
+
+/** Interval to poll descriptor while waiting for winner (ms). */
+const WINNER_POLL_INTERVAL_MS = 1_000;
+
+const LOCK_FILENAME = "runtime.takeover.lock";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TakeoverCallbacks {
+	/** Start a local runtime process. Returns url + authToken when ready. */
+	startRuntime: () => Promise<{ url: string; authToken: string }>;
+
+	/** Called when a healthy runtime is found (existing or new). Connect the UI to it. */
+	onAttach: (descriptor: RuntimeDescriptor) => Promise<void>;
+
+	/** Called when takeover is starting (for UX state updates). */
+	onTakeoverStarting?: () => void;
+
+	/** Called when reconnected during grace window (for UX state updates). */
+	onReconnected?: () => void;
+
+	/** Optional logger. */
+	warn?: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+function checkHealth(url: string, authToken: string, timeoutMs: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		try {
+			const healthUrl = new URL("/api/health", url);
+			const transport = healthUrl.protocol === "https:" ? https : http;
+			const headers: Record<string, string> = {};
+			if (authToken) {
+				headers.Authorization = `Bearer ${authToken}`;
+			}
+
+			const timer = setTimeout(() => {
+				req.destroy();
+				resolve(false);
+			}, timeoutMs);
+
+			const req = transport.get(healthUrl, { headers }, (res) => {
+				clearTimeout(timer);
+				res.resume();
+				resolve(res.statusCode === 200);
+			});
+			req.on("error", () => {
+				clearTimeout(timer);
+				resolve(false);
+			});
+		} catch {
+			resolve(false);
+		}
+	});
+}
+
+async function isDescriptorHealthy(descriptor: RuntimeDescriptor | null): Promise<boolean> {
+	if (!descriptor) return false;
+	if (isDescriptorStale(descriptor)) return false;
+	return checkHealth(descriptor.url, descriptor.authToken, HEALTH_CHECK_TIMEOUT_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Lock file
+// ---------------------------------------------------------------------------
+
+function getLockPath(): string {
+	return join(getRuntimeDescriptorDir(), LOCK_FILENAME);
+}
+
+async function acquireLock(): Promise<boolean> {
+	try {
+		await mkdir(getRuntimeDescriptorDir(), { recursive: true });
+
+		// Check if a stale lock exists (from a crashed process).
+		// We use both TTL expiry AND PID liveness — if the lock holder's
+		// PID is dead, the lock is definitely stale regardless of TTL.
+		try {
+			const lockStat = await stat(getLockPath());
+			const ttlExpired = Date.now() - lockStat.mtimeMs > LOCK_TTL_MS;
+			const ownerDead = await isLockOwnerDead();
+			if (ttlExpired || ownerDead) {
+				await rm(getLockPath(), { force: true });
+			}
+		} catch {
+			// Lock doesn't exist — good.
+		}
+
+		// Atomic create — fails if file already exists (O_EXCL via wx flag).
+		await writeFile(getLockPath(), JSON.stringify({ pid: process.pid, at: Date.now() }), {
+			flag: "wx",
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Try to read the lock file and check if the owner PID is still alive. */
+async function isLockOwnerDead(): Promise<boolean> {
+	try {
+		const raw = await readFile(getLockPath(), "utf-8");
+		const parsed = JSON.parse(raw) as { pid?: number };
+		if (typeof parsed.pid !== "number") return false;
+		// process.kill(pid, 0) throws if PID doesn't exist.
+		process.kill(parsed.pid, 0);
+		return false; // PID is alive.
+	} catch {
+		return true; // Can't read lock or PID is dead.
+	}
+}
+
+async function releaseLock(): Promise<void> {
+	try {
+		await rm(getLockPath(), { force: true });
+	} catch {
+		// Best effort.
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grace window — retry health checks before giving up
+// ---------------------------------------------------------------------------
+
+async function retryHealthFor(url: string, authToken: string, graceMs: number): Promise<boolean> {
+	const deadline = Date.now() + graceMs;
+	while (Date.now() < deadline) {
+		const healthy = await checkHealth(url, authToken, HEALTH_CHECK_TIMEOUT_MS);
+		if (healthy) return true;
+		await delay(HEALTH_RETRY_INTERVAL_MS);
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Wait for another process to complete takeover
+// ---------------------------------------------------------------------------
+
+async function waitForHealthyDescriptor(timeoutMs: number): Promise<RuntimeDescriptor | null> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const d = await readRuntimeDescriptor();
+		if (d && !isDescriptorStale(d)) {
+			const healthy = await checkHealth(d.url, d.authToken, HEALTH_CHECK_TIMEOUT_MS);
+			if (healthy) return d;
+		}
+		await delay(WINNER_POLL_INTERVAL_MS);
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main takeover entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle runtime disconnect. Implements the full takeover algorithm:
+ * grace → re-read → lock → start → publish → reattach.
+ *
+ * @param failedUrl The URL of the runtime that went down
+ * @param failedAuthToken The auth token of the failed runtime
+ * @param callbacks Hooks for starting runtime, attaching, and UX updates
+ */
+export async function handleRuntimeDisconnect(
+	failedUrl: string,
+	failedAuthToken: string,
+	callbacks: TakeoverCallbacks,
+): Promise<void> {
+	const log = callbacks.warn ?? (() => {});
+
+	// ── Step 1: Grace window ──────────────────────────────────────────
+	log("[takeover] Runtime disconnected — entering grace window...");
+	const recovered = await retryHealthFor(failedUrl, failedAuthToken, GRACE_MS);
+	if (recovered) {
+		log("[takeover] Runtime recovered during grace window.");
+		callbacks.onReconnected?.();
+		return;
+	}
+
+	// ── Step 2: Re-read descriptor ────────────────────────────────────
+	log("[takeover] Grace window expired — checking descriptor...");
+	const currentDescriptor = await readRuntimeDescriptor();
+	if (currentDescriptor && (await isDescriptorHealthy(currentDescriptor))) {
+		log("[takeover] Another process already took over — attaching.");
+		await callbacks.onAttach(currentDescriptor);
+		return;
+	}
+
+	// ── Step 3: Acquire lock ──────────────────────────────────────────
+	callbacks.onTakeoverStarting?.();
+	log("[takeover] Attempting to acquire takeover lock...");
+
+	if (!(await acquireLock())) {
+		log("[takeover] Lock held by another process — waiting for winner...");
+		const winnerDescriptor = await waitForHealthyDescriptor(WAIT_FOR_WINNER_MS);
+		if (winnerDescriptor) {
+			log("[takeover] Winner published descriptor — attaching.");
+			await callbacks.onAttach(winnerDescriptor);
+			return;
+		}
+		// Winner didn't publish in time — try to acquire lock ourselves.
+		if (!(await acquireLock())) {
+			log("[takeover] Still can't acquire lock — giving up.");
+			return;
+		}
+	}
+
+	// ── Step 4: Double-check descriptor (under lock) ──────────────────
+	try {
+		const d2 = await readRuntimeDescriptor();
+		if (d2 && (await isDescriptorHealthy(d2))) {
+			log("[takeover] Healthy runtime appeared while acquiring lock — attaching.");
+			await callbacks.onAttach(d2);
+			return;
+		}
+
+		// ── Step 5: Start runtime + publish descriptor ────────────────
+		log("[takeover] Starting local runtime...");
+		const { url } = await callbacks.startRuntime();
+		log(`[takeover] Runtime started at ${url} — reading new descriptor.`);
+
+		// Re-read the descriptor that startRuntime() should have written.
+		// We intentionally ignore the { url, authToken } return value and
+		// re-read from disk — the descriptor is the single source of truth
+		// for runtime authority.  If the descriptor write lags or fails,
+		// this re-read will return null and the caller won't attach.
+		const newDescriptor = await readRuntimeDescriptor();
+		if (newDescriptor) {
+			log("[takeover] Descriptor published — attaching to new runtime.");
+			await callbacks.onAttach(newDescriptor);
+		} else {
+			log("[takeover] WARNING: startRuntime() succeeded but descriptor is missing — cannot attach.");
+		}
+	} finally {
+		await releaseLock();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/core/scoped-command.ts
+++ b/src/core/scoped-command.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+import { terminateProcessForTimeout } from "../server/process-termination";
+import type { RuntimeCommandRunResponse } from "./api-contract";
+
+export async function runScopedCommand(command: string, cwd: string): Promise<RuntimeCommandRunResponse> {
+	const startedAt = Date.now();
+	const outputLimitBytes = 64 * 1024;
+
+	return await new Promise<RuntimeCommandRunResponse>((resolve, reject) => {
+		const child = spawn(command, {
+			cwd,
+			shell: true,
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		if (!child.stdout || !child.stderr) {
+			reject(new Error("Shortcut process did not expose stdout/stderr."));
+			return;
+		}
+
+		let stdout = "";
+		let stderr = "";
+
+		const appendOutput = (current: string, chunk: string): string => {
+			const next = current + chunk;
+			if (next.length <= outputLimitBytes) {
+				return next;
+			}
+			return next.slice(0, outputLimitBytes);
+		};
+
+		child.stdout.on("data", (chunk: Buffer | string) => {
+			stdout = appendOutput(stdout, String(chunk));
+		});
+
+		child.stderr.on("data", (chunk: Buffer | string) => {
+			stderr = appendOutput(stderr, String(chunk));
+		});
+
+		child.on("error", (error) => {
+			reject(error);
+		});
+
+		const timeout = setTimeout(() => {
+			terminateProcessForTimeout(child);
+		}, 60_000);
+
+		child.on("close", (code) => {
+			clearTimeout(timeout);
+			const exitCode = typeof code === "number" ? code : 1;
+			const combinedOutput = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+			resolve({
+				exitCode,
+				stdout: stdout.trim(),
+				stderr: stderr.trim(),
+				combinedOutput,
+				durationMs: Date.now() - startedAt,
+			});
+		});
+	});
+}

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,3 +1,18 @@
+/**
+ * Resolve the default fallback shell binary as an absolute path.
+ *
+ * When `process.env.SHELL` is not set (common for macOS GUI apps launched via
+ * launchd, where the environment is minimal), we need a reliable absolute path
+ * so that `posix_spawn` can find the binary without depending on `PATH`.
+ */
+function resolveUnixFallbackShell(): string {
+	if (process.platform === "darwin") {
+		// macOS default shell since Catalina
+		return "/bin/zsh";
+	}
+	return "/bin/bash";
+}
+
 export function resolveInteractiveShellCommand(): { binary: string; args: string[] } {
 	if (process.platform === "win32") {
 		const command = process.env.COMSPEC?.trim();
@@ -21,7 +36,7 @@ export function resolveInteractiveShellCommand(): { binary: string; args: string
 		};
 	}
 	return {
-		binary: "bash",
+		binary: resolveUnixFallbackShell(),
 		args: ["-i"],
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
 export * from "./core/api-contract";
+export type { DescriptorTrustResult, RuntimeDescriptor } from "./core/runtime-descriptor";
+export {
+	clearRuntimeDescriptor,
+	evaluateDescriptorTrust,
+	getRuntimeDescriptorDir,
+	getRuntimeDescriptorPath,
+	readRuntimeDescriptor,
+	writeRuntimeDescriptor,
+} from "./core/runtime-descriptor";
+export type { TakeoverCallbacks } from "./core/runtime-takeover";
+export { handleRuntimeDisconnect } from "./core/runtime-takeover";
+export { listWorkspaceIndexEntries, loadWorkspaceState } from "./state/workspace-state";

--- a/src/prompts/append-system-prompt.ts
+++ b/src/prompts/append-system-prompt.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { realpathSync } from "node:fs";
 
 import packageJson from "../../package.json" with { type: "json" };
@@ -313,4 +314,19 @@ export function resolveHomeAgentAppendSystemPrompt(
 	return renderAppendSystemPrompt(resolveAppendSystemPromptCommandPrefix(options), {
 		agentId: resolveHomeAgentId(taskId),
 	});
+}
+
+/**
+ * Compute a short hash of the rendered home-agent system prompt for the
+ * given agent.  The web UI includes this in the session descriptor key so
+ * that stale sessions are automatically rotated when the prompt changes —
+ * for any reason (command prefix change, template edit, version bump, etc.).
+ *
+ * The hash covers the **full rendered prompt string**, nothing else.
+ * This keeps the versioning dead-simple and free of edge cases.
+ */
+export function computeHomeAgentPromptHash(agentId: RuntimeAgentId): string {
+	const commandPrefix = resolveAppendSystemPromptCommandPrefix();
+	const prompt = renderAppendSystemPrompt(commandPrefix, { agentId });
+	return createHash("sha256").update(prompt).digest("hex").slice(0, 16);
 }

--- a/src/runtime-start.ts
+++ b/src/runtime-start.ts
@@ -1,0 +1,286 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { loadGlobalRuntimeConfig, loadRuntimeConfig } from "./config/runtime-config";
+import { createGitProcessEnv } from "./core/git-process-env";
+import {
+	DEFAULT_KANBAN_RUNTIME_HOST,
+	getKanbanRuntimeOrigin,
+	getKanbanRuntimePort,
+	setKanbanRuntimeHost,
+	setKanbanRuntimePort,
+} from "./core/runtime-endpoint";
+import { runScopedCommand } from "./core/scoped-command";
+import type { RuntimeStateHub } from "./server/runtime-state-hub";
+import type { TerminalSessionManager } from "./terminal/session-manager";
+
+function readRuntimeVersion(): string {
+	try {
+		const packageJsonPath = fileURLToPath(new URL("../package.json", import.meta.url));
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version: string };
+		return packageJson.version;
+	} catch {
+		return "0.0.0";
+	}
+}
+
+export interface RuntimeCallbacks {
+	pickDirectory?: () => Promise<string | null>;
+	warn?: (message: string) => void;
+}
+
+export interface RuntimeStartOptions {
+	host?: string;
+	port?: number | "auto";
+	authToken?: string;
+	cwd?: string;
+	isLocal?: boolean;
+	openInBrowser?: boolean;
+	callbacks?: RuntimeCallbacks;
+}
+
+/** @deprecated Use {@link RuntimeStartOptions} instead. */
+export type RuntimeOptions = RuntimeStartOptions;
+
+export interface RuntimeShutdownOptions {
+	skipSessionCleanup?: boolean;
+}
+
+export interface RuntimeHandle {
+	url: string;
+	shutdown: (options?: RuntimeShutdownOptions) => Promise<void>;
+}
+
+function hasGitRepository(path: string): boolean {
+	const result = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+		cwd: path,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+		env: createGitProcessEnv(),
+	});
+	return result.status === 0 && result.stdout.trim() === "true";
+}
+
+async function pathIsDirectory(path: string): Promise<boolean> {
+	try {
+		const info = await stat(path);
+		return info.isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+async function assertPathIsDirectory(path: string): Promise<void> {
+	const info = await stat(path);
+	if (!info.isDirectory()) {
+		throw new Error(`Project path is not a directory: ${path}`);
+	}
+}
+
+function isAddressInUseError(error: unknown): error is NodeJS.ErrnoException {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as NodeJS.ErrnoException).code === "EADDRINUSE"
+	);
+}
+
+async function isPortAvailable(port: number, host: string): Promise<boolean> {
+	return await new Promise<boolean>((resolve) => {
+		const probe = createNetServer();
+		probe.once("error", () => {
+			resolve(false);
+		});
+		probe.listen(port, host, () => {
+			probe.close(() => {
+				resolve(true);
+			});
+		});
+	});
+}
+
+async function findAvailableRuntimePort(startPort: number, host: string): Promise<number> {
+	for (let candidate = startPort; candidate <= 65535; candidate += 1) {
+		if (await isPortAvailable(candidate, host)) {
+			return candidate;
+		}
+	}
+	throw new Error("No available runtime port found.");
+}
+
+async function bootServer(
+	warn: (message: string) => void,
+	pickDirectory: () => Promise<string | null>,
+	isLocal: boolean,
+	runtimeVersion: string,
+	runtimeCwd: string,
+	authToken: string | undefined,
+): Promise<{
+	url: string;
+	close: () => Promise<void>;
+	shutdown: (options?: { skipSessionCleanup?: boolean }) => Promise<void>;
+}> {
+	const [
+		{ resolveProjectInputPath },
+		{ createRuntimeServer },
+		{ createRuntimeStateHub },
+		{ resolveInteractiveShellCommand },
+		{ shutdownRuntimeServer },
+		{ collectProjectWorktreeTaskIdsForRemoval, createWorkspaceRegistry },
+	] = await Promise.all([
+		import("./projects/project-path.js"),
+		import("./server/runtime-server.js"),
+		import("./server/runtime-state-hub.js"),
+		import("./server/shell.js"),
+		import("./server/shutdown-coordinator.js"),
+		import("./server/workspace-registry.js"),
+	]);
+	let runtimeStateHub: RuntimeStateHub | undefined;
+	const workspaceRegistry = await createWorkspaceRegistry({
+		cwd: runtimeCwd,
+		loadGlobalRuntimeConfig,
+		loadRuntimeConfig,
+		hasGitRepository,
+		pathIsDirectory,
+		onTerminalManagerReady: (workspaceId, manager) => {
+			runtimeStateHub?.trackTerminalManager(workspaceId, manager);
+		},
+	});
+	runtimeStateHub = createRuntimeStateHub({
+		workspaceRegistry,
+		isLocal,
+		runtimeVersion,
+	});
+	const runtimeHub = runtimeStateHub;
+	for (const { workspaceId, terminalManager } of workspaceRegistry.listManagedWorkspaces()) {
+		runtimeHub.trackTerminalManager(workspaceId, terminalManager);
+	}
+
+	const disposeTrackedWorkspace = (
+		workspaceId: string,
+		options?: {
+			stopTerminalSessions?: boolean;
+		},
+	): { terminalManager: TerminalSessionManager | null; workspacePath: string | null } => {
+		const disposed = workspaceRegistry.disposeWorkspace(workspaceId, {
+			stopTerminalSessions: options?.stopTerminalSessions,
+		});
+		runtimeHub.disposeWorkspace(workspaceId);
+		return disposed;
+	};
+
+	const runtimeServer = await createRuntimeServer({
+		workspaceRegistry,
+		runtimeStateHub: runtimeHub,
+		warn: (message) => {
+			warn(`[kanban] ${message}`);
+		},
+		ensureTerminalManagerForWorkspace: workspaceRegistry.ensureTerminalManagerForWorkspace,
+		resolveInteractiveShellCommand,
+		runCommand: runScopedCommand,
+		resolveProjectInputPath,
+		assertPathIsDirectory,
+		hasGitRepository,
+		disposeWorkspace: disposeTrackedWorkspace,
+		collectProjectWorktreeTaskIdsForRemoval,
+		pickDirectoryPathFromSystemDialog: async () => await pickDirectory(),
+		authToken,
+		// Lazy getter: when port 0 is used, getKanbanRuntimeOrigin() returns
+		// the correct origin only after server.listen() updates the global port.
+		allowedOrigins: authToken ? () => [getKanbanRuntimeOrigin()] : undefined,
+		version: runtimeVersion,
+	});
+
+	const close = async () => {
+		await runtimeServer.close();
+	};
+
+	const shutdown = async (options?: { skipSessionCleanup?: boolean }) => {
+		await shutdownRuntimeServer({
+			workspaceRegistry,
+			warn: (message) => {
+				warn(`[kanban] ${message}`);
+			},
+			closeRuntimeServer: close,
+			skipSessionCleanup: options?.skipSessionCleanup ?? false,
+		});
+	};
+
+	return {
+		url: runtimeServer.url,
+		close,
+		shutdown,
+	};
+}
+
+export async function startRuntime(options?: RuntimeStartOptions): Promise<RuntimeHandle> {
+	const host = options?.host ?? DEFAULT_KANBAN_RUNTIME_HOST;
+	const portOption = options?.port;
+	const warn = options?.callbacks?.warn ?? console.warn;
+	const runtimeCwd = options?.cwd ?? process.cwd();
+
+	const defaultPickDirectory = async (): Promise<string | null> => {
+		const { pickDirectoryPathFromSystemDialog } = await import("./server/directory-picker.js");
+		return Promise.resolve(pickDirectoryPathFromSystemDialog());
+	};
+	const pickDirectory = options?.callbacks?.pickDirectory ?? defaultPickDirectory;
+	const isLocal = options?.isLocal ?? true;
+	const runtimeVersion = readRuntimeVersion();
+
+	setKanbanRuntimeHost(host);
+
+	// Publish the auth token to process.env so that PTY child processes
+	// (agents) inherit it automatically — same pattern as KANBAN_RUNTIME_HOST
+	// and KANBAN_RUNTIME_PORT.  This lets `kanban task create` invoked from
+	// within an agent PTY resolve the correct runtime connection without
+	// needing the filesystem descriptor fallback.
+	if (options?.authToken) {
+		process.env.KANBAN_AUTH_TOKEN = options.authToken;
+	}
+
+	if (portOption === "auto") {
+		// Use port 0 — the OS picks an available ephemeral port atomically,
+		// eliminating the TOCTOU race inherent in probe-then-listen.
+		// The actual port is read back after server.listen() completes.
+		setKanbanRuntimePort(0);
+	} else if (typeof portOption === "number") {
+		setKanbanRuntimePort(portOption);
+	}
+
+	const isAutoPort = portOption === "auto";
+
+	const boot = async (): Promise<RuntimeHandle> => {
+		const server = await bootServer(warn, pickDirectory, isLocal, runtimeVersion, runtimeCwd, options?.authToken);
+		return {
+			url: server.url,
+			shutdown: async (shutdownOptions?: RuntimeShutdownOptions) => {
+				await server.shutdown({
+					skipSessionCleanup: shutdownOptions?.skipSessionCleanup,
+				});
+			},
+		};
+	};
+
+	if (!isAutoPort) {
+		return await boot();
+	}
+
+	// Auto-port retry loop: if the port became busy between the probe and
+	// the actual listen, pick the next available port and retry.
+	while (true) {
+		try {
+			return await boot();
+		} catch (error) {
+			if (!isAddressInUseError(error)) {
+				throw error;
+			}
+			const currentPort = getKanbanRuntimePort();
+			const retryPort = await findAvailableRuntimePort(currentPort + 1, host);
+			setKanbanRuntimePort(retryPort);
+			warn(`Runtime port ${currentPort} became busy during startup, retrying on ${retryPort}.`);
+		}
+	}
+}

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -1,0 +1,241 @@
+import { timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+const CSP_HEADER_VALUE = [
+	"default-src 'self'",
+	"script-src 'self' 'unsafe-inline'",
+	"style-src 'self' 'unsafe-inline'",
+	"connect-src 'self' ws: wss: https://*.ingest.us.sentry.io",
+	"img-src 'self' data:",
+].join("; ");
+
+export interface AuthMiddlewareDependencies {
+	authToken?: string;
+	/** Static list or lazy getter — use a getter when the origin depends on a port assigned at listen time. */
+	allowedOrigins?: string[] | (() => string[]);
+	version: string;
+}
+
+export interface AuthMiddleware {
+	/**
+	 * Validate an HTTP request. Returns true if the request should proceed,
+	 * false if it has been rejected (response already sent with 401).
+	 */
+	handleHttpRequest: (req: IncomingMessage, res: ServerResponse) => boolean;
+
+	/**
+	 * Validate a WebSocket upgrade request. Returns true if the upgrade
+	 * should proceed, false if it should be rejected.
+	 */
+	handleWsUpgrade: (req: IncomingMessage) => boolean;
+}
+
+function extractBearerToken(req: IncomingMessage): string | null {
+	const header = req.headers.authorization;
+	if (typeof header !== "string") {
+		return null;
+	}
+	const parts = header.split(" ");
+	if (parts.length !== 2 || parts[0] !== "Bearer") {
+		return null;
+	}
+	return parts[1] ?? null;
+}
+
+/**
+ * Extract the auth token from a `kanban-auth` cookie.
+ *
+ * This is the fallback for WebSocket upgrade requests in Electron desktop
+ * mode.  Electron's `session.webRequest.onBeforeSendHeaders` intercepts
+ * regular HTTP requests but **not** WebSocket upgrades, so the renderer's
+ * `new WebSocket()` call never receives the `Authorization` header.
+ * A session cookie set by the main process before `loadURL` is sent on
+ * every request — including WS upgrades — giving us a transparent auth
+ * channel that doesn't require web-UI changes.
+ */
+const COOKIE_NAME = "kanban-auth";
+
+function extractTokenFromCookie(req: IncomingMessage): string | null {
+	const cookie = req.headers.cookie;
+	if (typeof cookie !== "string") {
+		return null;
+	}
+	const match = cookie.match(new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]+)`));
+	return match?.[1] ?? null;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+	const bufA = Buffer.from(a, "utf8");
+	const bufB = Buffer.from(b, "utf8");
+	if (bufA.length !== bufB.length) {
+		return false;
+	}
+	return timingSafeEqual(bufA, bufB);
+}
+
+function isStaticAssetPath(pathname: string): boolean {
+	return !pathname.startsWith("/api/");
+}
+
+function isHealthEndpoint(pathname: string): boolean {
+	return pathname === "/api/health";
+}
+
+function isHtmlContentType(contentType: string | undefined): boolean {
+	if (!contentType) {
+		return false;
+	}
+	return contentType.includes("text/html");
+}
+
+function getPathname(req: IncomingMessage): string {
+	const rawUrl = req.url ?? "/";
+	try {
+		const parsed = new URL(rawUrl, "http://localhost");
+		return parsed.pathname;
+	} catch {
+		return rawUrl.split("?")[0] ?? rawUrl;
+	}
+}
+
+function resolveHeadersFromArgs(args: unknown[]): Record<string, string | string[] | number | undefined> | undefined {
+	// writeHead(statusCode, headers)
+	if (args.length === 1 && typeof args[0] === "object" && args[0] !== null) {
+		return args[0] as Record<string, string | string[] | number | undefined>;
+	}
+	// writeHead(statusCode, statusMessage, headers)
+	if (args.length === 2 && typeof args[0] === "string" && typeof args[1] === "object" && args[1] !== null) {
+		return args[1] as Record<string, string | string[] | number | undefined>;
+	}
+	return undefined;
+}
+
+/**
+ * Validate the Origin header against the allowed origins list.
+ * Returns true if the request should proceed, false if it should be rejected.
+ *
+ * - Origin absent → allow (non-browser clients like curl, CLI tools)
+ * - Origin present + matches an allowed origin → allow
+ * - Origin present + mismatched → reject
+ */
+function isOriginAllowed(req: IncomingMessage, allowedOrigins: string[]): boolean {
+	const origin = req.headers.origin;
+	if (typeof origin !== "string" || origin === "") {
+		// No Origin header — non-browser client, allow through
+		return true;
+	}
+	return allowedOrigins.some((allowed) => origin === allowed);
+}
+
+function patchWriteHeadForCsp(res: ServerResponse): void {
+	const originalWriteHead = res.writeHead;
+	function patchedWriteHead(statusCode: number, ...rest: unknown[]): ServerResponse {
+		const headers = resolveHeadersFromArgs(rest);
+		if (headers) {
+			const contentType = headers["Content-Type"];
+			const contentTypeStr = Array.isArray(contentType)
+				? contentType[0]
+				: typeof contentType === "string"
+					? contentType
+					: undefined;
+			if (isHtmlContentType(contentTypeStr)) {
+				headers["Content-Security-Policy"] = CSP_HEADER_VALUE;
+			}
+		}
+		return originalWriteHead.apply(res, [statusCode, ...rest] as Parameters<typeof originalWriteHead>);
+	}
+	res.writeHead = patchedWriteHead as typeof res.writeHead;
+}
+
+export function createAuthMiddleware(deps: AuthMiddlewareDependencies): AuthMiddleware {
+	const { authToken, allowedOrigins: allowedOriginsInput, version } = deps;
+
+	// allowedOrigins can be a static array or a lazy getter (used when the
+	// origin depends on a port assigned at listen time — e.g. port 0).
+	const resolveAllowedOrigins = (): string[] | undefined => {
+		const resolved = typeof allowedOriginsInput === "function" ? allowedOriginsInput() : allowedOriginsInput;
+		return resolved && resolved.length > 0 ? resolved : undefined;
+	};
+	// Lazy getter → always resolve at request time to handle both static
+	// arrays and dynamic getters (e.g. port 0 where the origin isn't known
+	// until after listen).
+	const hasOriginValidation =
+		typeof allowedOriginsInput === "function" ||
+		(Array.isArray(allowedOriginsInput) && allowedOriginsInput.length > 0);
+
+	const handleHttpRequest = (req: IncomingMessage, res: ServerResponse): boolean => {
+		const pathname = getPathname(req);
+
+		// /api/health is always exempt from auth
+		if (isHealthEndpoint(pathname)) {
+			res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
+			res.end(JSON.stringify({ ok: true, version }));
+			return false; // Response already sent — caller should not continue routing
+		}
+
+		// Add CSP headers to the response for HTML responses.
+		// We patch writeHead to inspect the headers argument and inject the CSP
+		// header when the Content-Type indicates HTML.
+		patchWriteHeadForCsp(res);
+
+		// Static assets are exempt from auth (the web UI needs to load before it can send tokens)
+		if (isStaticAssetPath(pathname)) {
+			return true;
+		}
+
+		// CSRF defense-in-depth: validate Origin header on API paths
+		const origins = resolveAllowedOrigins();
+		if (hasOriginValidation && origins && !isOriginAllowed(req, origins)) {
+			res.writeHead(403, { "Content-Type": "application/json; charset=utf-8" });
+			res.end('{"error":"Forbidden"}');
+			return false;
+		}
+
+		// When no authToken is configured (local CLI mode), skip validation
+		if (!authToken) {
+			return true;
+		}
+
+		// Primary: Bearer token from Authorization header.
+		// Fallback: kanban-auth session cookie — allows browser tabs opened
+		// by the CLI to authenticate against a desktop-owned runtime using
+		// the cookie set during the initial ?auth= handshake.
+		const token = extractBearerToken(req) ?? extractTokenFromCookie(req);
+		if (!token || !constantTimeEqual(token, authToken)) {
+			res.writeHead(401, { "Content-Type": "application/json; charset=utf-8" });
+			res.end('{"error":"Unauthorized"}');
+			return false;
+		}
+
+		return true;
+	};
+
+	const handleWsUpgrade = (req: IncomingMessage): boolean => {
+		// CSRF defense-in-depth: validate Origin header on WS upgrade paths
+		const wsOrigins = resolveAllowedOrigins();
+		if (hasOriginValidation && wsOrigins && !isOriginAllowed(req, wsOrigins)) {
+			return false;
+		}
+
+		// When no authToken is configured (local CLI mode), skip validation
+		if (!authToken) {
+			return true;
+		}
+
+		// Primary: Bearer token from Authorization header (CLI/programmatic clients).
+		// Fallback: kanban-auth session cookie (Electron desktop — see
+		// extractTokenFromCookie docstring for why this is needed).
+		// No query-param fallback. Ever.
+		const token = extractBearerToken(req) ?? extractTokenFromCookie(req);
+		if (!token || !constantTimeEqual(token, authToken)) {
+			return false;
+		}
+
+		return true;
+	};
+
+	return {
+		handleHttpRequest,
+		handleWsUpgrade,
+	};
+}

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
@@ -18,6 +19,7 @@ import {
 	getKanbanRuntimePort,
 	getKanbanRuntimeTls,
 	isKanbanRemoteHost,
+	setKanbanRuntimePort,
 } from "../core/runtime-endpoint";
 import {
 	checkRateLimit,
@@ -31,7 +33,7 @@ import {
 	validatePasscode,
 	validateSession,
 } from "../security/passcode-manager";
-import { loadWorkspaceContextById } from "../state/workspace-state";
+import { getWorkspaceDirectoryPath, loadWorkspaceContextById } from "../state/workspace-state";
 import type { TerminalSessionManager } from "../terminal/session-manager";
 import { createTerminalWebSocketBridge } from "../terminal/ws-server";
 import { type RuntimeTrpcContext, type RuntimeTrpcWorkspaceScope, runtimeAppRouter } from "../trpc/app-router";
@@ -40,8 +42,10 @@ import { createProjectsApi } from "../trpc/projects-api";
 import { createRuntimeApi } from "../trpc/runtime-api";
 import { createWorkspaceApi } from "../trpc/workspace-api";
 import { getWebUiDir, normalizeRequestPath, readAsset } from "./assets";
+import { createAuthMiddleware } from "./auth-middleware";
 import type { RuntimeStateHub } from "./runtime-state-hub";
 import type { WorkspaceRegistry } from "./workspace-registry";
+import { createWorkspaceStateWatcher } from "./workspace-state-watcher";
 
 interface DisposeTrackedWorkspaceResult {
 	terminalManager: TerminalSessionManager | null;
@@ -65,7 +69,10 @@ export interface CreateRuntimeServerDependencies {
 		},
 	) => DisposeTrackedWorkspaceResult;
 	collectProjectWorktreeTaskIdsForRemoval: (board: RuntimeWorkspaceStateResponse["board"]) => Set<string>;
-	pickDirectoryPathFromSystemDialog: () => string | null;
+	pickDirectoryPathFromSystemDialog: () => Promise<string | null> | string | null;
+	authToken?: string;
+	allowedOrigins?: string[] | (() => string[]);
+	version: string;
 }
 
 export interface RuntimeServer {
@@ -94,6 +101,14 @@ function readWorkspaceIdFromRequest(request: IncomingMessage, requestUrl: URL): 
 
 export async function createRuntimeServer(deps: CreateRuntimeServerDependencies): Promise<RuntimeServer> {
 	const webUiDir = getWebUiDir();
+	const authMiddleware = createAuthMiddleware({
+		authToken: deps.authToken,
+		// Forward directly — the auth middleware accepts both static arrays
+		// and lazy getters.  When port 0 is used (OS-assigned port), callers
+		// pass a getter so the origin resolves after the global port is set.
+		allowedOrigins: deps.allowedOrigins,
+		version: deps.version,
+	});
 
 	try {
 		await readFile(join(webUiDir, "index.html"));
@@ -122,13 +137,37 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 				workspaceScope: null,
 			};
 		}
+		const scope: RuntimeTrpcWorkspaceScope = {
+			workspaceId: requestedWorkspaceContext.workspaceId,
+			workspacePath: requestedWorkspaceContext.repoPath,
+		};
+
+		// Eagerly start the file watcher so external changes from another
+		// runtime (e.g. Electron ↔ CLI) are detected even if this runtime
+		// has not yet written to the workspace itself.
+		workspaceStateWatcher.watch(scope.workspaceId, scope.workspacePath, getWorkspaceDirectoryPath(scope.workspaceId));
+
 		return {
 			requestedWorkspaceId,
-			workspaceScope: {
-				workspaceId: requestedWorkspaceContext.workspaceId,
-				workspacePath: requestedWorkspaceContext.repoPath,
-			},
+			workspaceScope: scope,
 		};
+	};
+
+	// ── Workspace state file watcher ──────────────────────────────────────
+	// Detects external writes to meta.json (by another runtime instance)
+	// and broadcasts updates to connected WebSocket clients so they stay
+	// in sync without requiring a manual browser refresh.
+	const workspaceStateWatcher = createWorkspaceStateWatcher({
+		broadcastRuntimeWorkspaceStateUpdated: (workspaceId, workspacePath) =>
+			deps.runtimeStateHub.broadcastRuntimeWorkspaceStateUpdated(workspaceId, workspacePath),
+		warn: deps.warn,
+	});
+
+	/** Wraps the hub broadcast to mark self-writes + lazily start watching. */
+	const broadcastAndMarkSelfWrite = async (workspaceId: string, workspacePath: string): Promise<void> => {
+		workspaceStateWatcher.markSelfWrite(workspaceId);
+		workspaceStateWatcher.watch(workspaceId, workspacePath, getWorkspaceDirectoryPath(workspaceId));
+		await deps.runtimeStateHub.broadcastRuntimeWorkspaceStateUpdated(workspaceId, workspacePath);
 	};
 
 	const getScopedTerminalManager = async (scope: RuntimeTrpcWorkspaceScope): Promise<TerminalSessionManager> =>
@@ -203,7 +242,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 			workspaceApi: createWorkspaceApi({
 				ensureTerminalManagerForWorkspace: deps.ensureTerminalManagerForWorkspace,
 				getScopedClineTaskSessionService,
-				broadcastRuntimeWorkspaceStateUpdated: deps.runtimeStateHub.broadcastRuntimeWorkspaceStateUpdated,
+				broadcastRuntimeWorkspaceStateUpdated: broadcastAndMarkSelfWrite,
 				broadcastRuntimeProjectsUpdated: deps.runtimeStateHub.broadcastRuntimeProjectsUpdated,
 				buildWorkspaceStateSnapshot: deps.workspaceRegistry.buildWorkspaceStateSnapshot,
 			}),
@@ -233,7 +272,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 			hooksApi: createHooksApi({
 				getWorkspacePathById: deps.workspaceRegistry.getWorkspacePathById,
 				ensureTerminalManagerForWorkspace: deps.ensureTerminalManagerForWorkspace,
-				broadcastRuntimeWorkspaceStateUpdated: deps.runtimeStateHub.broadcastRuntimeWorkspaceStateUpdated,
+				broadcastRuntimeWorkspaceStateUpdated: broadcastAndMarkSelfWrite,
 				broadcastTaskReadyForReview: deps.runtimeStateHub.broadcastTaskReadyForReview,
 			}),
 		};
@@ -268,8 +307,43 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 	const tlsConfig = getKanbanRuntimeTls();
 	const requestHandler = async (req: IncomingMessage, res: import("node:http").ServerResponse) => {
 		try {
+			if (!authMiddleware.handleHttpRequest(req, res)) {
+				return;
+			}
 			const requestUrl = new URL(req.url ?? "/", "http://localhost");
 			const pathname = normalizeRequestPath(requestUrl.pathname);
+
+			// ── Auth token handshake (CLI → desktop runtime) ─────────────────
+			// When the CLI opens a browser to a desktop-owned runtime, it
+			// appends ?auth=TOKEN to the URL. We validate the token, set a
+			// session cookie, and redirect to the clean URL so all subsequent
+			// requests (including WS upgrades) are authenticated via cookie.
+			const authParam = requestUrl.searchParams.get("auth");
+			if (authParam && deps.authToken && !pathname.startsWith("/api/")) {
+				const tokenBuffer = Buffer.from(authParam, "utf8");
+				const expectedBuffer = Buffer.from(deps.authToken, "utf8");
+				if (tokenBuffer.length === expectedBuffer.length && timingSafeEqual(tokenBuffer, expectedBuffer)) {
+					const cookieFlags = [
+						`kanban-auth=${authParam}`,
+						"HttpOnly",
+						"SameSite=Strict",
+						"Path=/",
+						`Max-Age=${24 * 60 * 60}`,
+						...(tlsConfig !== null ? ["Secure"] : []),
+					].join("; ");
+					// Remove the auth param from the redirect URL.
+					requestUrl.searchParams.delete("auth");
+					const redirectUrl = requestUrl.pathname + (requestUrl.search || "");
+					res.writeHead(302, {
+						"Set-Cookie": cookieFlags,
+						Location: redirectUrl,
+						"Cache-Control": "no-store",
+					});
+					res.end();
+					return;
+				}
+				// Invalid token — ignore the param and serve normally.
+			}
 
 			// ── Passcode gate (remote mode only) ──────────────────────────────
 			const passcodeActive = isRemoteMode && isPasscodeEnabled();
@@ -470,6 +544,14 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 	if (!address || typeof address === "string") {
 		throw new Error("Failed to start local server.");
 	}
+
+	// When port 0 was requested, the OS assigned an ephemeral port.
+	// Update the global runtime port so getKanbanRuntimeOrigin() /
+	// buildKanbanRuntimeUrl() reflect the actual listening port.
+	if (address.port !== getKanbanRuntimePort()) {
+		setKanbanRuntimePort(address.port);
+	}
+
 	const activeWorkspaceId = deps.workspaceRegistry.getActiveWorkspaceId();
 	const url = activeWorkspaceId
 		? buildKanbanRuntimeUrl(`/${encodeURIComponent(activeWorkspaceId)}`)
@@ -478,6 +560,7 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 	return {
 		url,
 		close: async () => {
+			workspaceStateWatcher.close();
 			await Promise.all(
 				Array.from(clineTaskSessionServiceByWorkspaceId.values()).map(async (service) => {
 					await service.dispose();

--- a/src/server/runtime-state-hub.ts
+++ b/src/server/runtime-state-hub.ts
@@ -36,6 +36,8 @@ export interface CreateRuntimeStateHubDependencies {
 		WorkspaceRegistry,
 		"resolveWorkspaceForStream" | "buildProjectsPayload" | "buildWorkspaceStateSnapshot"
 	>;
+	isLocal: boolean;
+	runtimeVersion: string;
 }
 
 export interface RuntimeStateHub {
@@ -433,6 +435,8 @@ export function createRuntimeStateHub(deps: CreateRuntimeStateHubDependencies): 
 				}
 				sendRuntimeStateMessage(client, {
 					type: "snapshot",
+					isLocal: deps.isLocal,
+					runtimeVersion: deps.runtimeVersion,
 					currentProjectId: projectsPayload.currentProjectId,
 					projects: projectsPayload.projects,
 					workspaceState,

--- a/src/server/workspace-state-watcher.ts
+++ b/src/server/workspace-state-watcher.ts
@@ -1,0 +1,178 @@
+/**
+ * Watches workspace state directories for external modifications and triggers
+ * live broadcasts so that changes made by a different runtime instance
+ * (e.g. CLI runtime vs desktop Electron runtime) appear in all connected
+ * web clients without requiring a manual browser refresh.
+ *
+ * Monitors **meta.json** rather than board.json because meta.json is always
+ * written with a fresh revision + updatedAt on every save.  board.json uses
+ * atomic-write content comparison and skips the write (leaving mtime
+ * unchanged) when only sessions changed — which caused the other runtime
+ * to miss the update entirely.
+ *
+ * Uses **mtime polling** rather than `fs.watch()` because macOS's FSEvents /
+ * kqueue does not reliably deliver cross-process directory events for
+ * atomic-rename writes — the second process to start often misses events.
+ * Polling every 2 s with mtime comparison is simple, deterministic, and
+ * works regardless of startup order.
+ *
+ * Uses self-write tracking to avoid broadcasting our own mutations back.
+ */
+
+import { mkdirSync, statSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+
+const META_FILENAME = "meta.json";
+
+/** How often to poll for external changes (ms). */
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Ignore mtime changes within this window after a self-write (ms).
+ * Must exceed POLL_INTERVAL_MS so the next poll cycle is suppressed.
+ *
+ * This is a timing-based heuristic: under unusual slow IO, clock skew, or
+ * overlapping writes the cooldown could miss or delay rebroadcasts.
+ * In practice the 3 s window is generous enough for the 2 s poll cycle.
+ */
+const SELF_WRITE_COOLDOWN_MS = 3_000;
+
+export interface WorkspaceStateWatcherDependencies {
+	broadcastRuntimeWorkspaceStateUpdated: (workspaceId: string, workspacePath: string) => Promise<void> | void;
+	warn?: (message: string) => void;
+}
+
+interface WatchedWorkspace {
+	workspaceId: string;
+	workspacePath: string;
+	statePath: string;
+	pollTimer: NodeJS.Timeout;
+	lastSelfWriteAt: number;
+	/** Last known mtime of meta.json (ms since epoch). */
+	lastMetaMtimeMs: number;
+}
+
+export interface WorkspaceStateWatcher {
+	/**
+	 * Start watching a workspace's state directory for meta.json changes.
+	 * Safe to call multiple times for the same workspace — duplicates are ignored.
+	 * Creates the state directory if it doesn't exist yet.
+	 */
+	watch: (workspaceId: string, workspacePath: string, statePath: string) => void;
+
+	/**
+	 * Mark that the current process just wrote to this workspace's state files.
+	 * This suppresses the next poll cycle to avoid echoing our own writes.
+	 */
+	markSelfWrite: (workspaceId: string) => void;
+
+	/**
+	 * Stop watching a specific workspace.
+	 */
+	unwatch: (workspaceId: string) => void;
+
+	/**
+	 * Stop all watchers and clean up.
+	 */
+	close: () => void;
+}
+
+export function createWorkspaceStateWatcher(deps: WorkspaceStateWatcherDependencies): WorkspaceStateWatcher {
+	const watched = new Map<string, WatchedWorkspace>();
+
+	const log = deps.warn ?? (() => {});
+
+	async function pollMetaChange(entry: WatchedWorkspace): Promise<void> {
+		// If we recently wrote to this workspace, skip — it's our own mutation.
+		if (Date.now() - entry.lastSelfWriteAt < SELF_WRITE_COOLDOWN_MS) {
+			return;
+		}
+
+		let metaStat: Awaited<ReturnType<typeof stat>>;
+		try {
+			metaStat = await stat(join(entry.statePath, META_FILENAME));
+		} catch {
+			// File doesn't exist (yet or was deleted) — nothing to broadcast.
+			return;
+		}
+
+		const currentMtimeMs = metaStat.mtimeMs;
+		if (currentMtimeMs === entry.lastMetaMtimeMs) {
+			return;
+		}
+		entry.lastMetaMtimeMs = currentMtimeMs;
+
+		log(`[workspace-state-watcher] External meta.json change detected for workspace ${entry.workspaceId}`);
+
+		try {
+			await deps.broadcastRuntimeWorkspaceStateUpdated(entry.workspaceId, entry.workspacePath);
+		} catch (err) {
+			log(`[workspace-state-watcher] Broadcast failed for workspace ${entry.workspaceId}: ${err}`);
+		}
+	}
+
+	return {
+		watch: (workspaceId, workspacePath, statePath) => {
+			if (watched.has(workspaceId)) {
+				return;
+			}
+
+			// Ensure the state directory exists.
+			try {
+				mkdirSync(statePath, { recursive: true });
+			} catch {
+				return;
+			}
+
+			// Snapshot the current mtime so we don't broadcast stale state.
+			let initialMtimeMs = 0;
+			try {
+				initialMtimeMs = statSync(join(statePath, META_FILENAME)).mtimeMs;
+			} catch {
+				// meta.json doesn't exist yet — mtime stays 0.
+			}
+
+			const entry: WatchedWorkspace = {
+				workspaceId,
+				workspacePath,
+				statePath,
+				pollTimer: null as unknown as NodeJS.Timeout,
+				lastSelfWriteAt: 0,
+				lastMetaMtimeMs: initialMtimeMs,
+			};
+
+			entry.pollTimer = setInterval(() => {
+				void pollMetaChange(entry);
+			}, POLL_INTERVAL_MS);
+
+			// Don't prevent process exit.
+			entry.pollTimer.unref();
+
+			watched.set(workspaceId, entry);
+		},
+
+		markSelfWrite: (workspaceId) => {
+			const entry = watched.get(workspaceId);
+			if (entry) {
+				entry.lastSelfWriteAt = Date.now();
+			}
+		},
+
+		unwatch: (workspaceId) => {
+			const entry = watched.get(workspaceId);
+			if (!entry) {
+				return;
+			}
+			clearInterval(entry.pollTimer);
+			watched.delete(workspaceId);
+		},
+
+		close: () => {
+			for (const entry of watched.values()) {
+				clearInterval(entry.pollTimer);
+			}
+			watched.clear();
+		},
+	};
+}

--- a/src/terminal/agent-registry.ts
+++ b/src/terminal/agent-registry.ts
@@ -6,6 +6,7 @@ import type {
 	RuntimeClineProviderSettings,
 	RuntimeConfigResponse,
 } from "../core/api-contract";
+import { computeHomeAgentPromptHash } from "../prompts/append-system-prompt";
 import { isBinaryAvailableOnPath } from "./command-discovery";
 
 export interface ResolvedAgentCommand {
@@ -124,5 +125,6 @@ export function buildRuntimeConfigResponse(
 		openPrPromptTemplate: runtimeConfig.openPrPromptTemplate,
 		commitPromptTemplateDefault: runtimeConfig.commitPromptTemplateDefault,
 		openPrPromptTemplateDefault: runtimeConfig.openPrPromptTemplateDefault,
+		homeAgentPromptHash: computeHomeAgentPromptHash(runtimeConfig.selectedAgentId),
 	};
 }

--- a/src/terminal/pty-session.ts
+++ b/src/terminal/pty-session.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+
 import * as pty from "node-pty";
 
 import {
@@ -87,13 +90,23 @@ export class PtySession {
 		const normalizedArgs = typeof args === "string" ? [args] : args;
 		const terminalName = env?.TERM?.trim() || process.env.TERM?.trim() || "xterm-256color";
 		const launchEnv: NodeJS.ProcessEnv = env ? { ...process.env, ...env } : process.env;
+
+		// Validate cwd exists — posix_spawn returns ENOENT when the working
+		// directory is missing, which produces a confusing "binary not found"
+		// error even though the shell binary is fine.
+		let safeCwd = cwd;
+		if (!existsSync(safeCwd)) {
+			const home = launchEnv.HOME ?? homedir();
+			safeCwd = existsSync(home) ? home : "/";
+		}
+
 		const useWindowsShellLaunch = shouldUseWindowsCmdLaunch(binary, process.platform, launchEnv);
 		const spawnBinary = useWindowsShellLaunch ? resolveWindowsComSpec(launchEnv) : binary;
 		const spawnArgs = useWindowsShellLaunch ? buildWindowsCmdArgsCommandLine(binary, normalizedArgs) : normalizedArgs;
 		const ptyOptions: pty.IPtyForkOptions = {
 			name: terminalName,
-			cwd,
-			env,
+			cwd: safeCwd,
+			env: launchEnv,
 			cols,
 			rows,
 			encoding: null,

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -1,6 +1,7 @@
 // PTY-backed runtime for non-Cline task sessions and the workspace shell terminal.
 // It owns process lifecycle, terminal protocol filtering, and summary updates
 // for command-driven agents such as Claude Code, Codex, Gemini, and shell sessions.
+import { delimiter } from "node:path";
 import type {
 	RuntimeTaskHookActivity,
 	RuntimeTaskImage,
@@ -163,19 +164,41 @@ function cloneStartShellSessionRequest(request: StartShellSessionRequest): Start
 }
 
 function formatSpawnFailure(binary: string, error: unknown): string {
+	const code = (error as NodeJS.ErrnoException).code ?? "unknown";
 	const message = error instanceof Error ? error.message : String(error);
 	const normalized = message.toLowerCase();
-	if (normalized.includes("posix_spawnp failed") || normalized.includes("enoent")) {
-		return `Failed to launch "${binary}". Command not found. Install a supported agent CLI and select it in Settings.`;
+
+	if (
+		normalized.includes("posix_spawnp failed") ||
+		normalized.includes("posix_spawn failed") ||
+		normalized.includes("enoent") ||
+		code === "ENOENT"
+	) {
+		const pathEntries = (process.env.PATH ?? "").split(delimiter);
+		const pathSummary =
+			pathEntries.length <= 5
+				? pathEntries.join(", ")
+				: `${pathEntries.slice(0, 3).join(", ")} ... (${pathEntries.length} total)`;
+		return (
+			`Agent binary "${binary}" not found. ` +
+			`PATH has ${pathEntries.length} entries: ${pathSummary}. ` +
+			"Install a supported agent CLI and select it in Settings."
+		);
 	}
-	return `Failed to launch "${binary}": ${message}`;
+
+	return `Failed to launch "${binary}": ${message}${code !== "unknown" ? ` (${code})` : ""}`;
 }
 
-function formatShellSpawnFailure(binary: string, error: unknown): string {
+function formatShellSpawnFailure(binary: string, error: unknown, cwd?: string): string {
 	const message = error instanceof Error ? error.message : String(error);
 	const normalized = message.toLowerCase();
-	if (normalized.includes("posix_spawnp failed") || normalized.includes("enoent")) {
-		return `Failed to launch "${binary}". Command not found on this system.`;
+	if (
+		normalized.includes("posix_spawnp failed") ||
+		normalized.includes("posix_spawn failed") ||
+		normalized.includes("enoent")
+	) {
+		const cwdHint = cwd ? ` Verify the workspace directory "${cwd}" exists and the shell binary is installed.` : "";
+		return `Failed to launch "${binary}": No such file or directory.${cwdHint}`;
 	}
 	return `Failed to launch "${binary}": ${message}`;
 }
@@ -660,7 +683,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 				previousTurnCheckpoint: null,
 			});
 			this.emitSummary(summary);
-			throw new Error(formatShellSpawnFailure(request.binary, error));
+			throw new Error(formatShellSpawnFailure(request.binary, error, request.cwd));
 		}
 
 		const active: ActiveProcessState = {

--- a/src/trpc/projects-api.ts
+++ b/src/trpc/projects-api.ts
@@ -54,7 +54,7 @@ export interface CreateProjectsApiDependencies {
 		currentProjectId: string | null;
 		projects: RuntimeProjectSummary[];
 	}>;
-	pickDirectoryPathFromSystemDialog: () => string | null;
+	pickDirectoryPathFromSystemDialog: () => Promise<string | null> | string | null;
 	serverCwd: string;
 }
 
@@ -235,7 +235,7 @@ export function createProjectsApi(deps: CreateProjectsApiDependencies): RuntimeT
 		},
 		pickProjectDirectory: async () => {
 			try {
-				const selectedPath = deps.pickDirectoryPathFromSystemDialog();
+				const selectedPath = await deps.pickDirectoryPathFromSystemDialog();
 				if (!selectedPath) {
 					return {
 						ok: false,

--- a/test/cli/token-generate.test.ts
+++ b/test/cli/token-generate.test.ts
@@ -1,0 +1,77 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+
+import { generateToken, registerTokenCommand } from "../../src/commands/token";
+
+describe("generateToken", () => {
+	it("returns a 64-character hex string", () => {
+		const token = generateToken();
+		expect(token).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("returns a different token on each call", () => {
+		const a = generateToken();
+		const b = generateToken();
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("registerTokenCommand", () => {
+	it("registers a token command with a generate subcommand", () => {
+		const program = new Command();
+		program.exitOverride();
+		registerTokenCommand(program);
+
+		const tokenCmd = program.commands.find((cmd) => cmd.name() === "token");
+		expect(tokenCmd).toBeDefined();
+
+		const generateCmd = tokenCmd?.commands.find((cmd) => cmd.name() === "generate");
+		expect(generateCmd).toBeDefined();
+	});
+
+	it("writes a 64-char hex token followed by a newline to stdout", async () => {
+		const program = new Command();
+		program.exitOverride();
+		registerTokenCommand(program);
+
+		const written: string[] = [];
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+			written.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		try {
+			await program.parseAsync(["token", "generate"], { from: "user" });
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		expect(written).toHaveLength(1);
+		const output = written[0] ?? "";
+		expect(output).toMatch(/^[0-9a-f]{64}\n$/);
+	});
+
+	it("produces raw output with no labels or extra text", async () => {
+		const program = new Command();
+		program.exitOverride();
+		registerTokenCommand(program);
+
+		const written: string[] = [];
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+			written.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+			return true;
+		});
+
+		try {
+			await program.parseAsync(["token", "generate"], { from: "user" });
+		} finally {
+			writeSpy.mockRestore();
+		}
+
+		const output = written.join("");
+		// Should be exactly: 64 hex chars + newline — nothing else
+		expect(output.length).toBe(65);
+		expect(output[64]).toBe("\n");
+		expect(output.slice(0, 64)).toMatch(/^[0-9a-f]{64}$/);
+	});
+});

--- a/test/integration/desktop-agent-task-create.integration.test.ts
+++ b/test/integration/desktop-agent-task-create.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration test: Desktop agent can create tasks via inherited env vars.
+ *
+ * This test simulates the desktop app flow:
+ *   1. Start the kanban runtime with an auth token (like Electron does)
+ *   2. Spawn a child process that inherits KANBAN_RUNTIME_HOST, KANBAN_RUNTIME_PORT,
+ *      and KANBAN_AUTH_TOKEN from process.env (like a PTY session would)
+ *   3. That child runs `kanban task create --prompt "..." --project-path <path>`
+ *   4. Verify the task appears on the board
+ *
+ * This is the VS Code-style env var propagation pattern — the same mechanism
+ * that makes `code` CLI work from VS Code's integrated terminal.
+ *
+ * IMPORTANT: We use async `spawn` (not `spawnSync`) because the runtime
+ * server runs in-process. `spawnSync` would deadlock — the child tries to
+ * HTTP-connect to the parent, which is blocked waiting on the child.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { type RuntimeHandle, startRuntime } from "../../src/runtime-start";
+import { createGitTestEnv } from "../utilities/git-env";
+import { createTempDir } from "../utilities/temp-dir";
+
+const requireFromHere = createRequire(import.meta.url);
+
+function resolveTsxLoaderImportSpecifier(): string {
+	return pathToFileURL(requireFromHere.resolve("tsx")).href;
+}
+
+function initGitRepository(path: string): void {
+	const env = createGitTestEnv();
+	const init = spawnSync("git", ["init"], { cwd: path, stdio: "ignore", env });
+	if (init.status !== 0) throw new Error(`git init failed at ${path}`);
+	const checkout = spawnSync("git", ["checkout", "-B", "main"], { cwd: path, stdio: "ignore", env });
+	if (checkout.status !== 0) throw new Error(`git checkout failed at ${path}`);
+	spawnSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: path, stdio: "ignore", env });
+}
+
+async function getAvailablePort(): Promise<number> {
+	const server = createServer();
+	await new Promise<void>((res, rej) => {
+		server.once("error", rej);
+		server.listen(0, "127.0.0.1", () => res());
+	});
+	const address = server.address();
+	const port = typeof address === "object" && address ? address.port : null;
+	await new Promise<void>((res, rej) => {
+		server.close((err) => (err ? rej(err) : res()));
+	});
+	if (!port) throw new Error("Could not allocate a test port.");
+	return port;
+}
+
+/**
+ * Run `kanban task create` in a child process with the given env vars.
+ * Uses async `spawn` to avoid deadlocking with the in-process runtime server.
+ */
+function runTaskCreate(
+	port: number,
+	authToken: string | undefined,
+	projectPath: string,
+	prompt: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+	const cliEntryPath = resolve(process.cwd(), "src/cli.ts");
+	return new Promise((res) => {
+		const child = spawn(
+			process.execPath,
+			[
+				"--import",
+				resolveTsxLoaderImportSpecifier(),
+				cliEntryPath,
+				"task",
+				"create",
+				"--prompt",
+				prompt,
+				"--project-path",
+				projectPath,
+			],
+			{
+				stdio: ["ignore", "pipe", "pipe"],
+				env: {
+					...process.env,
+					KANBAN_RUNTIME_HOST: "127.0.0.1",
+					KANBAN_RUNTIME_PORT: String(port),
+					...(authToken ? { KANBAN_AUTH_TOKEN: authToken } : {}),
+				},
+			},
+		);
+
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.once("exit", (exitCode) => {
+			res({ stdout, stderr, exitCode });
+		});
+
+		// Safety timeout
+		setTimeout(() => {
+			child.kill("SIGKILL");
+		}, 20_000);
+	});
+}
+
+describe("desktop agent task create via env var propagation", { timeout: 60_000 }, () => {
+	let runtime: RuntimeHandle | null = null;
+	const cleanups: Array<() => void> = [];
+
+	afterEach(async () => {
+		if (runtime) {
+			await runtime.shutdown({ skipSessionCleanup: true }).catch(() => {});
+			runtime = null;
+		}
+		delete process.env.KANBAN_AUTH_TOKEN;
+		for (const cleanup of cleanups) {
+			cleanup();
+		}
+		cleanups.length = 0;
+	});
+
+	it("creates a task when KANBAN_AUTH_TOKEN is set in the child env", async () => {
+		const { path: tempDir, cleanup } = createTempDir("desktop-agent-task-create");
+		cleanups.push(cleanup);
+		initGitRepository(tempDir);
+
+		const port = await getAvailablePort();
+		const authToken = `test-desktop-auth-${Date.now()}`;
+
+		// Start the runtime with auth — exactly what the desktop app does.
+		runtime = await startRuntime({
+			host: "127.0.0.1",
+			port,
+			authToken,
+			callbacks: { warn: () => {} },
+			isLocal: true,
+		});
+
+		// Verify runtime is up.
+		const healthResponse = await fetch(`http://127.0.0.1:${port}/api/health`, {
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		expect(healthResponse.ok).toBe(true);
+
+		// Now simulate what the desktop agent does: run `kanban task create`
+		// in a child process with env vars inherited from the runtime.
+		const result = await runTaskCreate(port, authToken, tempDir, "Test task from desktop agent");
+
+		expect(result.exitCode, `task create should exit 0.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+
+		// Verify the output contains the created task info.
+		expect(result.stdout).toContain("Test task from desktop agent");
+	});
+
+	it("task create fails without auth token when runtime requires auth", async () => {
+		const { path: tempDir, cleanup } = createTempDir("desktop-agent-no-auth");
+		cleanups.push(cleanup);
+		initGitRepository(tempDir);
+
+		const port = await getAvailablePort();
+		const authToken = `test-desktop-auth-${Date.now()}`;
+
+		runtime = await startRuntime({
+			host: "127.0.0.1",
+			port,
+			authToken,
+			callbacks: { warn: () => {} },
+			isLocal: true,
+		});
+
+		// Ensure no stale auth token from prior tests.
+		delete process.env.KANBAN_AUTH_TOKEN;
+
+		// Try without auth token — should fail.
+		const result = await runTaskCreate(port, undefined, tempDir, "Should fail");
+
+		expect(result.exitCode).not.toBe(0);
+	});
+});

--- a/test/runtime/append-system-prompt.test.ts
+++ b/test/runtime/append-system-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	computeHomeAgentPromptHash,
 	renderAppendSystemPrompt,
 	resolveAppendSystemPromptCommandPrefix,
 	resolveHomeAgentAppendSystemPrompt,
@@ -132,5 +133,24 @@ describe("resolveHomeAgentAppendSystemPrompt", () => {
 		expect(prompt).toContain("Current home agent: `kiro`");
 		expect(prompt).toContain("kiro-cli mcp add --name linear --url https://mcp.linear.app/mcp --scope global");
 		expect(prompt).not.toContain("--scope user");
+	});
+});
+
+describe("computeHomeAgentPromptHash", () => {
+	it("returns a 16-char hex string", () => {
+		const hash = computeHomeAgentPromptHash("claude");
+		expect(hash).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it("returns the same hash for the same agent", () => {
+		const a = computeHomeAgentPromptHash("claude");
+		const b = computeHomeAgentPromptHash("claude");
+		expect(a).toBe(b);
+	});
+
+	it("returns different hashes for different agents", () => {
+		const claudeHash = computeHomeAgentPromptHash("claude");
+		const codexHash = computeHomeAgentPromptHash("codex");
+		expect(claudeHash).not.toBe(codexHash);
 	});
 });

--- a/test/runtime/auth-middleware.test.ts
+++ b/test/runtime/auth-middleware.test.ts
@@ -1,0 +1,360 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { createAuthMiddleware } from "../../src/server/auth-middleware";
+
+function createMockRequest(overrides?: {
+	url?: string;
+	headers?: Record<string, string | string[] | undefined>;
+}): IncomingMessage {
+	return {
+		url: overrides?.url ?? "/",
+		headers: overrides?.headers ?? {},
+	} as IncomingMessage;
+}
+
+interface MockResponse {
+	response: ServerResponse;
+	getStatus: () => number | undefined;
+	getHeaders: () => Record<string, string | string[] | number | undefined>;
+	getBody: () => string;
+}
+
+function createMockResponse(): MockResponse {
+	let statusCode: number | undefined;
+	let responseHeaders: Record<string, string | string[] | number | undefined> = {};
+	let body = "";
+
+	const res = {
+		writeHead(status: number, ...rest: unknown[]): ServerResponse {
+			statusCode = status;
+			if (rest.length === 2) {
+				responseHeaders = rest[1] as Record<string, string | string[] | number | undefined>;
+			} else if (rest.length === 1 && typeof rest[0] === "object" && rest[0] !== null) {
+				responseHeaders = rest[0] as Record<string, string | string[] | number | undefined>;
+			}
+			return res as unknown as ServerResponse;
+		},
+		end(data?: string) {
+			if (data) {
+				body = data;
+			}
+		},
+	} as unknown as ServerResponse;
+
+	return {
+		response: res,
+		getStatus: () => statusCode,
+		getHeaders: () => responseHeaders,
+		getBody: () => body,
+	};
+}
+
+const TEST_TOKEN = "test-secret-token-abc123";
+const TEST_VERSION = "1.2.3";
+
+describe("auth-middleware", () => {
+	describe("token validation with authToken configured", () => {
+		it("allows request with valid Bearer token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: `Bearer ${TEST_TOKEN}` },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("rejects request with wrong token → 401", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: "Bearer wrong-token" },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+			expect(JSON.parse(mock.getBody())).toEqual({ error: "Unauthorized" });
+		});
+
+		it("rejects request without Authorization header → 401", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/trpc/some.procedure", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+
+		it("rejects malformed Authorization header (no Bearer prefix)", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: TEST_TOKEN },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+
+		it("rejects empty Bearer token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: "Bearer " },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+
+		it("rejects extra spaces in Authorization header", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: `Bearer  ${TEST_TOKEN}` },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+	});
+
+	describe("static assets exempt from auth", () => {
+		it("allows static asset request without token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/index.html", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows JS asset request without token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/assets/main.js", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows CSS asset request without token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/assets/style.css", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows root path request without token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("/api/health endpoint", () => {
+		it("returns { ok: true, version } without auth", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/health", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(200);
+			expect(JSON.parse(mock.getBody())).toEqual({ ok: true, version: TEST_VERSION });
+		});
+
+		it("returns health even when no auth token is configured", () => {
+			const middleware = createAuthMiddleware({ version: "0.0.1" });
+			const req = createMockRequest({ url: "/api/health", headers: {} });
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(200);
+			expect(JSON.parse(mock.getBody())).toEqual({ ok: true, version: "0.0.1" });
+		});
+
+		it("returns health response with Content-Type application/json", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/health" });
+			const mock = createMockResponse();
+			middleware.handleHttpRequest(req, mock.response);
+			expect(mock.getHeaders()["Content-Type"]).toBe("application/json; charset=utf-8");
+		});
+	});
+
+	describe("CSP headers on HTML responses", () => {
+		it("adds Content-Security-Policy header when Content-Type is text/html", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/index.html" });
+			const headers: Record<string, string | string[] | number | undefined> = {
+				"Content-Type": "text/html; charset=utf-8",
+				"Cache-Control": "no-store",
+			};
+			const res = {
+				writeHead: vi.fn((_s: number, _h: Record<string, string | string[] | number | undefined>) => res),
+				end: vi.fn(),
+			} as unknown as ServerResponse;
+			middleware.handleHttpRequest(req, res);
+			res.writeHead(200, headers);
+			expect(headers["Content-Security-Policy"]).toBe(
+				"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https://*.ingest.us.sentry.io; img-src 'self' data:",
+			);
+		});
+
+		it("does not add CSP header for non-HTML responses", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/assets/main.js" });
+			const headers: Record<string, string | string[] | number | undefined> = {
+				"Content-Type": "text/javascript; charset=utf-8",
+			};
+			const res = {
+				writeHead: vi.fn((_s: number, _h: Record<string, string | string[] | number | undefined>) => res),
+				end: vi.fn(),
+			} as unknown as ServerResponse;
+			middleware.handleHttpRequest(req, res);
+			res.writeHead(200, headers);
+			expect(headers["Content-Security-Policy"]).toBeUndefined();
+		});
+
+		it("adds CSP header with statusMessage + headers overload", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/" });
+			const headers: Record<string, string | string[] | number | undefined> = {
+				"Content-Type": "text/html; charset=utf-8",
+			};
+			const res = {
+				writeHead: vi.fn(),
+				end: vi.fn(),
+			} as unknown as ServerResponse;
+			middleware.handleHttpRequest(req, res);
+			(
+				res.writeHead as (
+					...args: [number, string, Record<string, string | string[] | number | undefined>]
+				) => unknown
+			)(200, "OK", headers);
+			expect(headers["Content-Security-Policy"]).toBe(
+				"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https://*.ingest.us.sentry.io; img-src 'self' data:",
+			);
+		});
+	});
+
+	describe("WebSocket upgrade auth", () => {
+		it("allows WS upgrade with valid Bearer token in header", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: { authorization: `Bearer ${TEST_TOKEN}` },
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+
+		it("rejects WS upgrade without Authorization header", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/runtime/ws", headers: {} });
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+
+		it("rejects WS upgrade with wrong token", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: { authorization: "Bearer wrong-token" },
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+
+		it("rejects WS upgrade with token only in query param (no header)", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: `/api/runtime/ws?token=${TEST_TOKEN}`,
+				headers: {},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+
+		it("WS auth ignores query params — only checks headers", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({
+				url: `/api/runtime/ws?token=${TEST_TOKEN}`,
+				headers: { authorization: "Bearer wrong-token" },
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+	});
+
+	describe("no authToken configured (local CLI mode)", () => {
+		it("allows API request without token", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/trpc/some.procedure", headers: {} });
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(true);
+		});
+
+		it("allows WS upgrade without token", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/runtime/ws", headers: {} });
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+
+		it("allows static assets", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = createMockRequest({ url: "/assets/style.css", headers: {} });
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(true);
+		});
+	});
+
+	describe("constant-time comparison", () => {
+		it("rejects token of different length", () => {
+			const middleware = createAuthMiddleware({ authToken: "short", version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/x",
+				headers: { authorization: "Bearer a-much-longer-token" },
+			});
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+
+		it("rejects token of same length but different content", () => {
+			const middleware = createAuthMiddleware({ authToken: "aaaa", version: TEST_VERSION });
+			const req = createMockRequest({
+				url: "/api/trpc/x",
+				headers: { authorization: "Bearer bbbb" },
+			});
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(false);
+			expect(mock.getStatus()).toBe(401);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("handles request with undefined url", () => {
+			const middleware = createAuthMiddleware({ version: TEST_VERSION });
+			const req = { url: undefined, headers: {} } as unknown as IncomingMessage;
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(true);
+		});
+
+		it("treats empty authToken string as no auth configured", () => {
+			const middleware = createAuthMiddleware({ authToken: "", version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/trpc/x", headers: {} });
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(true);
+		});
+
+		it("handleHttpRequest returns false for /api/health (response already sent)", () => {
+			const middleware = createAuthMiddleware({ authToken: TEST_TOKEN, version: TEST_VERSION });
+			const req = createMockRequest({ url: "/api/health" });
+			const mock = createMockResponse();
+			expect(middleware.handleHttpRequest(req, mock.response)).toBe(false);
+			expect(mock.getStatus()).toBe(200);
+		});
+	});
+});

--- a/test/runtime/core/resolve-runtime-connection.test.ts
+++ b/test/runtime/core/resolve-runtime-connection.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the descriptor module before importing the module under test.
+const mockReadRuntimeDescriptor = vi.fn();
+const mockIsDescriptorStale = vi.fn();
+
+vi.mock("../../../src/core/runtime-descriptor", () => ({
+	readRuntimeDescriptor: mockReadRuntimeDescriptor,
+	isDescriptorStale: mockIsDescriptorStale,
+}));
+
+// Mock fetch globally.
+const mockFetch = vi.fn();
+
+describe("resolveRuntimeConnection", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		vi.resetModules();
+		mockReadRuntimeDescriptor.mockReset();
+		mockIsDescriptorStale.mockReset();
+		mockFetch.mockReset();
+
+		// Clean env
+		delete process.env.KANBAN_RUNTIME_HOST;
+		delete process.env.KANBAN_RUNTIME_PORT;
+		delete process.env.KANBAN_AUTH_TOKEN;
+		delete process.env.KANBAN_RUNTIME_HTTPS;
+		delete process.env.KANBAN_RUNTIME_TLS_CA;
+
+		// Install mock fetch
+		vi.stubGlobal("fetch", mockFetch);
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+		vi.unstubAllGlobals();
+	});
+
+	async function loadModule() {
+		return await import("../../../src/core/runtime-endpoint");
+	}
+
+	it("env override wins over everything", async () => {
+		process.env.KANBAN_RUNTIME_HOST = "10.0.0.5";
+		process.env.KANBAN_RUNTIME_PORT = "9999";
+		process.env.KANBAN_AUTH_TOKEN = "env-token";
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("env");
+		expect(result.origin).toBe("http://10.0.0.5:9999");
+		expect(result.authToken).toBe("env-token");
+
+		// Descriptor should NOT be consulted.
+		expect(mockReadRuntimeDescriptor).not.toHaveBeenCalled();
+		// Fetch should NOT be called (no health check for env).
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	it("healthy descriptor wins over reachable default port", async () => {
+		// Descriptor points to a non-default port.
+		mockReadRuntimeDescriptor.mockResolvedValue({
+			url: "http://127.0.0.1:52341",
+			authToken: "desc-token",
+			pid: 12345,
+			updatedAt: new Date().toISOString(),
+			source: "cli",
+		});
+		mockIsDescriptorStale.mockReturnValue(false);
+
+		// Both descriptor runtime and default port respond.
+		mockFetch.mockImplementation((_url: string) => {
+			return Promise.resolve({ status: 200 });
+		});
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("descriptor");
+		expect(result.origin).toBe("http://127.0.0.1:52341");
+		expect(result.authToken).toBe("desc-token");
+
+		// Should have health-checked the descriptor URL, NOT the default.
+		const fetchCalls = mockFetch.mock.calls.map((c) => c[0] as string);
+		expect(fetchCalls[0]).toContain("127.0.0.1:52341");
+	});
+
+	it("stale descriptor is ignored — falls through to default port", async () => {
+		mockReadRuntimeDescriptor.mockResolvedValue({
+			url: "http://127.0.0.1:52341",
+			authToken: "desc-token",
+			pid: 99999,
+			updatedAt: "2020-01-01T00:00:00.000Z",
+			source: "cli",
+		});
+		mockIsDescriptorStale.mockReturnValue(true);
+
+		// Default port responds.
+		mockFetch.mockResolvedValue({ status: 200 });
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("default");
+		expect(result.origin).toBe("http://127.0.0.1:3484");
+	});
+
+	it("no descriptor — default port is used when reachable", async () => {
+		mockReadRuntimeDescriptor.mockResolvedValue(null);
+
+		// Default port responds.
+		mockFetch.mockResolvedValue({ status: 200 });
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("default");
+		expect(result.origin).toBe("http://127.0.0.1:3484");
+	});
+
+	it("descriptor runtime unreachable — falls through to default port", async () => {
+		mockReadRuntimeDescriptor.mockResolvedValue({
+			url: "http://127.0.0.1:52341",
+			authToken: "desc-token",
+			pid: 12345,
+			updatedAt: new Date().toISOString(),
+			source: "cli",
+		});
+		mockIsDescriptorStale.mockReturnValue(false);
+
+		// Descriptor runtime unreachable, default port responds.
+		mockFetch.mockImplementation((url: string) => {
+			if (url.includes("52341")) {
+				return Promise.reject(new Error("ECONNREFUSED"));
+			}
+			return Promise.resolve({ status: 200 });
+		});
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("default");
+		expect(result.origin).toBe("http://127.0.0.1:3484");
+	});
+
+	it("nothing reachable — returns default origin for clear error", async () => {
+		mockReadRuntimeDescriptor.mockResolvedValue(null);
+		mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("default");
+		expect(result.origin).toBe("http://127.0.0.1:3484");
+		expect(result.authToken).toBeNull();
+	});
+
+	it("descriptor URL with workspace path — origin strips path", async () => {
+		// Desktop may write a URL like "http://127.0.0.1:62929/cline" that
+		// includes a workspace path.  The resolver must strip the path so
+		// TRPC calls don't get routed to /cline/api/trpc/…
+		mockReadRuntimeDescriptor.mockResolvedValue({
+			url: "http://127.0.0.1:62929/cline",
+			authToken: "desc-token",
+			pid: 12345,
+			updatedAt: new Date().toISOString(),
+			source: "desktop",
+		});
+		mockIsDescriptorStale.mockReturnValue(false);
+		mockFetch.mockResolvedValue({ status: 200 });
+
+		const { resolveRuntimeConnection } = await loadModule();
+		const result = await resolveRuntimeConnection();
+
+		expect(result.source).toBe("descriptor");
+		// Must be origin only — no /cline path.
+		expect(result.origin).toBe("http://127.0.0.1:62929");
+		expect(result.authToken).toBe("desc-token");
+	});
+});
+
+describe("descriptorOriginFromUrl", () => {
+	it("strips path from descriptor URL", async () => {
+		const { descriptorOriginFromUrl } = await import("../../../src/core/runtime-endpoint");
+		expect(descriptorOriginFromUrl("http://127.0.0.1:62929/cline")).toBe("http://127.0.0.1:62929");
+		expect(descriptorOriginFromUrl("http://127.0.0.1:3484")).toBe("http://127.0.0.1:3484");
+		expect(descriptorOriginFromUrl("https://10.0.0.5:9999/workspace/deep")).toBe("https://10.0.0.5:9999");
+	});
+});

--- a/test/runtime/core/runtime-takeover.test.ts
+++ b/test/runtime/core/runtime-takeover.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We mock the runtime-descriptor module so handleRuntimeDisconnect never
+// touches the real ~/.cline/kanban/ directory.
+const mockReadRuntimeDescriptor = vi.fn();
+const mockIsDescriptorStale = vi.fn();
+const mockGetRuntimeDescriptorDir = vi.fn();
+
+vi.mock("../../../src/core/runtime-descriptor", () => ({
+	readRuntimeDescriptor: (...args: unknown[]) => mockReadRuntimeDescriptor(...args),
+	isDescriptorStale: (...args: unknown[]) => mockIsDescriptorStale(...args),
+	getRuntimeDescriptorDir: () => mockGetRuntimeDescriptorDir(),
+}));
+
+// Dynamic import so the mock is in place before the module loads.
+const { handleRuntimeDisconnect } = await import("../../../src/core/runtime-takeover");
+
+describe("handleRuntimeDisconnect", () => {
+	let tempDir: string;
+	const failedUrl = "http://127.0.0.1:9999";
+	const failedAuthToken = "failed-token";
+
+	beforeEach(async () => {
+		vi.resetAllMocks();
+		tempDir = join(tmpdir(), `takeover-test-${randomUUID()}`);
+		await mkdir(tempDir, { recursive: true });
+		mockGetRuntimeDescriptorDir.mockReturnValue(tempDir);
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+	});
+
+	it("proceeds to start runtime when lock owner PID is dead", async () => {
+		// Simulate a lock left behind by a dead process.
+		const lockPath = join(tempDir, "runtime.takeover.lock");
+		// Use PID 999999999 which is almost certainly dead.
+		await writeFile(lockPath, JSON.stringify({ pid: 999999999, at: Date.now() }));
+
+		// Grace window: runtime stays unreachable (no mock server).
+		// Descriptor: nothing usable.
+		mockReadRuntimeDescriptor.mockResolvedValue(null);
+
+		const startRuntimeMock = vi.fn().mockResolvedValue({
+			url: "http://127.0.0.1:12345",
+			authToken: "new-token",
+		});
+
+		// After startRuntime(), simulate descriptor being written.
+		const newDescriptor = {
+			url: "http://127.0.0.1:12345",
+			authToken: "new-token",
+			pid: process.pid,
+			updatedAt: new Date().toISOString(),
+			source: "cli" as const,
+		};
+		// First calls during grace/re-read return null, last call returns the new descriptor.
+		mockReadRuntimeDescriptor
+			.mockResolvedValue(null) // grace + re-read
+			.mockResolvedValueOnce(null) // double-check under lock
+			.mockResolvedValueOnce(newDescriptor); // after startRuntime
+
+		const onAttachMock = vi.fn().mockResolvedValue(undefined);
+		const logs: string[] = [];
+
+		await handleRuntimeDisconnect(failedUrl, failedAuthToken, {
+			startRuntime: startRuntimeMock,
+			onAttach: onAttachMock,
+			warn: (msg: string) => logs.push(msg),
+		});
+
+		// startRuntime should have been called — the dead-PID lock didn't block us.
+		expect(startRuntimeMock).toHaveBeenCalled();
+
+		// Lock file should have been cleaned up (released after takeover).
+		const lockExists = await readFile(lockPath, "utf-8").then(
+			() => true,
+			() => false,
+		);
+		expect(lockExists).toBe(false);
+	});
+
+	it("warns when descriptor is missing after startRuntime", async () => {
+		// No existing lock, no descriptor.
+		mockReadRuntimeDescriptor.mockResolvedValue(null);
+
+		const startRuntimeMock = vi.fn().mockResolvedValue({
+			url: "http://127.0.0.1:12345",
+			authToken: "new-token",
+		});
+
+		const onAttachMock = vi.fn().mockResolvedValue(undefined);
+		const logs: string[] = [];
+
+		await handleRuntimeDisconnect(failedUrl, failedAuthToken, {
+			startRuntime: startRuntimeMock,
+			onAttach: onAttachMock,
+			warn: (msg: string) => logs.push(msg),
+		});
+
+		// startRuntime was called.
+		expect(startRuntimeMock).toHaveBeenCalled();
+
+		// onAttach should NOT have been called — descriptor was missing after start.
+		expect(onAttachMock).not.toHaveBeenCalled();
+
+		// Should have logged a warning about missing descriptor.
+		const warningLog = logs.find((l) => l.includes("WARNING") && l.includes("descriptor is missing"));
+		expect(warningLog).toBeDefined();
+	});
+
+	it("attaches when descriptor appears after startRuntime", async () => {
+		const newDescriptor = {
+			url: "http://127.0.0.1:12345",
+			authToken: "new-token",
+			pid: process.pid,
+			updatedAt: new Date().toISOString(),
+			source: "cli" as const,
+		};
+
+		// First few calls return null (grace, re-read, double-check), then return descriptor.
+		mockReadRuntimeDescriptor
+			.mockResolvedValueOnce(null) // re-read after grace
+			.mockResolvedValueOnce(null) // double-check under lock
+			.mockResolvedValueOnce(newDescriptor); // after startRuntime
+
+		const startRuntimeMock = vi.fn().mockResolvedValue({
+			url: "http://127.0.0.1:12345",
+			authToken: "new-token",
+		});
+
+		const onAttachMock = vi.fn().mockResolvedValue(undefined);
+		const logs: string[] = [];
+
+		await handleRuntimeDisconnect(failedUrl, failedAuthToken, {
+			startRuntime: startRuntimeMock,
+			onAttach: onAttachMock,
+			warn: (msg: string) => logs.push(msg),
+		});
+
+		// startRuntime was called and descriptor was found — should attach.
+		expect(startRuntimeMock).toHaveBeenCalled();
+		expect(onAttachMock).toHaveBeenCalledWith(newDescriptor);
+
+		// Should have logged success, not a warning.
+		const successLog = logs.find((l) => l.includes("Descriptor published"));
+		expect(successLog).toBeDefined();
+	});
+});

--- a/test/runtime/core/shell.test.ts
+++ b/test/runtime/core/shell.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveInteractiveShellCommand } from "../../../src/core/shell";
+
+const originalPlatform = process.platform;
+const originalShell = process.env.SHELL;
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value,
+		configurable: true,
+	});
+}
+
+describe("resolveInteractiveShellCommand", () => {
+	afterEach(() => {
+		setPlatform(originalPlatform);
+		if (originalShell === undefined) {
+			delete process.env.SHELL;
+		} else {
+			process.env.SHELL = originalShell;
+		}
+	});
+
+	it("uses SHELL env when set on unix", () => {
+		setPlatform("darwin");
+		process.env.SHELL = "/bin/fish";
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary).toBe("/bin/fish");
+		expect(result.args).toEqual(["-i"]);
+	});
+
+	it("falls back to /bin/zsh on macOS when SHELL is unset", () => {
+		setPlatform("darwin");
+		delete process.env.SHELL;
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary).toBe("/bin/zsh");
+		expect(result.args).toEqual(["-i"]);
+	});
+
+	it("falls back to /bin/bash on Linux when SHELL is unset", () => {
+		setPlatform("linux");
+		delete process.env.SHELL;
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary).toBe("/bin/bash");
+		expect(result.args).toEqual(["-i"]);
+	});
+
+	it("trims whitespace from SHELL env", () => {
+		setPlatform("darwin");
+		process.env.SHELL = "  /bin/zsh  ";
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary).toBe("/bin/zsh");
+	});
+
+	it("treats empty SHELL as unset on macOS", () => {
+		setPlatform("darwin");
+		process.env.SHELL = "   ";
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary).toBe("/bin/zsh");
+	});
+
+	it("returns an absolute path for the fallback shell", () => {
+		setPlatform("darwin");
+		delete process.env.SHELL;
+		const result = resolveInteractiveShellCommand();
+		expect(result.binary.startsWith("/")).toBe(true);
+	});
+});

--- a/test/runtime/csrf-validation.test.ts
+++ b/test/runtime/csrf-validation.test.ts
@@ -1,0 +1,418 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createAuthMiddleware } from "../../src/server/auth-middleware";
+
+function createMockRequest(overrides?: {
+	url?: string;
+	headers?: Record<string, string | string[] | undefined>;
+}): IncomingMessage {
+	return {
+		url: overrides?.url ?? "/",
+		headers: overrides?.headers ?? {},
+	} as IncomingMessage;
+}
+
+interface MockResponse {
+	response: ServerResponse;
+	getStatus: () => number | undefined;
+	getHeaders: () => Record<string, string | string[] | number | undefined>;
+	getBody: () => string;
+}
+
+function createMockResponse(): MockResponse {
+	let statusCode: number | undefined;
+	let responseHeaders: Record<string, string | string[] | number | undefined> = {};
+	let body = "";
+
+	const res = {
+		writeHead(status: number, ...rest: unknown[]): ServerResponse {
+			statusCode = status;
+			if (rest.length === 2) {
+				responseHeaders = rest[1] as Record<string, string | string[] | number | undefined>;
+			} else if (rest.length === 1 && typeof rest[0] === "object" && rest[0] !== null) {
+				responseHeaders = rest[0] as Record<string, string | string[] | number | undefined>;
+			}
+			return res as unknown as ServerResponse;
+		},
+		end(data?: string) {
+			if (data) {
+				body = data;
+			}
+		},
+	} as unknown as ServerResponse;
+
+	return {
+		response: res,
+		getStatus: () => statusCode,
+		getHeaders: () => responseHeaders,
+		getBody: () => body,
+	};
+}
+
+const TEST_TOKEN = "test-secret-token-abc123";
+const TEST_VERSION = "1.2.3";
+const ALLOWED_ORIGIN = "http://127.0.0.1:3484";
+const ALLOWED_ORIGINS = [ALLOWED_ORIGIN];
+
+describe("CSRF Origin validation", () => {
+	describe("HTTP requests — Origin present + mismatched → 403", () => {
+		it("rejects API request with mismatched Origin header", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(403);
+			expect(JSON.parse(mock.getBody())).toEqual({ error: "Forbidden" });
+		});
+
+		it("rejects API request with mismatched Origin even without auth token configured", () => {
+			const middleware = createAuthMiddleware({
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { origin: "http://evil.example.com" },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(403);
+		});
+
+		it("rejects Origin with different port", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://127.0.0.1:9999",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(403);
+		});
+
+		it("rejects Origin with different scheme (https vs http)", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ["http://127.0.0.1:3484"],
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "https://127.0.0.1:3484",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(403);
+		});
+	});
+
+	describe("HTTP requests — Origin absent → allow (non-browser clients)", () => {
+		it("allows API request without Origin header", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { authorization: `Bearer ${TEST_TOKEN}` },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows API request with empty Origin header", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("HTTP requests — Origin present + matched → allow", () => {
+		it("allows API request with matching Origin header", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: ALLOWED_ORIGIN,
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows API request matching any of multiple allowed origins", () => {
+			const multipleOrigins = ["http://127.0.0.1:3484", "http://localhost:3484"];
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: multipleOrigins,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://localhost:3484",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("WebSocket upgrade — CSRF Origin validation", () => {
+		it("rejects WS upgrade with mismatched Origin", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+
+		it("allows WS upgrade without Origin header (non-browser client)", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: { authorization: `Bearer ${TEST_TOKEN}` },
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+
+		it("allows WS upgrade with matching Origin", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: ALLOWED_ORIGIN,
+				},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+
+		it("rejects WS upgrade with mismatched Origin even without auth token", () => {
+			const middleware = createAuthMiddleware({
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: { origin: "http://evil.example.com" },
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(false);
+		});
+
+		it("allows WS upgrade without Origin and without auth token", () => {
+			const middleware = createAuthMiddleware({
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: {},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+	});
+
+	describe("static assets and health exempt from CSRF", () => {
+		it("allows static asset with mismatched Origin (no CSRF check on statics)", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/index.html",
+				headers: { origin: "http://evil.example.com" },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("/api/health responds normally regardless of Origin", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/health",
+				headers: { origin: "http://evil.example.com" },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(200);
+			expect(JSON.parse(mock.getBody())).toEqual({ ok: true, version: TEST_VERSION });
+		});
+	});
+
+	describe("no allowedOrigins configured → skip CSRF", () => {
+		it("allows API request with any Origin when allowedOrigins is undefined", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows API request with any Origin when allowedOrigins is empty", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: [],
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(true);
+		});
+
+		it("allows WS upgrade with any Origin when allowedOrigins is undefined", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+
+		it("allows WS upgrade with any Origin when allowedOrigins is empty", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: [],
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/runtime/ws",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			expect(middleware.handleWsUpgrade(req)).toBe(true);
+		});
+	});
+
+	describe("CSRF runs before token auth (defense-in-depth)", () => {
+		it("returns 403 for mismatched Origin even with valid Bearer token", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: {
+					authorization: `Bearer ${TEST_TOKEN}`,
+					origin: "http://evil.example.com",
+				},
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			expect(mock.getStatus()).toBe(403);
+			expect(JSON.parse(mock.getBody())).toEqual({ error: "Forbidden" });
+		});
+
+		it("returns 403 (not 401) for mismatched Origin with missing Bearer token", () => {
+			const middleware = createAuthMiddleware({
+				authToken: TEST_TOKEN,
+				allowedOrigins: ALLOWED_ORIGINS,
+				version: TEST_VERSION,
+			});
+			const req = createMockRequest({
+				url: "/api/trpc/some.procedure",
+				headers: { origin: "http://evil.example.com" },
+			});
+			const mock = createMockResponse();
+			const result = middleware.handleHttpRequest(req, mock.response);
+			expect(result).toBe(false);
+			// CSRF check fires first → 403, not 401
+			expect(mock.getStatus()).toBe(403);
+		});
+	});
+});

--- a/test/runtime/kanban-command.test.ts
+++ b/test/runtime/kanban-command.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { buildKanbanCommandParts, resolveKanbanCommandParts } from "../../src/core/kanban-command";
 
 describe("resolveKanbanCommandParts", () => {
+	afterEach(() => {
+		delete process.env.KANBAN_CLI_COMMAND;
+	});
+
 	it("resolves node plus script entrypoint", () => {
 		const parts = resolveKanbanCommandParts({
 			execPath: "/usr/local/bin/node",
@@ -35,9 +39,67 @@ describe("resolveKanbanCommandParts", () => {
 		});
 		expect(parts).toEqual(["/usr/local/bin/kanban"]);
 	});
+
+	// -----------------------------------------------------------------------
+	// KANBAN_CLI_COMMAND env var override (desktop / explicit context)
+	// -----------------------------------------------------------------------
+
+	it("uses KANBAN_CLI_COMMAND env var when set", () => {
+		process.env.KANBAN_CLI_COMMAND = "kanban";
+		const parts = resolveKanbanCommandParts({
+			// Simulate Electron helper path — should be completely ignored.
+			execPath: "/Applications/Kanban.app/Contents/Frameworks/Kanban Helper.app/Contents/MacOS/Kanban Helper",
+			argv: [
+				"/Applications/Kanban.app/Contents/Frameworks/Kanban Helper.app/Contents/MacOS/Kanban Helper",
+				"/Applications/Kanban.app/Contents/Resources/app.asar.unpacked/dist/runtime-child-entry.js",
+			],
+		});
+		expect(parts).toEqual(["kanban"]);
+	});
+
+	it("splits multi-word KANBAN_CLI_COMMAND into parts", () => {
+		process.env.KANBAN_CLI_COMMAND = "npx -y kanban";
+		const parts = resolveKanbanCommandParts({
+			execPath: "/usr/local/bin/node",
+			argv: ["/usr/local/bin/node"],
+		});
+		expect(parts).toEqual(["npx", "-y", "kanban"]);
+	});
+
+	it("trims whitespace from KANBAN_CLI_COMMAND", () => {
+		process.env.KANBAN_CLI_COMMAND = "  kanban  ";
+		const parts = resolveKanbanCommandParts({
+			execPath: "/usr/local/bin/node",
+			argv: ["/usr/local/bin/node"],
+		});
+		expect(parts).toEqual(["kanban"]);
+	});
+
+	it("ignores empty KANBAN_CLI_COMMAND and falls back to inference", () => {
+		process.env.KANBAN_CLI_COMMAND = "   ";
+		const parts = resolveKanbanCommandParts({
+			execPath: "/usr/local/bin/kanban",
+			argv: ["/usr/local/bin/kanban", "hooks", "ingest"],
+		});
+		// Empty string is falsy after trim → falls through to inference.
+		expect(parts).toEqual(["/usr/local/bin/kanban"]);
+	});
+
+	it("env var takes priority over any process context", () => {
+		process.env.KANBAN_CLI_COMMAND = "/custom/path/to/kanban";
+		const parts = resolveKanbanCommandParts({
+			execPath: "/usr/local/bin/node",
+			argv: ["/usr/local/bin/node", "/some/entrypoint.js"],
+		});
+		expect(parts).toEqual(["/custom/path/to/kanban"]);
+	});
 });
 
 describe("buildKanbanCommandParts", () => {
+	afterEach(() => {
+		delete process.env.KANBAN_CLI_COMMAND;
+	});
+
 	it("appends command arguments to resolved runtime invocation", () => {
 		expect(
 			buildKanbanCommandParts(["hooks", "ingest"], {
@@ -45,5 +107,15 @@ describe("buildKanbanCommandParts", () => {
 				argv: ["/usr/local/bin/node", "/tmp/.npx/321/node_modules/kanban/dist/cli.js"],
 			}),
 		).toEqual(["/usr/local/bin/node", "/tmp/.npx/321/node_modules/kanban/dist/cli.js", "hooks", "ingest"]);
+	});
+
+	it("appends args when KANBAN_CLI_COMMAND is set", () => {
+		process.env.KANBAN_CLI_COMMAND = "kanban";
+		expect(
+			buildKanbanCommandParts(["task", "create", "--prompt", "test"], {
+				execPath: "/Applications/Kanban.app/Contents/Frameworks/Kanban Helper.app/Contents/MacOS/Kanban Helper",
+				argv: ["/irrelevant"],
+			}),
+		).toEqual(["kanban", "task", "create", "--prompt", "test"]);
 	});
 });

--- a/test/runtime/package-root-exports.test.ts
+++ b/test/runtime/package-root-exports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import * as kanban from "../../src/index";
+
+describe("package root exports", () => {
+	it("exports workspace-state helpers used by desktop interrupted-task detection", () => {
+		expect(typeof kanban.listWorkspaceIndexEntries).toBe("function");
+		expect(typeof kanban.loadWorkspaceState).toBe("function");
+	});
+});

--- a/test/runtime/runtime-endpoint.test.ts
+++ b/test/runtime/runtime-endpoint.test.ts
@@ -54,7 +54,7 @@ describe("runtime-endpoint", () => {
 	});
 
 	it("throws for invalid ports", () => {
-		expect(() => parseRuntimePort("0")).toThrow(/Invalid KANBAN_RUNTIME_PORT value/);
+		expect(parseRuntimePort("0")).toBe(0);
 		expect(() => parseRuntimePort("70000")).toThrow(/Invalid KANBAN_RUNTIME_PORT value/);
 		expect(() => parseRuntimePort("abc")).toThrow(/Invalid KANBAN_RUNTIME_PORT value/);
 	});

--- a/test/runtime/runtime-start.test.ts
+++ b/test/runtime/runtime-start.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getKanbanRuntimeHost,
+	getKanbanRuntimePort,
+	setKanbanRuntimeHost,
+	setKanbanRuntimePort,
+} from "../../src/core/runtime-endpoint";
+import type { RuntimeCallbacks, RuntimeHandle, RuntimeOptions, RuntimeStartOptions } from "../../src/runtime-start";
+
+const originalHost = getKanbanRuntimeHost();
+const originalPort = getKanbanRuntimePort();
+const originalEnvHost = process.env.KANBAN_RUNTIME_HOST;
+const originalEnvPort = process.env.KANBAN_RUNTIME_PORT;
+
+afterEach(() => {
+	setKanbanRuntimeHost(originalHost);
+	setKanbanRuntimePort(originalPort);
+	if (originalEnvHost === undefined) {
+		delete process.env.KANBAN_RUNTIME_HOST;
+	} else {
+		process.env.KANBAN_RUNTIME_HOST = originalEnvHost;
+	}
+	if (originalEnvPort === undefined) {
+		delete process.env.KANBAN_RUNTIME_PORT;
+	} else {
+		process.env.KANBAN_RUNTIME_PORT = originalEnvPort;
+	}
+});
+
+describe("runtime-start types", () => {
+	it("exports RuntimeStartOptions interface with expected optional fields", () => {
+		const options: RuntimeStartOptions = {};
+		expect(options.host).toBeUndefined();
+		expect(options.port).toBeUndefined();
+		expect(options.authToken).toBeUndefined();
+		expect(options.cwd).toBeUndefined();
+		expect(options.openInBrowser).toBeUndefined();
+		expect(options.callbacks).toBeUndefined();
+	});
+
+	it("RuntimeStartOptions has callbacks as a nested object with pickDirectory and warn", () => {
+		const options: RuntimeStartOptions = {
+			callbacks: {
+				pickDirectory: async () => "/tmp/test",
+				warn: () => {},
+			},
+		};
+		expect(options.callbacks).toBeDefined();
+		expect(typeof options.callbacks?.pickDirectory).toBe("function");
+		expect(typeof options.callbacks?.warn).toBe("function");
+	});
+
+	it("RuntimeCallbacks interface has expected shape", () => {
+		const callbacks: RuntimeCallbacks = {};
+		expect(callbacks.pickDirectory).toBeUndefined();
+		expect(callbacks.warn).toBeUndefined();
+	});
+
+	it("RuntimeOptions is a deprecated alias for RuntimeStartOptions", () => {
+		const options: RuntimeOptions = {};
+		const startOptions: RuntimeStartOptions = options;
+		expect(startOptions).toBe(options);
+	});
+
+	it("exports RuntimeHandle interface shape", () => {
+		const handle: RuntimeHandle = {
+			url: "http://127.0.0.1:3484",
+			shutdown: async () => {},
+		};
+		expect(handle.url).toBe("http://127.0.0.1:3484");
+		expect(typeof handle.shutdown).toBe("function");
+	});
+
+	it("RuntimeHandle does not expose close — only url and shutdown", () => {
+		const handle: RuntimeHandle = {
+			url: "http://127.0.0.1:3484",
+			shutdown: async () => {},
+		};
+		expect(Object.keys(handle).sort()).toEqual(["shutdown", "url"]);
+	});
+
+	it("callbacks.pickDirectory is async", async () => {
+		const pickDirectory: NonNullable<RuntimeCallbacks["pickDirectory"]> = async () => "/tmp/test";
+		const result = await pickDirectory();
+		expect(result).toBe("/tmp/test");
+	});
+
+	it("callbacks.pickDirectory can return null", async () => {
+		const pickDirectory: NonNullable<RuntimeCallbacks["pickDirectory"]> = async () => null;
+		const result = await pickDirectory();
+		expect(result).toBeNull();
+	});
+
+	it("callbacks.warn receives a string message", () => {
+		const messages: string[] = [];
+		const warn: NonNullable<RuntimeCallbacks["warn"]> = (message) => {
+			messages.push(message);
+		};
+		warn("test warning");
+		expect(messages).toEqual(["test warning"]);
+	});
+
+	it("RuntimeStartOptions.cwd accepts an explicit working directory", () => {
+		const options: RuntimeStartOptions = { cwd: "/tmp/kanban-workspace" };
+		expect(options.cwd).toBe("/tmp/kanban-workspace");
+	});
+
+	it("startRuntime with no callbacks provided still compiles (callbacks is optional)", () => {
+		const options: RuntimeStartOptions = {
+			host: "127.0.0.1",
+			port: 3484,
+		};
+		expect(options.callbacks).toBeUndefined();
+	});
+
+	it("startRuntime is exported as a function", async () => {
+		const mod = await import("../../src/runtime-start");
+		expect(typeof mod.startRuntime).toBe("function");
+	});
+});
+
+describe("runScopedCommand", () => {
+	it("is exported from core/scoped-command", async () => {
+		const mod = await import("../../src/core/scoped-command");
+		expect(typeof mod.runScopedCommand).toBe("function");
+	});
+});

--- a/test/runtime/snapshot-fields.test.ts
+++ b/test/runtime/snapshot-fields.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+	type RuntimeStateStreamSnapshotMessage,
+	runtimeStateStreamSnapshotMessageSchema,
+} from "../../src/core/api-contract";
+import type { RuntimeStartOptions } from "../../src/runtime-start";
+import type { CreateRuntimeStateHubDependencies } from "../../src/server/runtime-state-hub";
+
+describe("snapshot fields — isLocal and runtimeVersion", () => {
+	describe("api-contract schema", () => {
+		it("snapshot schema requires isLocal boolean field", () => {
+			const validSnapshot: RuntimeStateStreamSnapshotMessage = {
+				type: "snapshot",
+				isLocal: true,
+				runtimeVersion: "0.1.57",
+				currentProjectId: null,
+				projects: [],
+				workspaceState: null,
+				workspaceMetadata: null,
+				clineSessionContextVersion: 0,
+			};
+			const result = runtimeStateStreamSnapshotMessageSchema.safeParse(validSnapshot);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.isLocal).toBe(true);
+			}
+		});
+
+		it("snapshot schema requires runtimeVersion string field", () => {
+			const validSnapshot: RuntimeStateStreamSnapshotMessage = {
+				type: "snapshot",
+				isLocal: false,
+				runtimeVersion: "1.2.3",
+				currentProjectId: null,
+				projects: [],
+				workspaceState: null,
+				workspaceMetadata: null,
+				clineSessionContextVersion: 0,
+			};
+			const result = runtimeStateStreamSnapshotMessageSchema.safeParse(validSnapshot);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.runtimeVersion).toBe("1.2.3");
+			}
+		});
+
+		it("snapshot schema rejects payload missing isLocal", () => {
+			const invalidSnapshot = {
+				type: "snapshot",
+				runtimeVersion: "0.1.0",
+				currentProjectId: null,
+				projects: [],
+				workspaceState: null,
+				workspaceMetadata: null,
+				clineSessionContextVersion: 0,
+			};
+			const result = runtimeStateStreamSnapshotMessageSchema.safeParse(invalidSnapshot);
+			expect(result.success).toBe(false);
+		});
+
+		it("snapshot schema rejects payload missing runtimeVersion", () => {
+			const invalidSnapshot = {
+				type: "snapshot",
+				isLocal: true,
+				currentProjectId: null,
+				projects: [],
+				workspaceState: null,
+				workspaceMetadata: null,
+				clineSessionContextVersion: 0,
+			};
+			const result = runtimeStateStreamSnapshotMessageSchema.safeParse(invalidSnapshot);
+			expect(result.success).toBe(false);
+		});
+
+		it("isLocal: false is accepted by snapshot schema", () => {
+			const snapshot: RuntimeStateStreamSnapshotMessage = {
+				type: "snapshot",
+				isLocal: false,
+				runtimeVersion: "0.1.57",
+				currentProjectId: null,
+				projects: [],
+				workspaceState: null,
+				workspaceMetadata: null,
+				clineSessionContextVersion: 0,
+			};
+			const result = runtimeStateStreamSnapshotMessageSchema.safeParse(snapshot);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.isLocal).toBe(false);
+			}
+		});
+	});
+
+	describe("CreateRuntimeStateHubDependencies", () => {
+		it("requires isLocal and runtimeVersion fields", () => {
+			const deps: Pick<CreateRuntimeStateHubDependencies, "isLocal" | "runtimeVersion"> = {
+				isLocal: true,
+				runtimeVersion: "0.1.57",
+			};
+			expect(deps.isLocal).toBe(true);
+			expect(deps.runtimeVersion).toBe("0.1.57");
+		});
+
+		it("accepts isLocal: false", () => {
+			const deps: Pick<CreateRuntimeStateHubDependencies, "isLocal" | "runtimeVersion"> = {
+				isLocal: false,
+				runtimeVersion: "1.0.0",
+			};
+			expect(deps.isLocal).toBe(false);
+		});
+	});
+
+	describe("RuntimeStartOptions", () => {
+		it("isLocal defaults to undefined when not set", () => {
+			const options: RuntimeStartOptions = {};
+			expect(options.isLocal).toBeUndefined();
+		});
+
+		it("accepts isLocal: true", () => {
+			const options: RuntimeStartOptions = { isLocal: true };
+			expect(options.isLocal).toBe(true);
+		});
+
+		it("accepts isLocal: false", () => {
+			const options: RuntimeStartOptions = { isLocal: false };
+			expect(options.isLocal).toBe(false);
+		});
+	});
+
+	describe("runtimeVersion reading", () => {
+		it("package.json version is a non-empty string", async () => {
+			const { readFileSync } = await import("node:fs");
+			const { join } = await import("node:path");
+			const packageJsonPath = join(__dirname, "..", "..", "package.json");
+			const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version: string };
+			expect(typeof packageJson.version).toBe("string");
+			expect(packageJson.version.length).toBeGreaterThan(0);
+			expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+/);
+		});
+	});
+
+	describe("startRuntime exports", () => {
+		it("startRuntime function is exported", async () => {
+			const mod = await import("../../src/runtime-start");
+			expect(typeof mod.startRuntime).toBe("function");
+		});
+
+		it("RuntimeStartOptions type supports isLocal field", () => {
+			// Type-level check: if this compiles, the field exists on RuntimeStartOptions
+			const opts: RuntimeStartOptions = { isLocal: false, callbacks: { warn: () => {} } };
+			expect(opts.isLocal).toBe(false);
+		});
+	});
+});

--- a/test/runtime/terminal/pty-session.test.ts
+++ b/test/runtime/terminal/pty-session.test.ts
@@ -321,4 +321,45 @@ describe("PtySession", () => {
 
 		expect(() => session.write("hello")).toThrow("permission denied");
 	});
+
+	it("falls back to HOME when cwd does not exist", () => {
+		setPlatform("darwin");
+		const ptyProcess = createMockPtyProcess();
+		ptyMocks.spawn.mockReturnValue(ptyProcess);
+
+		PtySession.spawn({
+			binary: "/bin/zsh",
+			args: ["-i"],
+			cwd: "/nonexistent/deleted-worktree-path",
+			env: { HOME: "/tmp" },
+			cols: 120,
+			rows: 40,
+		});
+
+		expect(ptyMocks.spawn).toHaveBeenCalledTimes(1);
+		const ptyOptions = ptyMocks.spawn.mock.calls[0]?.[2];
+		// The cwd should NOT be the nonexistent path
+		expect(ptyOptions?.cwd).not.toBe("/nonexistent/deleted-worktree-path");
+		// It should fall back to a directory that exists
+		expect(typeof ptyOptions?.cwd).toBe("string");
+		expect(ptyOptions?.cwd.length).toBeGreaterThan(0);
+	});
+
+	it("uses original cwd when it exists", () => {
+		setPlatform("darwin");
+		const ptyProcess = createMockPtyProcess();
+		ptyMocks.spawn.mockReturnValue(ptyProcess);
+
+		PtySession.spawn({
+			binary: "/bin/zsh",
+			args: ["-i"],
+			cwd: "/tmp",
+			cols: 120,
+			rows: 40,
+		});
+
+		expect(ptyMocks.spawn).toHaveBeenCalledTimes(1);
+		const ptyOptions = ptyMocks.spawn.mock.calls[0]?.[2];
+		expect(ptyOptions?.cwd).toBe("/tmp");
+	});
 });

--- a/test/runtime/workspace-state-watcher.test.ts
+++ b/test/runtime/workspace-state-watcher.test.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWorkspaceStateWatcher } from "../../src/server/workspace-state-watcher";
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Poll interval in the watcher is 2 000 ms. We wait slightly longer
+// to ensure at least one poll cycle has fired.
+const POLL_WAIT_MS = 2_500;
+
+function createMetaJson(revision: number): string {
+	return JSON.stringify({ revision, updatedAt: Date.now() });
+}
+
+describe("WorkspaceStateWatcher", () => {
+	let tempDir: string;
+	let metaPath: string;
+	const workspaceId = "test-workspace";
+	const workspacePath = "/fake/repo";
+
+	beforeEach(async () => {
+		tempDir = join(tmpdir(), `watcher-test-${randomUUID()}`);
+		await mkdir(tempDir, { recursive: true });
+		metaPath = join(tempDir, "meta.json");
+		await writeFile(metaPath, createMetaJson(1));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("broadcasts when meta.json is modified externally", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, tempDir);
+
+			// Simulate external write
+			await writeFile(metaPath, createMetaJson(2));
+
+			await delay(POLL_WAIT_MS);
+
+			expect(broadcastMock).toHaveBeenCalledWith(workspaceId, workspacePath);
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("broadcasts when meta.json is created after watcher starts", async () => {
+		// Start with a directory that has NO meta.json yet
+		const emptyDir = join(tmpdir(), `watcher-create-test-${randomUUID()}`);
+		await mkdir(emptyDir, { recursive: true });
+
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, emptyDir);
+
+			// Another runtime creates meta.json
+			await writeFile(join(emptyDir, "meta.json"), createMetaJson(1));
+
+			await delay(POLL_WAIT_MS);
+
+			expect(broadcastMock).toHaveBeenCalledWith(workspaceId, workspacePath);
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("creates the state directory if it does not exist", () => {
+		const nonExistentDir = join(tmpdir(), `watcher-mkdir-test-${randomUUID()}`, "nested");
+		const broadcastMock = vi.fn();
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			// Should not throw — watcher creates the directory
+			watcher.watch(workspaceId, workspacePath, nonExistentDir);
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("suppresses broadcast after markSelfWrite", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, tempDir);
+
+			// Mark self-write, then modify file
+			watcher.markSelfWrite(workspaceId);
+			await writeFile(metaPath, createMetaJson(2));
+
+			await delay(POLL_WAIT_MS);
+
+			expect(broadcastMock).not.toHaveBeenCalled();
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("ignores duplicate watch calls for same workspaceId", () => {
+		const broadcastMock = vi.fn();
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, tempDir);
+			// Should not throw or create a second watcher
+			watcher.watch(workspaceId, workspacePath, tempDir);
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("unwatch stops broadcasting for that workspace", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, tempDir);
+			watcher.unwatch(workspaceId);
+
+			await writeFile(metaPath, createMetaJson(2));
+			await delay(POLL_WAIT_MS);
+
+			expect(broadcastMock).not.toHaveBeenCalled();
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("detects atomic writes (write-to-temp then rename)", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		try {
+			watcher.watch(workspaceId, workspacePath, tempDir);
+
+			// Simulate atomic write like lockedFileSystem.writeJsonFileAtomic:
+			// 1. Write to temp file  2. Rename to meta.json
+			const tempFile = join(tempDir, `meta.json.tmp.${process.pid}.${Date.now()}.${randomUUID()}`);
+			await writeFile(tempFile, createMetaJson(2));
+			await rename(tempFile, metaPath);
+
+			await delay(POLL_WAIT_MS);
+
+			expect(broadcastMock).toHaveBeenCalledWith(workspaceId, workspacePath);
+		} finally {
+			watcher.close();
+		}
+	});
+
+	it("close stops all watchers", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue(undefined);
+		const watcher = createWorkspaceStateWatcher({
+			broadcastRuntimeWorkspaceStateUpdated: broadcastMock,
+		});
+
+		watcher.watch(workspaceId, workspacePath, tempDir);
+		watcher.close();
+
+		await writeFile(metaPath, createMetaJson(2));
+		await delay(POLL_WAIT_MS);
+
+		expect(broadcastMock).not.toHaveBeenCalled();
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,15 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
-		exclude: ["apps/**", "web-ui/**", "third_party/**", "**/node_modules/**", "**/dist/**", ".worktrees/**"],
+		exclude: [
+			"apps/**",
+			"packages/**",
+			"web-ui/**",
+			"third_party/**",
+			"**/node_modules/**",
+			"**/dist/**",
+			".worktrees/**",
+		],
 		testTimeout: 15_000,
 	},
 });


### PR DESCRIPTION
## Summary

Extracts shared runtime boundaries so the Kanban runtime can be started and discovered by both the CLI and the desktop Electron shell.

**Part 1 of 3** in the desktop app PR stack.

## Changes

### New modules
- **`runtime-start.ts`** — standalone entry point (`startRuntime()`) for embedding the Kanban runtime in any host process (Electron, tests, etc.)
- **`runtime-descriptor.ts`** — per-user file (`~/.cline/kanban/runtime.json`) for cross-process runtime discovery. CLI writes on startup, clears on shutdown.
- **`runtime-endpoint.ts`** — `resolveRuntimeConnection()` with descriptor-first, port-fallback policy
- **`runtime-takeover.ts`** — failover coordination when the runtime authority dies (grace window → re-read → advisory lock → start)
- **`workspace-state-watcher.ts`** — mtime-based polling on `meta.json` for cross-runtime board sync
- **`kanban-command.ts`** — `KANBAN_CLI_COMMAND` env override for Electron context (CLI shim path)
- **`scoped-command.ts`** / **`shell.ts`** — extracted desktop-safe command helpers

### Modified
- **`auth-middleware.ts`** — cookie-based auth support (`kanban-auth` session cookie)
- **`runtime-server.ts`** — integrates workspace state watcher
- **`cli.ts`** — writes/clears runtime descriptor on startup/shutdown
- **`package.json`** — adds exports for `./runtime-start`, `./server/directory-picker`, `./core/runtime-descriptor`

### Architecture note
The desktop app (Part 3) uses `runtime-start.ts` directly but does **not** use the descriptor/takeover/endpoint-resolution modules. Those exist solely for CLI-side discovery. The desktop follows a simpler model: health-check port 3484 → attach if healthy → start child if not → show disconnected screen if it dies.

## PR stack

| PR | Scope | Status |
|---|---|---|
| **#305 (this)** | Shared runtime infrastructure (`src/`) | 🟡 Open |
| #329 | Web UI desktop compatibility (`web-ui/`) | 🟡 Open |
| #330 | Electron desktop app (`packages/desktop/`) | 🟡 Open |

The old 8-branch stack (`desktop/pr1` through `desktop/pr8`) has been collapsed to 3 PRs after the [lean shell-model simplification](https://github.com/cline/kanban/compare/main...feature/desktop-app). The connection manager, connection store, connection menu, boot state machine, descriptor watcher, failure dialog, and orphan cleanup were all deleted.

## Testing
- All existing core tests pass
- New tests: runtime-descriptor, runtime-takeover, workspace-state-watcher, runtime-endpoint resolution, auth-middleware CSRF, package exports