### PR TITLE
Prevent Task Card Resizing And Layout Shifts

### DIFF
--- a/web-ui/src/components/board-card.test.tsx
+++ b/web-ui/src/components/board-card.test.tsx
@@ -595,11 +595,9 @@ describe("BoardCard", () => {
 		expect(container.textContent).toContain("Freshly created task description");
 	});
 
-	it("shows see more for trash card previews without using card click to expand", async () => {
-		mockMeasureWidths = [240, 96];
+	it("renders session activity as single-line truncated text on trash cards", async () => {
 		const preview =
 			"Reviewing the archived implementation details and collecting the final notes for the handoff before cleanup hidden tail";
-		const onCardClick = vi.fn();
 
 		await act(async () => {
 			root.render(
@@ -608,7 +606,6 @@ describe("BoardCard", () => {
 						card={createCard()}
 						index={0}
 						columnId="trash"
-						onClick={onCardClick}
 						sessionSummary={createSummary("awaiting_review", {
 							latestHookActivity: {
 								activityText: null,
@@ -627,36 +624,18 @@ describe("BoardCard", () => {
 
 		const findButton = (label: string) =>
 			Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === label);
-		const cardElement = container.querySelector('[data-task-id="task-1"]');
 
-		expect(findButton("See more")).toBeDefined();
-		expect(container.textContent).not.toContain("hidden tail");
-
-		await act(async () => {
-			cardElement?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-		});
-
-		expect(onCardClick).not.toHaveBeenCalled();
-		expect(findButton("See more")).toBeDefined();
-		expect(findButton("Less")).toBeUndefined();
-		expect(container.textContent).not.toContain("hidden tail");
-
-		const seeMoreButton = findButton("See more");
-		await act(async () => {
-			seeMoreButton?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-			seeMoreButton?.click();
-		});
-
+		// Session activity uses CSS truncation with no See more / Less buttons
 		expect(findButton("See more")).toBeUndefined();
-		expect(findButton("Less")).toBeDefined();
+		expect(findButton("Less")).toBeUndefined();
+
+		// The full text is in the DOM (CSS handles visual truncation)
 		expect(container.textContent).toContain(preview);
 	});
 
-	it("uses single-line truncation for running task previews instead of see more", async () => {
-		mockMeasureWidths = [240, 96];
+	it("renders session activity as single-line truncated text for running tasks", async () => {
 		const preview =
 			"Reviewing the archived implementation details and collecting the final notes for the handoff before cleanup hidden tail";
-		const onCardClick = vi.fn();
 
 		await act(async () => {
 			root.render(
@@ -664,7 +643,6 @@ describe("BoardCard", () => {
 					card={createCard()}
 					index={0}
 					columnId="in_progress"
-					onClick={onCardClick}
 					sessionSummary={createSummary("running", {
 						latestHookActivity: {
 							activityText: null,
@@ -683,16 +661,12 @@ describe("BoardCard", () => {
 		const findButton = (label: string) =>
 			Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === label);
 
-		// Running tasks use single-line CSS truncation instead of See more / Less
+		// Session activity uses CSS truncation with no See more / Less buttons
 		expect(findButton("See more")).toBeUndefined();
 		expect(findButton("Less")).toBeUndefined();
 
-		// The full text is still present in the DOM (CSS truncation hides overflow visually)
+		// The full text is in the DOM (CSS handles visual truncation)
 		expect(container.textContent).toContain(preview);
-
-		// The session preview paragraph has the truncate class
-		expect(sessionPreviewP).not.toBeNull();
-		expect(sessionPreviewP?.textContent).toContain(preview);
 	});
 
 	it("shows the latest assistant preview on active task cards", async () => {

--- a/web-ui/src/components/board-card.test.tsx
+++ b/web-ui/src/components/board-card.test.tsx
@@ -691,8 +691,7 @@ describe("BoardCard", () => {
 		expect(container.textContent).toContain(preview);
 
 		// The session preview paragraph has the truncate class
-		const sessionPreviewP = container.querySelector("p.truncate");
-		expect(sessionPreviewP).toBeDefined();
+		expect(sessionPreviewP).not.toBeNull();
 		expect(sessionPreviewP?.textContent).toContain(preview);
 	});
 

--- a/web-ui/src/components/board-card.test.tsx
+++ b/web-ui/src/components/board-card.test.tsx
@@ -652,7 +652,7 @@ describe("BoardCard", () => {
 		expect(container.textContent).toContain(preview);
 	});
 
-	it("shows see more for active task previews without using card click to expand", async () => {
+	it("uses single-line truncation for running task previews instead of see more", async () => {
 		mockMeasureWidths = [240, 96];
 		const preview =
 			"Reviewing the archived implementation details and collecting the final notes for the handoff before cleanup hidden tail";
@@ -682,30 +682,18 @@ describe("BoardCard", () => {
 
 		const findButton = (label: string) =>
 			Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === label);
-		const cardElement = container.querySelector('[data-task-id="task-1"]');
 
-		expect(findButton("See more")).toBeDefined();
-		expect(container.textContent).not.toContain("hidden tail");
-
-		await act(async () => {
-			cardElement?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-		});
-
-		expect(onCardClick).toHaveBeenCalledTimes(1);
-		expect(findButton("See more")).toBeDefined();
-		expect(findButton("Less")).toBeUndefined();
-		expect(container.textContent).not.toContain("hidden tail");
-
-		const seeMoreButton = findButton("See more");
-		await act(async () => {
-			seeMoreButton?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-			seeMoreButton?.click();
-		});
-
-		expect(onCardClick).toHaveBeenCalledTimes(1);
+		// Running tasks use single-line CSS truncation instead of See more / Less
 		expect(findButton("See more")).toBeUndefined();
-		expect(findButton("Less")).toBeDefined();
+		expect(findButton("Less")).toBeUndefined();
+
+		// The full text is still present in the DOM (CSS truncation hides overflow visually)
 		expect(container.textContent).toContain(preview);
+
+		// The session preview paragraph has the truncate class
+		const sessionPreviewP = container.querySelector("p.truncate");
+		expect(sessionPreviewP).toBeDefined();
+		expect(sessionPreviewP?.textContent).toContain(preview);
 	});
 
 	it("shows the latest assistant preview on active task cards", async () => {

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -675,7 +675,7 @@ export function BoardCard({
 												{"… "}
 												<button
 													type="button"
-													className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+													className="inline cursor-pointer rounded-sm text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
 													aria-expanded={isDescriptionExpanded}
 													aria-label={
 														isDescriptionExpanded
@@ -698,7 +698,7 @@ export function BoardCard({
 												{" "}
 												<button
 													type="button"
-													className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+													className="inline cursor-pointer rounded-sm text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
 													aria-expanded={isDescriptionExpanded}
 													aria-label="Collapse task description"
 													onMouseDown={stopEvent}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -45,7 +45,6 @@ const SESSION_ACTIVITY_COLOR = {
 } as const;
 
 const DESCRIPTION_COLLAPSE_LINES = 3;
-const DESCRIPTION_EXPANDED_MAX_LINES = 10;
 const DESCRIPTION_EXPAND_LABEL = "See more";
 const DESCRIPTION_COLLAPSE_LABEL = "Less";
 const DESCRIPTION_COLLAPSE_SUFFIX = `… ${DESCRIPTION_EXPAND_LABEL}`;
@@ -368,31 +367,22 @@ export function BoardCard({
 	const descriptionDisplay = useMemo(() => {
 		if (!displayDescription) {
 			return {
-				collapsed: { text: "", isTruncated: false },
-				expanded: { text: "", isTruncated: false },
+				text: "",
+				isTruncated: false,
 			};
 		}
 		if (descriptionWidth <= 0) {
 			return {
-				collapsed: { text: displayDescription, isTruncated: false },
-				expanded: { text: displayDescription, isTruncated: false },
+				text: displayDescription,
+				isTruncated: false,
 			};
 		}
-		const measure = (value: string) => measureTextWidth(value, descriptionFont);
-		return {
-			collapsed: clampTextWithInlineSuffix(displayDescription, {
-				maxWidthPx: descriptionWidth,
-				maxLines: DESCRIPTION_COLLAPSE_LINES,
-				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
-				measureText: measure,
-			}),
-			expanded: clampTextWithInlineSuffix(displayDescription, {
-				maxWidthPx: descriptionWidth,
-				maxLines: DESCRIPTION_EXPANDED_MAX_LINES,
-				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
-				measureText: measure,
-			}),
-		};
+		return clampTextWithInlineSuffix(displayDescription, {
+			maxWidthPx: descriptionWidth,
+			maxLines: DESCRIPTION_COLLAPSE_LINES,
+			suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+			measureText: (value) => measureTextWidth(value, descriptionFont),
+		});
 	}, [descriptionFont, descriptionWidth, displayDescription]);
 
 	const isCreditLimit = isCardCreditLimitError(sessionSummary);
@@ -662,60 +652,46 @@ export function BoardCard({
 											margin: "2px 0 0",
 										}}
 									>
-										{(() => {
-											const activeDisplay = isDescriptionExpanded
-												? descriptionDisplay.expanded
-												: descriptionDisplay.collapsed;
-											const showFull = isDescriptionExpanded && !activeDisplay.isTruncated;
-											return (
+										{isDescriptionExpanded || !descriptionDisplay.isTruncated
+											? displayDescription
+											: descriptionDisplay.text}
+										{descriptionDisplay.isTruncated ? (
+											isDescriptionExpanded ? (
 												<>
-													{showFull || !activeDisplay.isTruncated
-														? displayDescription
-														: activeDisplay.text}
-													{activeDisplay.isTruncated ? (
-														<>
-															{"… "}
-															<button
-																type="button"
-																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-																aria-expanded={isDescriptionExpanded}
-																aria-label={
-																	isDescriptionExpanded
-																		? "Collapse task description"
-																		: "Expand task description"
-																}
-																onMouseDown={stopEvent}
-																onClick={(event) => {
-																	stopEvent(event);
-																	setIsDescriptionExpanded(!isDescriptionExpanded);
-																}}
-															>
-																{isDescriptionExpanded
-																	? DESCRIPTION_COLLAPSE_LABEL
-																	: DESCRIPTION_EXPAND_LABEL}
-															</button>
-														</>
-													) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (
-														<>
-															{" "}
-															<button
-																type="button"
-																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-																aria-expanded={isDescriptionExpanded}
-																aria-label="Collapse task description"
-																onMouseDown={stopEvent}
-																onClick={(event) => {
-																	stopEvent(event);
-																	setIsDescriptionExpanded(false);
-																}}
-															>
-																{DESCRIPTION_COLLAPSE_LABEL}
-															</button>
-														</>
-													) : null}
+													{" "}
+													<button
+														type="button"
+														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+														aria-expanded={isDescriptionExpanded}
+														aria-label="Collapse task description"
+														onMouseDown={stopEvent}
+														onClick={(event) => {
+															stopEvent(event);
+															setIsDescriptionExpanded(false);
+														}}
+													>
+														{DESCRIPTION_COLLAPSE_LABEL}
+													</button>
 												</>
-											);
-										})()}
+											) : (
+												<>
+													{"… "}
+													<button
+														type="button"
+														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+														aria-expanded={isDescriptionExpanded}
+														aria-label="Expand task description"
+														onMouseDown={stopEvent}
+														onClick={(event) => {
+															stopEvent(event);
+															setIsDescriptionExpanded(true);
+														}}
+													>
+														{DESCRIPTION_EXPAND_LABEL}
+													</button>
+												</>
+											)
+										) : null}
 									</p>
 								</div>
 							) : null}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -49,6 +49,7 @@ const DESCRIPTION_EXPANDED_MAX_LINES = 10;
 const DESCRIPTION_EXPAND_LABEL = "See more";
 const DESCRIPTION_COLLAPSE_LABEL = "Less";
 const DESCRIPTION_COLLAPSE_SUFFIX = `… ${DESCRIPTION_EXPAND_LABEL}`;
+const DESCRIPTION_EXPANDED_SUFFIX = `… ${DESCRIPTION_COLLAPSE_LABEL}`;
 
 function reconstructTaskWorktreeDisplayPath(taskId: string, workspacePath: string | null | undefined): string | null {
 	if (!workspacePath) {
@@ -389,7 +390,7 @@ export function BoardCard({
 			expanded: clampTextWithInlineSuffix(displayDescription, {
 				maxWidthPx: descriptionWidth,
 				maxLines: DESCRIPTION_EXPANDED_MAX_LINES,
-				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+				suffix: DESCRIPTION_EXPANDED_SUFFIX,
 				measureText: measure,
 			}),
 		};
@@ -469,7 +470,6 @@ export function BoardCard({
 	const activeDescriptionDisplay = isDescriptionExpanded
 		? descriptionDisplay.expanded
 		: descriptionDisplay.collapsed;
-	const showFullDescription = isDescriptionExpanded && !activeDescriptionDisplay.isTruncated;
 
 	return (
 		<Draggable draggableId={card.id} index={index} isDragDisabled={false}>
@@ -667,9 +667,9 @@ export function BoardCard({
 											margin: "2px 0 0",
 										}}
 									>
-										{showFullDescription || !activeDescriptionDisplay.isTruncated
-											? displayDescription
-											: activeDescriptionDisplay.text}
+										{activeDescriptionDisplay.isTruncated
+											? activeDescriptionDisplay.text
+											: displayDescription}
 										{activeDescriptionDisplay.isTruncated ? (
 											<>
 												{"… "}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -432,6 +432,7 @@ export function BoardCard({
 		});
 	}, [sessionActivity?.text, sessionPreviewFont, sessionPreviewWidth]);
 
+	const isSessionRunning = sessionSummary?.state === "running";
 	const isCreditLimit = isCardCreditLimitError(sessionSummary);
 	const renderStatusMarker = () => {
 		if (isCreditLimit) {
@@ -778,18 +779,23 @@ export function BoardCard({
 											ref={sessionPreviewRef}
 											className={cn(
 												"m-0 font-mono",
-												!isSessionPreviewMeasured && !isSessionPreviewExpanded && "line-clamp-6",
+												isSessionRunning
+													? "truncate"
+													: !isSessionPreviewMeasured && !isSessionPreviewExpanded && "line-clamp-6",
 											)}
 											style={{
 												fontSize: 12,
-												whiteSpace: "normal",
-												overflowWrap: "anywhere",
+												...(isSessionRunning
+													? {}
+													: { whiteSpace: "normal" as const, overflowWrap: "anywhere" as const }),
 											}}
 										>
-											{isSessionPreviewExpanded || !sessionPreviewDisplay.isTruncated
+											{isSessionRunning
 												? sessionActivity.text
-												: sessionPreviewDisplay.text}
-											{sessionPreviewDisplay.isTruncated ? (
+												: isSessionPreviewExpanded || !sessionPreviewDisplay.isTruncated
+													? sessionActivity.text
+													: sessionPreviewDisplay.text}
+											{!isSessionRunning && sessionPreviewDisplay.isTruncated ? (
 												isSessionPreviewExpanded ? (
 													<>
 														{" "}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -45,7 +45,7 @@ const SESSION_ACTIVITY_COLOR = {
 } as const;
 
 const DESCRIPTION_COLLAPSE_LINES = 3;
-const SESSION_PREVIEW_COLLAPSE_LINES = 6;
+const DESCRIPTION_EXPANDED_MAX_LINES = 10;
 const DESCRIPTION_EXPAND_LABEL = "See more";
 const DESCRIPTION_COLLAPSE_LABEL = "Less";
 const DESCRIPTION_COLLAPSE_SUFFIX = `… ${DESCRIPTION_EXPAND_LABEL}`;
@@ -264,20 +264,14 @@ export function BoardCard({
 	const titleInputRef = useRef<HTMLInputElement | null>(null);
 	const titleEditCancelledRef = useRef(false);
 	const [descriptionContainerRef, descriptionRect] = useMeasure<HTMLDivElement>();
-	const [sessionPreviewContainerRef, sessionPreviewRect] = useMeasure<HTMLDivElement>();
 	const descriptionRef = useRef<HTMLParagraphElement | null>(null);
-	const sessionPreviewRef = useRef<HTMLParagraphElement | null>(null);
 	const [descriptionWidthFallback, setDescriptionWidthFallback] = useState(0);
-	const [sessionPreviewWidthFallback, setSessionPreviewWidthFallback] = useState(0);
 	const [descriptionFont, setDescriptionFont] = useState(DEFAULT_TEXT_MEASURE_FONT);
-	const [sessionPreviewFont, setSessionPreviewFont] = useState(DEFAULT_TEXT_MEASURE_FONT);
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
-	const [isSessionPreviewExpanded, setIsSessionPreviewExpanded] = useState(false);
 	const reviewWorkspaceSnapshot = useTaskWorkspaceSnapshotValue(card.id);
 	const isTrashCard = columnId === "trash";
 	const isCardInteractive = !isTrashCard;
 	const descriptionWidth = descriptionRect.width > 0 ? descriptionRect.width : descriptionWidthFallback;
-	const sessionPreviewWidth = sessionPreviewRect.width > 0 ? sessionPreviewRect.width : sessionPreviewWidthFallback;
 	const rawSessionActivity = useMemo(() => getCardSessionActivity(sessionSummary), [sessionSummary]);
 	const lastSessionActivityRef = useRef<CardSessionActivity | null>(null);
 	const lastSessionActivityCardIdRef = useRef<string | null>(null);
@@ -309,30 +303,12 @@ export function BoardCard({
 	}, [descriptionRect.width, descriptionWidthFallback, displayDescription]);
 
 	useLayoutEffect(() => {
-		if (sessionPreviewRect.width > 0 || !isTrashCard || !sessionActivity?.text) {
-			return;
-		}
-		const nextWidth = sessionPreviewRef.current?.parentElement?.getBoundingClientRect().width ?? 0;
-		if (nextWidth > 0 && nextWidth !== sessionPreviewWidthFallback) {
-			setSessionPreviewWidthFallback(nextWidth);
-		}
-	}, [isTrashCard, sessionActivity?.text, sessionPreviewRect.width, sessionPreviewWidthFallback]);
-
-	useLayoutEffect(() => {
 		setDescriptionFont(readElementFontShorthand(descriptionRef.current, DEFAULT_TEXT_MEASURE_FONT));
 	}, [descriptionWidth, displayDescription]);
-
-	useLayoutEffect(() => {
-		setSessionPreviewFont(readElementFontShorthand(sessionPreviewRef.current, DEFAULT_TEXT_MEASURE_FONT));
-	}, [sessionActivity?.text, sessionPreviewWidth]);
 
 	useEffect(() => {
 		setIsDescriptionExpanded(false);
 	}, [card.id, displayDescription]);
-
-	useEffect(() => {
-		setIsSessionPreviewExpanded(false);
-	}, [card.id, sessionActivity?.text]);
 
 	useEffect(() => {
 		setDraftTitle(card.title);
@@ -388,51 +364,37 @@ export function BoardCard({
 	};
 
 	const isDescriptionMeasured = descriptionRect.width > 0;
-	const isSessionPreviewMeasured = sessionPreviewRect.width > 0;
 
 	const descriptionDisplay = useMemo(() => {
 		if (!displayDescription) {
 			return {
-				text: "",
-				isTruncated: false,
+				collapsed: { text: "", isTruncated: false },
+				expanded: { text: "", isTruncated: false },
 			};
 		}
 		if (descriptionWidth <= 0) {
 			return {
-				text: displayDescription,
-				isTruncated: false,
+				collapsed: { text: displayDescription, isTruncated: false },
+				expanded: { text: displayDescription, isTruncated: false },
 			};
 		}
-		return clampTextWithInlineSuffix(displayDescription, {
-			maxWidthPx: descriptionWidth,
-			maxLines: DESCRIPTION_COLLAPSE_LINES,
-			suffix: DESCRIPTION_COLLAPSE_SUFFIX,
-			measureText: (value) => measureTextWidth(value, descriptionFont),
-		});
+		const measure = (value: string) => measureTextWidth(value, descriptionFont);
+		return {
+			collapsed: clampTextWithInlineSuffix(displayDescription, {
+				maxWidthPx: descriptionWidth,
+				maxLines: DESCRIPTION_COLLAPSE_LINES,
+				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+				measureText: measure,
+			}),
+			expanded: clampTextWithInlineSuffix(displayDescription, {
+				maxWidthPx: descriptionWidth,
+				maxLines: DESCRIPTION_EXPANDED_MAX_LINES,
+				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+				measureText: measure,
+			}),
+		};
 	}, [descriptionFont, descriptionWidth, displayDescription]);
 
-	const sessionPreviewDisplay = useMemo(() => {
-		if (!sessionActivity?.text) {
-			return {
-				text: "",
-				isTruncated: false,
-			};
-		}
-		if (sessionPreviewWidth <= 0) {
-			return {
-				text: sessionActivity.text,
-				isTruncated: false,
-			};
-		}
-		return clampTextWithInlineSuffix(sessionActivity.text, {
-			maxWidthPx: sessionPreviewWidth,
-			maxLines: SESSION_PREVIEW_COLLAPSE_LINES,
-			suffix: DESCRIPTION_COLLAPSE_SUFFIX,
-			measureText: (value) => measureTextWidth(value, sessionPreviewFont),
-		});
-	}, [sessionActivity?.text, sessionPreviewFont, sessionPreviewWidth]);
-
-	const isSessionRunning = sessionSummary?.state === "running";
 	const isCreditLimit = isCardCreditLimitError(sessionSummary);
 	const renderStatusMarker = () => {
 		if (isCreditLimit) {
@@ -700,46 +662,60 @@ export function BoardCard({
 											margin: "2px 0 0",
 										}}
 									>
-										{isDescriptionExpanded || !descriptionDisplay.isTruncated
-											? displayDescription
-											: descriptionDisplay.text}
-										{descriptionDisplay.isTruncated ? (
-											isDescriptionExpanded ? (
+										{(() => {
+											const activeDisplay = isDescriptionExpanded
+												? descriptionDisplay.expanded
+												: descriptionDisplay.collapsed;
+											const showFull = isDescriptionExpanded && !activeDisplay.isTruncated;
+											return (
 												<>
-													{" "}
-													<button
-														type="button"
-														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-														aria-expanded={isDescriptionExpanded}
-														aria-label="Collapse task description"
-														onMouseDown={stopEvent}
-														onClick={(event) => {
-															stopEvent(event);
-															setIsDescriptionExpanded(false);
-														}}
-													>
-														{DESCRIPTION_COLLAPSE_LABEL}
-													</button>
+													{showFull || !activeDisplay.isTruncated
+														? displayDescription
+														: activeDisplay.text}
+													{activeDisplay.isTruncated ? (
+														<>
+															{"… "}
+															<button
+																type="button"
+																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+																aria-expanded={isDescriptionExpanded}
+																aria-label={
+																	isDescriptionExpanded
+																		? "Collapse task description"
+																		: "Expand task description"
+																}
+																onMouseDown={stopEvent}
+																onClick={(event) => {
+																	stopEvent(event);
+																	setIsDescriptionExpanded(!isDescriptionExpanded);
+																}}
+															>
+																{isDescriptionExpanded
+																	? DESCRIPTION_COLLAPSE_LABEL
+																	: DESCRIPTION_EXPAND_LABEL}
+															</button>
+														</>
+													) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (
+														<>
+															{" "}
+															<button
+																type="button"
+																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+																aria-expanded={isDescriptionExpanded}
+																aria-label="Collapse task description"
+																onMouseDown={stopEvent}
+																onClick={(event) => {
+																	stopEvent(event);
+																	setIsDescriptionExpanded(false);
+																}}
+															>
+																{DESCRIPTION_COLLAPSE_LABEL}
+															</button>
+														</>
+													) : null}
 												</>
-											) : (
-												<>
-													{"… "}
-													<button
-														type="button"
-														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-														aria-expanded={isDescriptionExpanded}
-														aria-label="Expand task description"
-														onMouseDown={stopEvent}
-														onClick={(event) => {
-															stopEvent(event);
-															setIsDescriptionExpanded(true);
-														}}
-													>
-														{DESCRIPTION_EXPAND_LABEL}
-													</button>
-												</>
-											)
-										) : null}
+											);
+										})()}
 									</p>
 								</div>
 							) : null}
@@ -774,64 +750,9 @@ export function BoardCard({
 											marginTop: 4,
 										}}
 									/>
-									<div ref={sessionPreviewContainerRef} className="min-w-0 flex-1">
-										<p
-											ref={sessionPreviewRef}
-											className={cn(
-												"m-0 font-mono",
-												isSessionRunning
-													? "truncate"
-													: !isSessionPreviewMeasured && !isSessionPreviewExpanded && "line-clamp-6",
-											)}
-											style={{
-												fontSize: 12,
-												...(isSessionRunning
-													? {}
-													: { whiteSpace: "normal" as const, overflowWrap: "anywhere" as const }),
-											}}
-										>
-											{isSessionRunning
-												? sessionActivity.text
-												: isSessionPreviewExpanded || !sessionPreviewDisplay.isTruncated
-													? sessionActivity.text
-													: sessionPreviewDisplay.text}
-											{!isSessionRunning && sessionPreviewDisplay.isTruncated ? (
-												isSessionPreviewExpanded ? (
-													<>
-														{" "}
-														<button
-															type="button"
-															className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-															aria-expanded={isSessionPreviewExpanded}
-															aria-label="Collapse task agent preview"
-															onMouseDown={stopEvent}
-															onClick={(event) => {
-																stopEvent(event);
-																setIsSessionPreviewExpanded(false);
-															}}
-														>
-															{DESCRIPTION_COLLAPSE_LABEL}
-														</button>
-													</>
-												) : (
-													<>
-														{"… "}
-														<button
-															type="button"
-															className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-															aria-expanded={isSessionPreviewExpanded}
-															aria-label="Expand task agent preview"
-															onMouseDown={stopEvent}
-															onClick={(event) => {
-																stopEvent(event);
-																setIsSessionPreviewExpanded(true);
-															}}
-														>
-															{DESCRIPTION_EXPAND_LABEL}
-														</button>
-													</>
-												)
-											) : null}
+									<div className="min-w-0 flex-1">
+										<p className="m-0 font-mono truncate" style={{ fontSize: 12 }}>
+											{sessionActivity.text}
 										</p>
 									</div>
 								</div>

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -45,6 +45,7 @@ const SESSION_ACTIVITY_COLOR = {
 } as const;
 
 const DESCRIPTION_COLLAPSE_LINES = 3;
+const DESCRIPTION_EXPANDED_MAX_LINES = 10;
 const DESCRIPTION_EXPAND_LABEL = "See more";
 const DESCRIPTION_COLLAPSE_LABEL = "Less";
 const DESCRIPTION_COLLAPSE_SUFFIX = `… ${DESCRIPTION_EXPAND_LABEL}`;
@@ -367,22 +368,31 @@ export function BoardCard({
 	const descriptionDisplay = useMemo(() => {
 		if (!displayDescription) {
 			return {
-				text: "",
-				isTruncated: false,
+				collapsed: { text: "", isTruncated: false },
+				expanded: { text: "", isTruncated: false },
 			};
 		}
 		if (descriptionWidth <= 0) {
 			return {
-				text: displayDescription,
-				isTruncated: false,
+				collapsed: { text: displayDescription, isTruncated: false },
+				expanded: { text: displayDescription, isTruncated: false },
 			};
 		}
-		return clampTextWithInlineSuffix(displayDescription, {
-			maxWidthPx: descriptionWidth,
-			maxLines: DESCRIPTION_COLLAPSE_LINES,
-			suffix: DESCRIPTION_COLLAPSE_SUFFIX,
-			measureText: (value) => measureTextWidth(value, descriptionFont),
-		});
+		const measure = (value: string) => measureTextWidth(value, descriptionFont);
+		return {
+			collapsed: clampTextWithInlineSuffix(displayDescription, {
+				maxWidthPx: descriptionWidth,
+				maxLines: DESCRIPTION_COLLAPSE_LINES,
+				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+				measureText: measure,
+			}),
+			expanded: clampTextWithInlineSuffix(displayDescription, {
+				maxWidthPx: descriptionWidth,
+				maxLines: DESCRIPTION_EXPANDED_MAX_LINES,
+				suffix: DESCRIPTION_COLLAPSE_SUFFIX,
+				measureText: measure,
+			}),
+		};
 	}, [descriptionFont, descriptionWidth, displayDescription]);
 
 	const isCreditLimit = isCardCreditLimitError(sessionSummary);
@@ -652,46 +662,60 @@ export function BoardCard({
 											margin: "2px 0 0",
 										}}
 									>
-										{isDescriptionExpanded || !descriptionDisplay.isTruncated
-											? displayDescription
-											: descriptionDisplay.text}
-										{descriptionDisplay.isTruncated ? (
-											isDescriptionExpanded ? (
+										{(() => {
+											const activeDisplay = isDescriptionExpanded
+												? descriptionDisplay.expanded
+												: descriptionDisplay.collapsed;
+											const showFull = isDescriptionExpanded && !activeDisplay.isTruncated;
+											return (
 												<>
-													{" "}
-													<button
-														type="button"
-														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-														aria-expanded={isDescriptionExpanded}
-														aria-label="Collapse task description"
-														onMouseDown={stopEvent}
-														onClick={(event) => {
-															stopEvent(event);
-															setIsDescriptionExpanded(false);
-														}}
-													>
-														{DESCRIPTION_COLLAPSE_LABEL}
-													</button>
+													{showFull || !activeDisplay.isTruncated
+														? displayDescription
+														: activeDisplay.text}
+													{activeDisplay.isTruncated ? (
+														<>
+															{"… "}
+															<button
+																type="button"
+																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+																aria-expanded={isDescriptionExpanded}
+																aria-label={
+																	isDescriptionExpanded
+																		? "Collapse task description"
+																		: "Expand task description"
+																}
+																onMouseDown={stopEvent}
+																onClick={(event) => {
+																	stopEvent(event);
+																	setIsDescriptionExpanded(!isDescriptionExpanded);
+																}}
+															>
+																{isDescriptionExpanded
+																	? DESCRIPTION_COLLAPSE_LABEL
+																	: DESCRIPTION_EXPAND_LABEL}
+															</button>
+														</>
+													) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (
+														<>
+															{" "}
+															<button
+																type="button"
+																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+																aria-expanded={isDescriptionExpanded}
+																aria-label="Collapse task description"
+																onMouseDown={stopEvent}
+																onClick={(event) => {
+																	stopEvent(event);
+																	setIsDescriptionExpanded(false);
+																}}
+															>
+																{DESCRIPTION_COLLAPSE_LABEL}
+															</button>
+														</>
+													) : null}
 												</>
-											) : (
-												<>
-													{"… "}
-													<button
-														type="button"
-														className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-														aria-expanded={isDescriptionExpanded}
-														aria-label="Expand task description"
-														onMouseDown={stopEvent}
-														onClick={(event) => {
-															stopEvent(event);
-															setIsDescriptionExpanded(true);
-														}}
-													>
-														{DESCRIPTION_EXPAND_LABEL}
-													</button>
-												</>
-											)
-										) : null}
+											);
+										})()}
 									</p>
 								</div>
 							) : null}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -466,6 +466,11 @@ export function BoardCard({
 		return parts.length > 0 ? parts.join(" · ") : null;
 	}, [agentOverrideLabel, modelOverrideLabel]);
 
+	const activeDescriptionDisplay = isDescriptionExpanded
+		? descriptionDisplay.expanded
+		: descriptionDisplay.collapsed;
+	const showFullDescription = isDescriptionExpanded && !activeDescriptionDisplay.isTruncated;
+
 	return (
 		<Draggable draggableId={card.id} index={index} isDragDisabled={false}>
 			{(provided, snapshot) => {
@@ -662,60 +667,50 @@ export function BoardCard({
 											margin: "2px 0 0",
 										}}
 									>
-										{(() => {
-											const activeDisplay = isDescriptionExpanded
-												? descriptionDisplay.expanded
-												: descriptionDisplay.collapsed;
-											const showFull = isDescriptionExpanded && !activeDisplay.isTruncated;
-											return (
-												<>
-													{showFull || !activeDisplay.isTruncated
-														? displayDescription
-														: activeDisplay.text}
-													{activeDisplay.isTruncated ? (
-														<>
-															{"… "}
-															<button
-																type="button"
-																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-																aria-expanded={isDescriptionExpanded}
-																aria-label={
-																	isDescriptionExpanded
-																		? "Collapse task description"
-																		: "Expand task description"
-																}
-																onMouseDown={stopEvent}
-																onClick={(event) => {
-																	stopEvent(event);
-																	setIsDescriptionExpanded(!isDescriptionExpanded);
-																}}
-															>
-																{isDescriptionExpanded
-																	? DESCRIPTION_COLLAPSE_LABEL
-																	: DESCRIPTION_EXPAND_LABEL}
-															</button>
-														</>
-													) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (
-														<>
-															{" "}
-															<button
-																type="button"
-																className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
-																aria-expanded={isDescriptionExpanded}
-																aria-label="Collapse task description"
-																onMouseDown={stopEvent}
-																onClick={(event) => {
-																	stopEvent(event);
-																	setIsDescriptionExpanded(false);
-																}}
-															>
-																{DESCRIPTION_COLLAPSE_LABEL}
-															</button>
-														</>
-													) : null}
-												</>
-											);
-										})()}
+										{showFullDescription || !activeDescriptionDisplay.isTruncated
+											? displayDescription
+											: activeDescriptionDisplay.text}
+										{activeDescriptionDisplay.isTruncated ? (
+											<>
+												{"… "}
+												<button
+													type="button"
+													className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+													aria-expanded={isDescriptionExpanded}
+													aria-label={
+														isDescriptionExpanded
+															? "Collapse task description"
+															: "Expand task description"
+													}
+													onMouseDown={stopEvent}
+													onClick={(event) => {
+														stopEvent(event);
+														setIsDescriptionExpanded(!isDescriptionExpanded);
+													}}
+												>
+													{isDescriptionExpanded
+														? DESCRIPTION_COLLAPSE_LABEL
+														: DESCRIPTION_EXPAND_LABEL}
+												</button>
+											</>
+										) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (
+											<>
+												{" "}
+												<button
+													type="button"
+													className="inline cursor-pointer rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [color:inherit] [font:inherit]"
+													aria-expanded={isDescriptionExpanded}
+													aria-label="Collapse task description"
+													onMouseDown={stopEvent}
+													onClick={(event) => {
+														stopEvent(event);
+														setIsDescriptionExpanded(false);
+													}}
+												>
+													{DESCRIPTION_COLLAPSE_LABEL}
+												</button>
+											</>
+										) : null}
 									</p>
 								</div>
 							) : null}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -675,7 +675,7 @@ export function BoardCard({
 												{"… "}
 												<button
 													type="button"
-													className="inline cursor-pointer rounded-sm text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
+													className="inline cursor-pointer rounded-sm text-text-tertiary hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
 													aria-expanded={isDescriptionExpanded}
 													aria-label={
 														isDescriptionExpanded
@@ -698,7 +698,7 @@ export function BoardCard({
 												{" "}
 												<button
 													type="button"
-													className="inline cursor-pointer rounded-sm text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
+													className="inline cursor-pointer rounded-sm text-text-tertiary hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent [font:inherit]"
 													aria-expanded={isDescriptionExpanded}
 													aria-label="Collapse task description"
 													onMouseDown={stopEvent}


### PR DESCRIPTION
- Truncates session activity text on board card to 1 line
- Removes "See More" and "Less" texts 

This helps:
- Provide consistent heights across cards
- Prevent resizing and layout shifts (especially important for components that have buttons aka the "See More" and "Less" buttons)

<img width="399" height="577" alt="Screenshot 2026-04-15 at 11 33 23 AM" src="https://github.com/user-attachments/assets/20b61d71-a550-4411-b9e9-806cff30af77" />
