### PR TITLE
Show Pencil Icon on Hover to Edit Task Title

### DIFF
--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -613,13 +613,10 @@ export function BoardCard({
 													setDraftTitle(card.title);
 													setIsEditingTitle(true);
 												}}
-												className={cn(
-													"shrink-0 cursor-pointer rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-													isHovered ? "opacity-100" : "opacity-0",
-												)}
-											>
-												<Pencil size={12} />
-											</button>
+											className={cn(
+												"shrink-0 cursor-pointer rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+												isHovered ? "opacity-100" : "opacity-0",
+											)}
 										</div>
 									) : (
 										<p

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -613,10 +613,13 @@ export function BoardCard({
 													setDraftTitle(card.title);
 													setIsEditingTitle(true);
 												}}
-											className={cn(
-												"shrink-0 cursor-pointer rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-												isHovered ? "opacity-100" : "opacity-0",
-											)}
+												className={cn(
+													"shrink-0 cursor-pointer rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+													isHovered ? "opacity-100" : "opacity-0",
+												)}
+											>
+												<Pencil size={12} />
+											</button>
 										</div>
 									) : (
 										<p

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -614,7 +614,7 @@ export function BoardCard({
 													setIsEditingTitle(true);
 												}}
 												className={cn(
-													"shrink-0 rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+													"shrink-0 cursor-pointer rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
 													isHovered ? "opacity-100" : "opacity-0",
 												)}
 											>

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -614,7 +614,7 @@ export function BoardCard({
 													setIsEditingTitle(true);
 												}}
 												className={cn(
-													"shrink-0 rounded-sm p-0.5 text-text-tertiary transition-opacity hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+													"shrink-0 rounded-sm p-0.5 text-text-tertiary hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
 													isHovered ? "opacity-100" : "opacity-0",
 												)}
 											>

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -2,7 +2,7 @@ import { Draggable } from "@hello-pangea/dnd";
 import { getRuntimeAgentCatalogEntry } from "@runtime-agent-catalog";
 import { formatClineToolCallLabel } from "@runtime-cline-tool-call-display";
 import { buildTaskWorktreeDisplayPath } from "@runtime-task-worktree-path";
-import { AlertCircle, AlertTriangle, Bot, GitBranch, Play, RotateCcw, Trash2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, Bot, GitBranch, Pencil, Play, RotateCcw, Trash2 } from "lucide-react";
 import type { KeyboardEvent, MouseEvent } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -595,22 +595,32 @@ export function BoardCard({
 											className="h-7 w-full rounded-md border border-border-focus bg-surface-2 px-2 text-sm font-medium text-text-primary focus:outline-none"
 										/>
 									) : onSaveTitle ? (
-										<button
-											type="button"
-											aria-label="Edit task title"
-											onMouseDown={stopEvent}
-											onClick={(event) => {
-												stopEvent(event);
-												setDraftTitle(card.title);
-												setIsEditingTitle(true);
-											}}
-											className={cn(
-												"kb-line-clamp-1 m-0 w-full cursor-text rounded-sm text-left font-medium text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
-												isTrashCard && "line-through text-text-tertiary",
-											)}
-										>
-											{displayTitle}
-										</button>
+										<div className="flex items-center gap-1 min-w-0">
+											<p
+												className={cn(
+													"kb-line-clamp-1 m-0 min-w-0 font-medium text-sm",
+													isTrashCard && "line-through text-text-tertiary",
+												)}
+											>
+												{displayTitle}
+											</p>
+											<button
+												type="button"
+												aria-label="Edit task title"
+												onMouseDown={stopEvent}
+												onClick={(event) => {
+													stopEvent(event);
+													setDraftTitle(card.title);
+													setIsEditingTitle(true);
+												}}
+												className={cn(
+													"shrink-0 rounded-sm p-0.5 text-text-tertiary transition-opacity hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+													isHovered ? "opacity-100" : "opacity-0",
+												)}
+											>
+												<Pencil size={12} />
+											</button>
+										</div>
 									) : (
 										<p
 											className={cn(


### PR DESCRIPTION
Previously, clicking anywhere on the task title text opened the editable input field, which was easy to trigger accidentally when intending to click the card itself.

Now the title displays as plain text (truncated with ellipsis) and a small pencil icon appears inline on card hover. Only clicking the pencil icon opens the title editor.

**Hover**
<img width="1908" height="975" alt="Screenshot 2026-04-13 at 3 52 13 PM" src="https://github.com/user-attachments/assets/d369f34e-6782-4fc4-9920-5e9fb6a405e4" />

**Active**
<img width="1908" height="975" alt="Screenshot 2026-04-13 at 3 53 07 PM" src="https://github.com/user-attachments/assets/88f4320a-1401-4ab3-8b64-34a3997744ff" />


