### PR TITLE
Add File Tree Toggle For Diff Views

### DIFF
--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -72,6 +72,11 @@ vi.mock("@/stores/workspace-metadata-store", () => ({
 	useTaskWorkspaceStateVersionValue: () => 0,
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children: ReactNode }) => children,
+	TooltipProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
 vi.mock("@/resize/layout-customizations", () => ({
 	useLayoutResetEffect: () => {},
 }));

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -1,5 +1,14 @@
 import type { DropResult } from "@hello-pangea/dnd";
-import { Files, GitCompareArrows, Maximize2, MessageSquare, Minimize2, X } from "lucide-react";
+import {
+	Files,
+	GitCompareArrows,
+	Maximize2,
+	MessageSquare,
+	Minimize2,
+	PanelRightClose,
+	PanelRightOpen,
+	X,
+} from "lucide-react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -10,6 +19,7 @@ import { type DiffLineComment, DiffViewerPanel } from "@/components/detail-panel
 import { FileTreePanel } from "@/components/detail-panels/file-tree-panel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/components/ui/cn";
+import { Tooltip } from "@/components/ui/tooltip";
 import type { ClineChatActionResult } from "@/hooks/use-cline-chat-runtime-actions";
 import type { ClineChatMessage } from "@/hooks/use-cline-chat-session";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -266,12 +276,16 @@ function DiffToolbar({
 	isExpanded,
 	onToggleExpand,
 	hideExpand,
+	isFileTreeVisible,
+	onToggleFileTree,
 }: {
 	mode: RuntimeWorkspaceChangesMode;
 	onModeChange: (mode: RuntimeWorkspaceChangesMode) => void;
 	isExpanded: boolean;
 	onToggleExpand: () => void;
 	hideExpand?: boolean;
+	isFileTreeVisible?: boolean;
+	onToggleFileTree?: () => void;
 }): React.ReactElement {
 	return (
 		<div className="flex items-center gap-1 border-b border-divider px-2 py-1">
@@ -294,14 +308,28 @@ function DiffToolbar({
 				</DiffModeButton>
 			</div>
 			{!hideExpand ? (
-				<Button
-					variant="ghost"
-					size="sm"
-					icon={isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
-					onClick={onToggleExpand}
-					className="ml-auto h-5"
-					aria-label={isExpanded ? "Collapse split diff view" : "Expand split diff view"}
-				/>
+				<div className="ml-auto flex items-center gap-0.5">
+					<Button
+						variant="ghost"
+						size="sm"
+						icon={isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+						onClick={onToggleExpand}
+						className="h-5"
+						aria-label={isExpanded ? "Collapse split diff view" : "Expand split diff view"}
+					/>
+					{onToggleFileTree ? (
+						<Tooltip content={isFileTreeVisible ? "Hide file tree" : "Show file tree"}>
+							<Button
+								variant="ghost"
+								size="sm"
+								icon={isFileTreeVisible ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
+								onClick={onToggleFileTree}
+								className="h-5"
+								aria-label={isFileTreeVisible ? "Hide file tree" : "Show file tree"}
+							/>
+						</Tooltip>
+					) : null}
+				</div>
 			) : null}
 		</div>
 	);
@@ -446,6 +474,8 @@ export function CardDetailView({
 		setAgentPanelRatio,
 		detailDiffFileTreeRatio,
 		setDetailDiffFileTreeRatio,
+		isFileTreeVisible,
+		setFileTreeVisible,
 	} = useCardDetailLayout({
 		isDiffExpanded,
 	});
@@ -602,6 +632,10 @@ export function CardDetailView({
 		}
 		setIsDiffExpanded((previous) => !previous);
 	}, [bottomTerminalOpen, isDiffExpanded, onBottomTerminalClose]);
+
+	const handleToggleFileTree = useCallback(() => {
+		setFileTreeVisible(!isFileTreeVisible);
+	}, [isFileTreeVisible, setFileTreeVisible]);
 
 	const handleAddDiffComments = useCallback(
 		(formatted: string) => {
@@ -863,6 +897,8 @@ export function CardDetailView({
 										onModeChange={setDiffMode}
 										isExpanded={isDiffExpanded}
 										onToggleExpand={handleToggleDiffExpand}
+										isFileTreeVisible={isFileTreeVisible}
+										onToggleFileTree={handleToggleFileTree}
 									/>
 								) : null}
 								<div className="flex min-h-0 flex-1">
@@ -874,7 +910,9 @@ export function CardDetailView({
 										<div ref={detailDiffRowRef} className="flex min-w-0 flex-1">
 											<div
 												className="flex min-h-0 min-w-0"
-												style={{ flex: `0 0 ${detailDiffContentPanelPercent}` }}
+												style={{
+													flex: isFileTreeVisible ? `0 0 ${detailDiffContentPanelPercent}` : "1 1 0",
+												}}
 											>
 												<DiffViewerPanel
 													workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
@@ -895,23 +933,27 @@ export function CardDetailView({
 													onCommentsChange={setDiffComments}
 												/>
 											</div>
-											<ResizeHandle
-												orientation="vertical"
-												ariaLabel="Resize detail diff panels"
-												onMouseDown={handleDetailDiffSeparatorMouseDown}
-												className="z-10"
-											/>
-											<div
-												className="flex min-h-0 min-w-0"
-												style={{ flex: `0 0 ${detailDiffFileTreePanelPercent}` }}
-											>
-												<FileTreePanel
-													workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
-													selectedPath={selectedPath}
-													onSelectPath={setSelectedPath}
-													panelFlex="1 1 0"
-												/>
-											</div>
+											{isFileTreeVisible ? (
+												<>
+													<ResizeHandle
+														orientation="vertical"
+														ariaLabel="Resize detail diff panels"
+														onMouseDown={handleDetailDiffSeparatorMouseDown}
+														className="z-10"
+													/>
+													<div
+														className="flex min-h-0 min-w-0"
+														style={{ flex: `0 0 ${detailDiffFileTreePanelPercent}` }}
+													>
+														<FileTreePanel
+															workspaceFiles={isRuntimeAvailable ? runtimeFiles : null}
+															selectedPath={selectedPath}
+															onSelectPath={setSelectedPath}
+															panelFlex="1 1 0"
+														/>
+													</div>
+												</>
+											) : null}
 										</div>
 									)}
 								</div>

--- a/web-ui/src/components/git-history/git-commit-diff-panel.test.tsx
+++ b/web-ui/src/components/git-history/git-commit-diff-panel.test.tsx
@@ -2,6 +2,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitCommitDiffPanel, type GitCommitDiffSource } from "@/components/git-history/git-commit-diff-panel";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 vi.mock("@/resize/layout-customizations", () => ({
 	useLayoutResetEffect: () => {},
@@ -72,14 +73,16 @@ describe("GitCommitDiffPanel", () => {
 
 		await act(async () => {
 			root.render(
-				<GitCommitDiffPanel
-					diffSource={diffSource}
-					isLoading={false}
-					errorMessage={null}
-					selectedPath={null}
-					onSelectPath={() => {}}
-					headerContent={<div style={{ height: 28 }}>Header</div>}
-				/>,
+				<TooltipProvider>
+					<GitCommitDiffPanel
+						diffSource={diffSource}
+						isLoading={false}
+						errorMessage={null}
+						selectedPath={null}
+						onSelectPath={() => {}}
+						headerContent={<div style={{ height: 28 }}>Header</div>}
+					/>
+				</TooltipProvider>,
 			);
 		});
 
@@ -120,14 +123,16 @@ describe("GitCommitDiffPanel", () => {
 
 		await act(async () => {
 			root.render(
-				<GitCommitDiffPanel
-					diffSource={diffSource}
-					isLoading={false}
-					errorMessage={null}
-					selectedPath="src/b.ts"
-					onSelectPath={() => {}}
-					headerContent={<div style={{ height: 28 }}>Header</div>}
-				/>,
+				<TooltipProvider>
+					<GitCommitDiffPanel
+						diffSource={diffSource}
+						isLoading={false}
+						errorMessage={null}
+						selectedPath="src/b.ts"
+						onSelectPath={() => {}}
+						headerContent={<div style={{ height: 28 }}>Header</div>}
+					/>
+				</TooltipProvider>,
 			);
 		});
 
@@ -150,13 +155,15 @@ describe("GitCommitDiffPanel", () => {
 
 		await act(async () => {
 			root.render(
-				<GitCommitDiffPanel
-					diffSource={diffSource}
-					isLoading={false}
-					errorMessage={null}
-					selectedPath={null}
-					onSelectPath={() => {}}
-				/>,
+				<TooltipProvider>
+					<GitCommitDiffPanel
+						diffSource={diffSource}
+						isLoading={false}
+						errorMessage={null}
+						selectedPath={null}
+						onSelectPath={() => {}}
+					/>
+				</TooltipProvider>,
 			);
 		});
 

--- a/web-ui/src/components/git-history/git-commit-diff-panel.tsx
+++ b/web-ui/src/components/git-history/git-commit-diff-panel.tsx
@@ -1,4 +1,12 @@
-import { AlertCircle, ChevronDown, ChevronRight, GitCommit, GitCompare } from "lucide-react";
+import {
+	AlertCircle,
+	ChevronDown,
+	ChevronRight,
+	GitCommit,
+	GitCompare,
+	PanelRightClose,
+	PanelRightOpen,
+} from "lucide-react";
 import { type MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FileTreePanel } from "@/components/detail-panels/file-tree-panel";
 import {
@@ -8,6 +16,8 @@ import {
 	truncatePathMiddle,
 	type UnifiedDiffRow,
 } from "@/components/shared/diff-renderer";
+import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import { ResizeHandle } from "@/resize/resize-handle";
 import { useGitCommitDiffLayout } from "@/resize/use-git-commit-diff-layout";
 import { useResizeDrag } from "@/resize/use-resize-drag";
@@ -89,7 +99,8 @@ export function GitCommitDiffPanel({
 	headerContent?: React.ReactNode;
 }): React.ReactElement {
 	const [expandedPaths, setExpandedPaths] = useState<Record<string, boolean>>({});
-	const { fileTreePanelRatio, setFileTreePanelRatio } = useGitCommitDiffLayout();
+	const { fileTreePanelRatio, setFileTreePanelRatio, isFileTreeVisible, setFileTreeVisible } =
+		useGitCommitDiffLayout();
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const sectionElementsRef = useRef<Record<string, HTMLElement | null>>({});
 	const diffLayoutRef = useRef<HTMLDivElement | null>(null);
@@ -322,13 +333,25 @@ export function GitCommitDiffPanel({
 			<div
 				style={{
 					display: "flex",
-					flex: `0 0 ${diffContentPanelPercent}`,
+					flex: isFileTreeVisible ? `0 0 ${diffContentPanelPercent}` : "1 1 0",
 					minWidth: 0,
 					minHeight: 0,
 					flexDirection: "column",
 				}}
 			>
 				{headerContent ? headerContent : null}
+				<div className="flex items-center justify-end border-b border-divider px-2 py-1">
+					<Tooltip content={isFileTreeVisible ? "Hide file tree" : "Show file tree"}>
+						<Button
+							variant="ghost"
+							size="sm"
+							icon={isFileTreeVisible ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
+							onClick={() => setFileTreeVisible(!isFileTreeVisible)}
+							className="h-5"
+							aria-label={isFileTreeVisible ? "Hide file tree" : "Show file tree"}
+						/>
+					</Tooltip>
+				</div>
 				<div
 					ref={scrollContainerRef}
 					onScroll={handleDiffScroll}
@@ -433,27 +456,31 @@ export function GitCommitDiffPanel({
 					})}
 				</div>
 			</div>
-			<ResizeHandle
-				orientation="vertical"
-				ariaLabel="Resize git diff panels"
-				onMouseDown={handleDiffSplitSeparatorMouseDown}
-				className="z-10"
-			/>
-			<div
-				style={{
-					display: "flex",
-					flex: `0 0 ${fileTreePanelPercent}`,
-					minWidth: 0,
-					minHeight: 0,
-				}}
-			>
-				<FileTreePanel
-					workspaceFiles={workspaceFilesForTree}
-					selectedPath={selectedPath}
-					onSelectPath={onSelectPath}
-					panelFlex="1 1 0"
-				/>
-			</div>
+			{isFileTreeVisible ? (
+				<>
+					<ResizeHandle
+						orientation="vertical"
+						ariaLabel="Resize git diff panels"
+						onMouseDown={handleDiffSplitSeparatorMouseDown}
+						className="z-10"
+					/>
+					<div
+						style={{
+							display: "flex",
+							flex: `0 0 ${fileTreePanelPercent}`,
+							minWidth: 0,
+							minHeight: 0,
+						}}
+					>
+						<FileTreePanel
+							workspaceFiles={workspaceFilesForTree}
+							selectedPath={selectedPath}
+							onSelectPath={onSelectPath}
+							panelFlex="1 1 0"
+						/>
+					</div>
+				</>
+			) : null}
 		</div>
 	);
 }

--- a/web-ui/src/resize/use-card-detail-layout.ts
+++ b/web-ui/src/resize/use-card-detail-layout.ts
@@ -4,8 +4,11 @@ import { useLayoutResetEffect } from "@/resize/layout-customizations";
 import { clampBetween } from "@/resize/resize-persistence";
 import {
 	getResizePreferenceDefaultValue,
+	loadBooleanResizePreference,
 	loadResizePreference,
+	persistBooleanResizePreference,
 	persistResizePreference,
+	type ResizeBooleanPreference,
 	type ResizeNumberPreference,
 } from "@/resize/resize-preferences";
 import { LocalStorageKey } from "@/storage/local-storage-store";
@@ -34,11 +37,18 @@ const EXPANDED_DIFF_FILE_TREE_RATIO_PREFERENCE: ResizeNumberPreference = {
 	normalize: (value) => clampBetween(value, 0.12, 0.6),
 };
 
+const FILE_TREE_VISIBLE_PREFERENCE: ResizeBooleanPreference = {
+	key: LocalStorageKey.DetailDiffFileTreeVisible,
+	defaultValue: true,
+};
+
 export function useCardDetailLayout({ isDiffExpanded }: { isDiffExpanded: boolean }): {
 	agentPanelRatio: number;
 	detailDiffFileTreeRatio: number;
+	isFileTreeVisible: boolean;
 	setAgentPanelRatio: (ratio: number) => void;
 	setDetailDiffFileTreeRatio: (ratio: number) => void;
+	setFileTreeVisible: (visible: boolean) => void;
 	setTaskCardsPanelRatio: (ratio: number) => void;
 	taskCardsPanelRatio: number;
 } {
@@ -51,6 +61,9 @@ export function useCardDetailLayout({ isDiffExpanded }: { isDiffExpanded: boolea
 	);
 	const [expandedDetailDiffFileTreeRatio, setExpandedDetailDiffFileTreeRatioState] = useState(() =>
 		loadResizePreference(EXPANDED_DIFF_FILE_TREE_RATIO_PREFERENCE),
+	);
+	const [isFileTreeVisible, setIsFileTreeVisibleState] = useState(() =>
+		loadBooleanResizePreference(FILE_TREE_VISIBLE_PREFERENCE),
 	);
 
 	const setTaskCardsPanelRatio = useCallback((ratio: number) => {
@@ -76,6 +89,10 @@ export function useCardDetailLayout({ isDiffExpanded }: { isDiffExpanded: boolea
 		[isDiffExpanded],
 	);
 
+	const setFileTreeVisible = useCallback((visible: boolean) => {
+		setIsFileTreeVisibleState(persistBooleanResizePreference(FILE_TREE_VISIBLE_PREFERENCE, visible));
+	}, []);
+
 	useLayoutResetEffect(() => {
 		setTaskCardsPanelRatioState(getResizePreferenceDefaultValue(TASK_CARDS_RATIO_PREFERENCE));
 		setAgentPanelRatioState(getResizePreferenceDefaultValue(AGENT_RATIO_PREFERENCE));
@@ -85,6 +102,7 @@ export function useCardDetailLayout({ isDiffExpanded }: { isDiffExpanded: boolea
 		setExpandedDetailDiffFileTreeRatioState(
 			getResizePreferenceDefaultValue(EXPANDED_DIFF_FILE_TREE_RATIO_PREFERENCE),
 		);
+		setIsFileTreeVisibleState(FILE_TREE_VISIBLE_PREFERENCE.defaultValue);
 	});
 
 	return {
@@ -94,5 +112,7 @@ export function useCardDetailLayout({ isDiffExpanded }: { isDiffExpanded: boolea
 		setAgentPanelRatio,
 		detailDiffFileTreeRatio: isDiffExpanded ? expandedDetailDiffFileTreeRatio : collapsedDetailDiffFileTreeRatio,
 		setDetailDiffFileTreeRatio,
+		isFileTreeVisible,
+		setFileTreeVisible,
 	};
 }

--- a/web-ui/src/resize/use-git-commit-diff-layout.ts
+++ b/web-ui/src/resize/use-git-commit-diff-layout.ts
@@ -4,8 +4,11 @@ import { useLayoutResetEffect } from "@/resize/layout-customizations";
 import { clampBetween } from "@/resize/resize-persistence";
 import {
 	getResizePreferenceDefaultValue,
+	loadBooleanResizePreference,
 	loadResizePreference,
+	persistBooleanResizePreference,
 	persistResizePreference,
+	type ResizeBooleanPreference,
 	type ResizeNumberPreference,
 } from "@/resize/resize-preferences";
 import { LocalStorageKey } from "@/storage/local-storage-store";
@@ -16,24 +19,41 @@ const FILE_TREE_RATIO_PREFERENCE: ResizeNumberPreference = {
 	normalize: (value) => clampBetween(value, 0.12, 0.6),
 };
 
+const FILE_TREE_VISIBLE_PREFERENCE: ResizeBooleanPreference = {
+	key: LocalStorageKey.GitDiffFileTreeVisible,
+	defaultValue: true,
+};
+
 export function useGitCommitDiffLayout(): {
 	fileTreePanelRatio: number;
+	isFileTreeVisible: boolean;
 	setFileTreePanelRatio: (ratio: number) => void;
+	setFileTreeVisible: (visible: boolean) => void;
 } {
 	const [fileTreePanelRatio, setFileTreePanelRatioState] = useState(() =>
 		loadResizePreference(FILE_TREE_RATIO_PREFERENCE),
+	);
+	const [isFileTreeVisible, setIsFileTreeVisibleState] = useState(() =>
+		loadBooleanResizePreference(FILE_TREE_VISIBLE_PREFERENCE),
 	);
 
 	const setFileTreePanelRatio = useCallback((ratio: number) => {
 		setFileTreePanelRatioState(persistResizePreference(FILE_TREE_RATIO_PREFERENCE, ratio));
 	}, []);
 
+	const setFileTreeVisible = useCallback((visible: boolean) => {
+		setIsFileTreeVisibleState(persistBooleanResizePreference(FILE_TREE_VISIBLE_PREFERENCE, visible));
+	}, []);
+
 	useLayoutResetEffect(() => {
 		setFileTreePanelRatioState(getResizePreferenceDefaultValue(FILE_TREE_RATIO_PREFERENCE));
+		setIsFileTreeVisibleState(FILE_TREE_VISIBLE_PREFERENCE.defaultValue);
 	});
 
 	return {
 		fileTreePanelRatio,
 		setFileTreePanelRatio,
+		isFileTreeVisible,
+		setFileTreeVisible,
 	};
 }

--- a/web-ui/src/storage/local-storage-store.ts
+++ b/web-ui/src/storage/local-storage-store.ts
@@ -14,6 +14,8 @@ export enum LocalStorageKey {
 	GitHistoryRefsPanelWidth = "kanban.git-history-refs-panel-width",
 	GitHistoryCommitsPanelWidth = "kanban.git-history-commits-panel-width",
 	GitDiffFileTreePanelRatio = "kanban.git-diff-file-tree-panel-ratio",
+	DetailDiffFileTreeVisible = "kanban.detail-diff-file-tree-visible",
+	GitDiffFileTreeVisible = "kanban.git-diff-file-tree-visible",
 	OnboardingDialogShown = "kanban.onboarding.dialog.shown",
 	NotificationPermissionPrompted = "kanban.notifications.permission-prompted",
 	PreferredOpenTarget = "kanban.preferred-open-target",


### PR DESCRIPTION
Add a toggle button to hide/show the file tree panel in both the card detail diff view and the git history diff view.

**Open**
<img width="1918" height="975" alt="Screenshot 2026-04-13 at 3 47 00 PM" src="https://github.com/user-attachments/assets/37d97acf-668e-411e-9c81-80eb34565f41" />


**Collapsed**
<img width="1918" height="975" alt="Screenshot 2026-04-13 at 3 47 07 PM" src="https://github.com/user-attachments/assets/c856e471-7668-463e-bd78-7458aa1e6f0d" />


