### PR TITLE
Fix: Preserve Task Detail View on Page Refresh

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -231,6 +231,7 @@ export default function App(): ReactElement {
 		isAwaitingWorkspaceSnapshot,
 		isInitialRuntimeLoad,
 		isProjectSwitching,
+		isWorkspaceMetadataPending,
 		onDetailClosed: () => {
 			setIsGitHistoryOpen(false);
 		},

--- a/web-ui/src/hooks/use-detail-task-navigation.test.tsx
+++ b/web-ui/src/hooks/use-detail-task-navigation.test.tsx
@@ -56,6 +56,7 @@ function HookHarness({
 		isAwaitingWorkspaceSnapshot: false,
 		isInitialRuntimeLoad: false,
 		isProjectSwitching: false,
+		isWorkspaceMetadataPending: false,
 		onDetailClosed,
 	});
 

--- a/web-ui/src/hooks/use-detail-task-navigation.ts
+++ b/web-ui/src/hooks/use-detail-task-navigation.ts
@@ -12,6 +12,7 @@ interface UseDetailTaskNavigationInput {
 	isAwaitingWorkspaceSnapshot: boolean;
 	isInitialRuntimeLoad: boolean;
 	isProjectSwitching: boolean;
+	isWorkspaceMetadataPending: boolean;
 	onDetailClosed?: () => void;
 }
 
@@ -28,6 +29,7 @@ export function useDetailTaskNavigation({
 	isAwaitingWorkspaceSnapshot,
 	isInitialRuntimeLoad,
 	isProjectSwitching,
+	isWorkspaceMetadataPending,
 	onDetailClosed,
 }: UseDetailTaskNavigationInput): UseDetailTaskNavigationResult {
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(() => {
@@ -67,7 +69,10 @@ export function useDetailTaskNavigation({
 	}, [closeDetail, currentProjectId]);
 
 	useEffect(() => {
-		if (selectedTaskId && (isInitialRuntimeLoad || isProjectSwitching || isAwaitingWorkspaceSnapshot)) {
+		if (
+			selectedTaskId &&
+			(isInitialRuntimeLoad || isProjectSwitching || isAwaitingWorkspaceSnapshot || isWorkspaceMetadataPending)
+		) {
 			return;
 		}
 		if (selectedTaskId && !selectedCard) {
@@ -78,6 +83,7 @@ export function useDetailTaskNavigation({
 		isAwaitingWorkspaceSnapshot,
 		isInitialRuntimeLoad,
 		isProjectSwitching,
+		isWorkspaceMetadataPending,
 		selectedCard,
 		selectedTaskId,
 	]);


### PR DESCRIPTION
On refresh, the task detail view was closing immediately because isAwaitingWorkspaceSnapshot flipped to false one render cycle before the board was hydrated. The guard effect saw an empty board with no matching card and called closeDetail().

Add isWorkspaceMetadataPending to the guard in useDetailTaskNavigation. This flag stays true until applyWorkspaceState sets both the board and appliedWorkspaceProjectId in the same callback, ensuring the board is hydrated before the guard allows detail-close logic to run.