### PR TITLE
Feat: polish cline agent chat panel UX

### DIFF
--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
@@ -429,7 +429,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 			<div className="flex min-h-0 min-w-0 flex-1 flex-col">
 				<div
 					ref={scrollContainerRef}
-					className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto px-2 py-3"
+					className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-x-hidden overflow-y-auto px-2 py-3"
 					onScroll={handleMessageListScroll}
 				>
 					{messages.map((message) => (

--- a/web-ui/src/components/detail-panels/cline-chat-message-item.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-message-item.tsx
@@ -28,24 +28,24 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 	const hasExpandableContent = Boolean(parsed.output || parsed.error || fullInput);
 
 	return (
-		<div className="w-full">
+		<div className="kb-chat-message-appear w-full rounded-lg border-l-2 border-status-blue/40 bg-status-blue/[0.03] py-1 pr-1 pl-0.5">
 			<button
 				type="button"
 				onClick={hasExpandableContent ? () => setExpanded((e) => !e) : undefined}
 				className={cn(
-					"group flex w-full items-center gap-1.5 rounded px-1.5 py-0 text-left text-sm",
-					hasExpandableContent && "cursor-pointer",
+					"group flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-left text-sm",
+					hasExpandableContent && "cursor-pointer hover:bg-surface-3/40",
 				)}
 			>
 				{isRunning ? (
-					<Spinner size={14} className="shrink-0" />
+					<Spinner size={14} className="shrink-0 text-status-blue" />
 				) : hasError ? (
 					<XCircle size={14} className="shrink-0 text-status-red" />
 				) : null}
 				<span
 					className={cn(
-						"shrink-0 font-semibold group-hover:text-[#C9D1D9]",
-						expanded ? "text-[#C9D1D9]" : "text-text-secondary",
+						"shrink-0 font-semibold group-hover:text-status-blue",
+						expanded ? "text-status-blue" : "text-text-secondary",
 					)}
 				>
 					{toolDisplay.toolName}
@@ -63,7 +63,7 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 				{hasExpandableContent ? (
 					<span
 						className={cn(
-							"shrink-0 group-hover:text-text-secondary",
+							"ml-auto shrink-0 group-hover:text-text-secondary",
 							expanded ? "text-text-secondary" : "text-text-tertiary",
 						)}
 					>
@@ -73,12 +73,12 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 			</button>
 
 			{expanded ? (
-				<div className="mt-1 space-y-1.5 pr-1.5 pl-[24px] pb-1">
+				<div className="mt-1.5 space-y-2 pr-2 pl-[26px] pb-1.5">
 					{/* Full tool input (e.g. complete run_commands commands) */}
 					{fullInput ? (
 						<div>
-							<div className="mb-0.5 text-xs text-text-tertiary">Command</div>
-							<pre className="max-h-60 overflow-auto rounded bg-surface-0 px-2 py-1.5 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
+							<div className="mb-0.5 text-xs font-medium text-text-tertiary">Command</div>
+							<pre className="max-h-60 overflow-auto rounded-md border border-border bg-surface-0 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
 								{fullInput}
 							</pre>
 						</div>
@@ -89,15 +89,15 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 						toolOutput.results.map((result, i) => (
 							<div key={i}>
 								{toolOutput.results.length > 1 ? (
-									<div className="mb-0.5 truncate text-xs text-text-tertiary">{result.query}</div>
+									<div className="mb-0.5 truncate text-xs font-medium text-text-tertiary">{result.query}</div>
 								) : null}
 								{result.error ? (
-									<pre className="max-h-60 overflow-auto rounded bg-status-red/5 px-2 py-1.5 text-xs leading-relaxed whitespace-pre-wrap break-all text-status-red">
+									<pre className="max-h-60 overflow-auto rounded-md border border-status-red/20 bg-status-red/5 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-all text-status-red">
 										{result.error}
 									</pre>
 								) : null}
 								{result.content ? (
-									<pre className="max-h-60 overflow-auto rounded bg-surface-0 px-2 py-1.5 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
+									<pre className="max-h-60 overflow-auto rounded-md border border-border bg-surface-0 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
 										{result.content}
 									</pre>
 								) : null}
@@ -106,8 +106,8 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 					) : parsed.output ? (
 						/* Fallback for non-ToolOperationResult output (skills, ask_question, MCP tools) */
 						<div>
-							<div className="mb-0.5 text-xs text-text-tertiary">Output</div>
-							<pre className="max-h-60 overflow-auto rounded bg-surface-0 px-2 py-1.5 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
+							<div className="mb-0.5 text-xs font-medium text-text-tertiary">Output</div>
+							<pre className="max-h-60 overflow-auto rounded-md border border-border bg-surface-0 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-all text-text-primary">
 								{parsed.output}
 							</pre>
 						</div>
@@ -116,8 +116,8 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 					{/* Tool-level error (SDK crash/timeout, separate from per-result errors) */}
 					{parsed.error ? (
 						<div>
-							<div className="mb-0.5 text-xs text-status-red">Error</div>
-							<pre className="max-h-60 overflow-auto rounded bg-status-red/5 px-2 py-1.5 text-xs leading-relaxed whitespace-pre-wrap break-all text-status-red">
+							<div className="mb-0.5 text-xs font-medium text-status-red">Error</div>
+							<pre className="max-h-60 overflow-auto rounded-md border border-status-red/20 bg-status-red/5 px-2.5 py-2 text-xs leading-relaxed whitespace-pre-wrap break-all text-status-red">
 								{parsed.error}
 							</pre>
 						</div>
@@ -130,12 +130,14 @@ function ToolMessageBlock({ message }: { message: ClineChatMessage }): ReactElem
 
 function ReasoningMessageBlock({ message }: { message: ClineChatMessage }): ReactElement {
 	return (
-		<div className="w-full">
-			<div className="mb-1 flex items-center gap-1.5 text-xs uppercase tracking-wide text-status-purple">
+		<div className="kb-chat-message-appear w-full rounded-lg border-l-2 border-status-purple/40 bg-status-purple/[0.03] px-3 py-2">
+			<div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-status-purple">
 				<Brain size={12} />
 				<span>Reasoning</span>
 			</div>
-			<div className="w-full text-sm whitespace-pre-wrap break-words text-text-secondary">{message.content}</div>
+			<div className="max-h-40 overflow-y-auto text-sm whitespace-pre-wrap break-words text-text-secondary">
+				{message.content}
+			</div>
 		</div>
 	);
 }
@@ -151,7 +153,7 @@ export function ClineChatMessageItem({ message }: { message: ClineChatMessage })
 		const hasText = message.content.trim().length > 0;
 		const hasImages = Boolean(message.images && message.images.length > 0);
 		return (
-			<div className="ml-auto max-w-[85%] rounded-md bg-accent/20 px-3 py-2 text-sm text-text-primary">
+			<div className="kb-chat-message-appear ml-auto max-w-[85%] rounded-xl bg-accent/15 px-3 py-2 text-sm text-text-primary">
 				{hasText ? (
 					<div className="whitespace-pre-wrap break-words">{normalizeUserInput(message.content)}</div>
 				) : null}
@@ -164,14 +166,14 @@ export function ClineChatMessageItem({ message }: { message: ClineChatMessage })
 	if (message.role === "assistant") {
 		const normalizedAssistantContent = message.content.replace(/^\n+/, "");
 		return (
-			<div className="min-w-0 w-full px-1.5 text-sm text-text-primary">
+			<div className="kb-chat-message-appear min-w-0 w-full px-1.5 text-sm text-text-primary">
 				<ClineMarkdownContent content={normalizedAssistantContent} />
 			</div>
 		);
 	}
 	const label = message.role === "status" ? "Status" : "System";
 	return (
-		<div className="max-w-[85%] rounded-md border border-border bg-surface-3/70 px-3 py-2 text-sm whitespace-pre-wrap break-all text-text-secondary">
+		<div className="kb-chat-message-appear max-w-[85%] rounded-lg border border-border bg-surface-3/70 px-3 py-2 text-sm whitespace-pre-wrap break-all text-text-secondary">
 			<div className="mb-1 text-xs uppercase tracking-wide text-text-tertiary">{label}</div>
 			{message.content}
 		</div>

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -960,6 +960,21 @@ body.kb-dependency-link-mode {
 	border-radius: var(--radius-sm);
 }
 
+@keyframes kb-chat-message-appear {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.kb-chat-message-appear {
+	animation: kb-chat-message-appear 300ms ease-out both;
+}
+
 /* -- Chat markdown -- */
 
 .kb-markdown > * {


### PR DESCRIPTION
- Add subtle fade+slide-up entrance animation for all chat messages
- Confine reasoning blocks to a max-height scroll container (160px) with a purple left-border accent card treatment
- Give tool call blocks a bespoke blue-accented card with hover feedback, rounded edges, and bordered pre blocks in expanded view
- Refine user message bubbles (rounded-xl, softer accent tint)
- Increase message gap spacing from gap-2 to gap-3
- Add font-medium to section labels for better visual hierarchy