### PR TITLE
Add Support For Multi Line Comments

### DIFF
--- a/web-ui/src/components/detail-panels/diff-selection-toolbar.test.ts
+++ b/web-ui/src/components/detail-panels/diff-selection-toolbar.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { type DiffHighlightRange, formatSnippetReference } from "./diff-selection-toolbar";
+
+describe("formatSnippetReference", () => {
+	it("formats a single-line range with file:line", () => {
+		const range: DiffHighlightRange = {
+			filePath: "src/utils/foo.ts",
+			startLine: 5,
+			endLine: 5,
+			text: "const x = 1;",
+		};
+		expect(formatSnippetReference(range)).toBe("src/utils/foo.ts:5\n```\nconst x = 1;\n```");
+	});
+
+	it("formats a multi-line range with file:start-end", () => {
+		const range: DiffHighlightRange = {
+			filePath: "src/utils/foo.ts",
+			startLine: 5,
+			endLine: 12,
+			text: "const x = 1;\nconst y = 2;",
+		};
+		expect(formatSnippetReference(range)).toBe("src/utils/foo.ts:5-12\n```\nconst x = 1;\nconst y = 2;\n```");
+	});
+
+	it("handles empty text gracefully", () => {
+		const range: DiffHighlightRange = {
+			filePath: "index.ts",
+			startLine: 1,
+			endLine: 1,
+			text: "",
+		};
+		expect(formatSnippetReference(range)).toBe("index.ts:1\n```\n\n```");
+	});
+
+	it("preserves file paths with deep nesting", () => {
+		const range: DiffHighlightRange = {
+			filePath: "web-ui/src/components/detail-panels/diff-viewer-panel.tsx",
+			startLine: 100,
+			endLine: 150,
+			text: "// some code",
+		};
+		const result = formatSnippetReference(range);
+		expect(result).toContain("web-ui/src/components/detail-panels/diff-viewer-panel.tsx:100-150");
+	});
+});

--- a/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
+++ b/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
@@ -29,7 +29,7 @@ export function formatSnippetReference(range: DiffHighlightRange): string {
 
 /**
  * Inline comment box rendered directly below the last highlighted diff row.
- * "Ask Cline" sends the snippet reference + comment to the agent.
+ * "Send" posts the snippet reference + user comment to the agent terminal.
  * "Cancel" (or Escape) dismisses the highlight and closes the box.
  */
 export function DiffHighlightCommentBox({
@@ -81,9 +81,9 @@ export function DiffHighlightCommentBox({
 				value={text}
 				onChange={(e) => setText(e.target.value)}
 				onKeyDown={handleKeyDown}
-				placeholder="Ask about this code..."
+				placeholder="Comment on this code..."
 				rows={2}
-				className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none"
+				className="w-full rounded-md border-none bg-surface-2 px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-border-bright resize-none"
 			/>
 			<div className="kb-diff-highlight-comment-actions">
 				<Button variant="ghost" size="sm" onClick={onCancel}>
@@ -96,7 +96,7 @@ export function DiffHighlightCommentBox({
 					icon={<Send size={14} />}
 					onClick={handleSend}
 				>
-					Ask Cline
+					Send
 				</Button>
 			</div>
 		</div>

--- a/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
+++ b/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
@@ -1,0 +1,172 @@
+import { MessageSquarePlus, Send, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export interface DiffHighlightRange {
+	filePath: string;
+	startLine: number;
+	endLine: number;
+	/** The text of every highlighted line joined with newlines. */
+	text: string;
+}
+
+/**
+ * Format a highlight range into the snippet reference sent to the agent.
+ * Example output:
+ *   src/utils/foo.ts:5-12
+ *   ```
+ *   <code lines>
+ *   ```
+ */
+function formatSnippetReference(range: DiffHighlightRange): string {
+	const loc =
+		range.startLine === range.endLine
+			? `${range.filePath}:${range.startLine}`
+			: `${range.filePath}:${range.startLine}-${range.endLine}`;
+	return `${loc}\n\`\`\`\n${range.text}\n\`\`\``;
+}
+
+export function DiffSelectionToolbar({
+	range,
+	anchorTop,
+	anchorLeft,
+	onAddToChat,
+	onSendToAgent,
+	onDismiss,
+}: {
+	range: DiffHighlightRange;
+	/** Top offset in px relative to the positioned scroll container. */
+	anchorTop: number;
+	/** Left offset in px relative to the positioned scroll container. */
+	anchorLeft: number;
+	onAddToChat: (formatted: string) => void;
+	onSendToAgent?: (formatted: string) => void;
+	onDismiss: () => void;
+}): React.ReactElement {
+	const [showAskDialog, setShowAskDialog] = useState(false);
+	const [askText, setAskText] = useState("");
+	const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		if (showAskDialog) {
+			// Small delay so the dialog renders before focusing
+			requestAnimationFrame(() => textAreaRef.current?.focus());
+		}
+	}, [showAskDialog]);
+
+	const handleAddToChat = useCallback(() => {
+		onAddToChat(formatSnippetReference(range));
+		onDismiss();
+	}, [onAddToChat, onDismiss, range]);
+
+	const handleSubmitAsk = useCallback(() => {
+		const comment = askText.trim();
+		if (comment.length === 0 || !onSendToAgent) {
+			return;
+		}
+		const snippet = formatSnippetReference(range);
+		const message = `${snippet}\n\n${comment}`;
+		onSendToAgent(message);
+		setShowAskDialog(false);
+		setAskText("");
+		onDismiss();
+	}, [askText, onDismiss, onSendToAgent, range]);
+
+	const handleCancelAsk = useCallback(() => {
+		setShowAskDialog(false);
+		setAskText("");
+	}, []);
+
+	const handleKeyDown = useCallback(
+		(event: React.KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				event.stopPropagation();
+				handleCancelAsk();
+				return;
+			}
+			if (event.key === "Enter" && !event.shiftKey) {
+				event.preventDefault();
+				handleSubmitAsk();
+			}
+		},
+		[handleCancelAsk, handleSubmitAsk],
+	);
+
+	if (showAskDialog) {
+		const lineRef =
+			range.startLine === range.endLine
+				? `${range.filePath}:${range.startLine}`
+				: `${range.filePath}:${range.startLine}-${range.endLine}`;
+
+		return (
+			<div
+				className="kb-diff-ask-dialog-backdrop"
+				onMouseDown={(e) => {
+					if (e.target === e.currentTarget) {
+						handleCancelAsk();
+					}
+				}}
+			>
+				<div className="kb-diff-ask-dialog">
+					<div className="kb-diff-ask-dialog-header">{lineRef}</div>
+					<div className="kb-diff-ask-dialog-code">{range.text}</div>
+					<div className="px-3 pb-2">
+						<textarea
+							ref={textAreaRef}
+							value={askText}
+							onChange={(e) => setAskText(e.target.value)}
+							onKeyDown={handleKeyDown}
+							placeholder="Ask about this code..."
+							rows={2}
+							className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none"
+						/>
+					</div>
+					<div className="kb-diff-ask-dialog-footer">
+						<Button variant="ghost" size="sm" onClick={handleCancelAsk}>
+							Cancel
+						</Button>
+						<Button
+							variant="primary"
+							size="sm"
+							disabled={askText.trim().length === 0}
+							icon={<Send size={14} />}
+							onClick={handleSubmitAsk}
+						>
+							Submit
+						</Button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="kb-diff-selection-toolbar"
+			style={{
+				top: anchorTop,
+				left: anchorLeft,
+				transform: "translateX(-50%)",
+			}}
+		>
+			<Button variant="ghost" size="sm" icon={<MessageSquarePlus size={14} />} onClick={handleAddToChat}>
+				Add to Chat
+			</Button>
+			{onSendToAgent ? (
+				<Button variant="ghost" size="sm" icon={<Send size={14} />} onClick={() => setShowAskDialog(true)}>
+					Ask Cline
+				</Button>
+			) : null}
+			<Button
+				variant="ghost"
+				size="sm"
+				icon={<X size={14} />}
+				onClick={onDismiss}
+				aria-label="Dismiss"
+				className="!px-1"
+			/>
+		</div>
+	);
+}

--- a/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
+++ b/web-ui/src/components/detail-panels/diff-selection-toolbar.tsx
@@ -1,4 +1,4 @@
-import { MessageSquarePlus, Send, X } from "lucide-react";
+import { Send } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -19,7 +19,7 @@ export interface DiffHighlightRange {
  *   <code lines>
  *   ```
  */
-function formatSnippetReference(range: DiffHighlightRange): string {
+export function formatSnippetReference(range: DiffHighlightRange): string {
 	const loc =
 		range.startLine === range.endLine
 			? `${range.filePath}:${range.startLine}`
@@ -27,146 +27,78 @@ function formatSnippetReference(range: DiffHighlightRange): string {
 	return `${loc}\n\`\`\`\n${range.text}\n\`\`\``;
 }
 
-export function DiffSelectionToolbar({
+/**
+ * Inline comment box rendered directly below the last highlighted diff row.
+ * "Ask Cline" sends the snippet reference + comment to the agent.
+ * "Cancel" (or Escape) dismisses the highlight and closes the box.
+ */
+export function DiffHighlightCommentBox({
 	range,
-	anchorTop,
-	anchorLeft,
-	onAddToChat,
-	onSendToAgent,
-	onDismiss,
+	onSend,
+	onCancel,
 }: {
 	range: DiffHighlightRange;
-	/** Top offset in px relative to the positioned scroll container. */
-	anchorTop: number;
-	/** Left offset in px relative to the positioned scroll container. */
-	anchorLeft: number;
-	onAddToChat: (formatted: string) => void;
-	onSendToAgent?: (formatted: string) => void;
-	onDismiss: () => void;
+	onSend: (formatted: string) => void;
+	onCancel: () => void;
 }): React.ReactElement {
-	const [showAskDialog, setShowAskDialog] = useState(false);
-	const [askText, setAskText] = useState("");
+	const [text, setText] = useState("");
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
 	useEffect(() => {
-		if (showAskDialog) {
-			// Small delay so the dialog renders before focusing
-			requestAnimationFrame(() => textAreaRef.current?.focus());
-		}
-	}, [showAskDialog]);
+		requestAnimationFrame(() => textAreaRef.current?.focus());
+	}, []);
 
-	const handleAddToChat = useCallback(() => {
-		onAddToChat(formatSnippetReference(range));
-		onDismiss();
-	}, [onAddToChat, onDismiss, range]);
-
-	const handleSubmitAsk = useCallback(() => {
-		const comment = askText.trim();
-		if (comment.length === 0 || !onSendToAgent) {
+	const handleSend = useCallback(() => {
+		const comment = text.trim();
+		if (comment.length === 0) {
 			return;
 		}
 		const snippet = formatSnippetReference(range);
 		const message = `${snippet}\n\n${comment}`;
-		onSendToAgent(message);
-		setShowAskDialog(false);
-		setAskText("");
-		onDismiss();
-	}, [askText, onDismiss, onSendToAgent, range]);
-
-	const handleCancelAsk = useCallback(() => {
-		setShowAskDialog(false);
-		setAskText("");
-	}, []);
+		onSend(message);
+	}, [onSend, range, text]);
 
 	const handleKeyDown = useCallback(
 		(event: React.KeyboardEvent) => {
 			if (event.key === "Escape") {
 				event.preventDefault();
 				event.stopPropagation();
-				handleCancelAsk();
+				onCancel();
 				return;
 			}
 			if (event.key === "Enter" && !event.shiftKey) {
 				event.preventDefault();
-				handleSubmitAsk();
+				handleSend();
 			}
 		},
-		[handleCancelAsk, handleSubmitAsk],
+		[handleSend, onCancel],
 	);
 
-	if (showAskDialog) {
-		const lineRef =
-			range.startLine === range.endLine
-				? `${range.filePath}:${range.startLine}`
-				: `${range.filePath}:${range.startLine}-${range.endLine}`;
-
-		return (
-			<div
-				className="kb-diff-ask-dialog-backdrop"
-				onMouseDown={(e) => {
-					if (e.target === e.currentTarget) {
-						handleCancelAsk();
-					}
-				}}
-			>
-				<div className="kb-diff-ask-dialog">
-					<div className="kb-diff-ask-dialog-header">{lineRef}</div>
-					<div className="kb-diff-ask-dialog-code">{range.text}</div>
-					<div className="px-3 pb-2">
-						<textarea
-							ref={textAreaRef}
-							value={askText}
-							onChange={(e) => setAskText(e.target.value)}
-							onKeyDown={handleKeyDown}
-							placeholder="Ask about this code..."
-							rows={2}
-							className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none"
-						/>
-					</div>
-					<div className="kb-diff-ask-dialog-footer">
-						<Button variant="ghost" size="sm" onClick={handleCancelAsk}>
-							Cancel
-						</Button>
-						<Button
-							variant="primary"
-							size="sm"
-							disabled={askText.trim().length === 0}
-							icon={<Send size={14} />}
-							onClick={handleSubmitAsk}
-						>
-							Submit
-						</Button>
-					</div>
-				</div>
-			</div>
-		);
-	}
-
 	return (
-		<div
-			className="kb-diff-selection-toolbar"
-			style={{
-				top: anchorTop,
-				left: anchorLeft,
-				transform: "translateX(-50%)",
-			}}
-		>
-			<Button variant="ghost" size="sm" icon={<MessageSquarePlus size={14} />} onClick={handleAddToChat}>
-				Add to Chat
-			</Button>
-			{onSendToAgent ? (
-				<Button variant="ghost" size="sm" icon={<Send size={14} />} onClick={() => setShowAskDialog(true)}>
+		<div className="kb-diff-highlight-comment-box" onClick={(e) => e.stopPropagation()}>
+			<textarea
+				ref={textAreaRef}
+				value={text}
+				onChange={(e) => setText(e.target.value)}
+				onKeyDown={handleKeyDown}
+				placeholder="Ask about this code..."
+				rows={2}
+				className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none resize-none"
+			/>
+			<div className="kb-diff-highlight-comment-actions">
+				<Button variant="ghost" size="sm" onClick={onCancel}>
+					Cancel
+				</Button>
+				<Button
+					variant="primary"
+					size="sm"
+					disabled={text.trim().length === 0}
+					icon={<Send size={14} />}
+					onClick={handleSend}
+				>
 					Ask Cline
 				</Button>
-			) : null}
-			<Button
-				variant="ghost"
-				size="sm"
-				icon={<X size={14} />}
-				onClick={onDismiss}
-				aria-label="Dismiss"
-				className="!px-1"
-			/>
+			</div>
 		</div>
 	);
 }

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -2,7 +2,11 @@ import { ChevronDown, ChevronRight, Command, CornerDownLeft, MessageSquare, X } 
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { type DiffHighlightRange, DiffSelectionToolbar } from "@/components/detail-panels/diff-selection-toolbar";
+import {
+	DiffHighlightCommentBox,
+	type DiffHighlightRange,
+	formatSnippetReference,
+} from "@/components/detail-panels/diff-selection-toolbar";
 import {
 	buildDisplayItems,
 	buildHighlightedLineMap,
@@ -146,20 +150,28 @@ function UnifiedDiff({
 	oldText,
 	newText,
 	comments,
-	onAddComment,
+	_onAddComment,
 	onUpdateComment,
 	onDeleteComment,
 	highlightedKeys,
 	onLineNumberClick,
+	lastHighlightedRowKey,
+	highlightRange,
+	onSendHighlightComment,
+	onDismissHighlight,
 }: {
 	path: string;
 	oldText: string | null | undefined;
 	newText: string;
 	comments: Map<string, DiffLineComment>;
-	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
+	_onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
 	highlightedKeys?: ReadonlySet<string>;
+	lastHighlightedRowKey?: string | null;
+	highlightRange?: DiffHighlightRange | null;
+	onSendHighlightComment?: (formatted: string) => void;
+	onDismissHighlight?: () => void;
 	onLineNumberClick?: (
 		filePath: string,
 		lineNumber: number,
@@ -260,6 +272,15 @@ function UnifiedDiff({
 						comment={existingComment}
 						onChange={(text) => onUpdateComment(row.lineNumber!, row.variant, text)}
 						onDelete={() => onDeleteComment(row.lineNumber!, row.variant)}
+					/>
+				) : null}
+				{rowKey === lastHighlightedRowKey && highlightRange && onSendHighlightComment && onDismissHighlight ? (
+					<DiffHighlightCommentBox
+						range={highlightRange}
+						onSend={(formatted) => {
+							onSendHighlightComment(formatted);
+						}}
+						onCancel={onDismissHighlight}
 					/>
 				) : null}
 			</div>
@@ -797,7 +818,6 @@ export function DiffViewerPanel({
 
 	// --- Line-number highlight state ---
 	const [lineHighlight, setLineHighlight] = useState<LineHighlightState | null>(null);
-	const [toolbarPos, setToolbarPos] = useState<{ top: number; left: number } | null>(null);
 
 	const highlightedKeys = useMemo(() => {
 		if (!lineHighlight) {
@@ -861,63 +881,14 @@ export function DiffViewerPanel({
 		[groupedByPath, lineHighlight],
 	);
 
-	// Position toolbar below the last highlighted row
-	useEffect(() => {
+	/** The key identifying the last row in the highlight — the comment box renders after this row. */
+	const lastHighlightedRowKey = useMemo(() => {
 		if (!lineHighlight || lineHighlight.rows.length === 0) {
-			setToolbarPos(null);
-			return;
+			return null;
 		}
-		const container = scrollContainerRef.current;
-		if (!container) {
-			return;
-		}
-		// Find the last highlighted row's DOM element via data attribute
-		const lastRow = lineHighlight.rows[lineHighlight.rows.length - 1]!;
-		const selector = `[data-diff-row-id="${rowIdKey(lastRow.filePath, lastRow.lineNumber, lastRow.variant)}"]`;
-		const el = container.querySelector(selector);
-		if (!el) {
-			return;
-		}
-		const containerRect = container.getBoundingClientRect();
-		const elRect = el.getBoundingClientRect();
-		setToolbarPos({
-			top: elRect.bottom - containerRect.top + container.scrollTop + 4,
-			left: elRect.left - containerRect.left + elRect.width / 2,
-		});
+		const last = lineHighlight.rows[lineHighlight.rows.length - 1]!;
+		return rowIdKey(last.filePath, last.lineNumber, last.variant);
 	}, [lineHighlight]);
-
-	// Also handle native text selection → show toolbar
-	const handleMouseUp = useCallback(() => {
-		if (!onAddToTerminal && !onSendToTerminal) {
-			return;
-		}
-		requestAnimationFrame(() => {
-			const sel = window.getSelection();
-			if (!sel || sel.isCollapsed || lineHighlight) {
-				return;
-			}
-			const text = sel.toString().trim();
-			if (text.length === 0) {
-				return;
-			}
-			const container = scrollContainerRef.current;
-			if (!container) {
-				return;
-			}
-			const range = sel.getRangeAt(0);
-			const rect = range.getBoundingClientRect();
-			const containerRect = container.getBoundingClientRect();
-			// Build a synthetic highlight from the text selection
-			setLineHighlight({
-				anchor: { filePath: "", lineNumber: 0, variant: "context", text },
-				rows: [{ filePath: "", lineNumber: 0, variant: "context", text }],
-			});
-			setToolbarPos({
-				top: rect.bottom - containerRect.top + container.scrollTop + 4,
-				left: rect.left - containerRect.left + rect.width / 2,
-			});
-		});
-	}, [lineHighlight, onAddToTerminal, onSendToTerminal]);
 
 	const highlightRange: DiffHighlightRange | null = useMemo(() => {
 		if (!lineHighlight || lineHighlight.rows.length === 0) {
@@ -933,7 +904,6 @@ export function DiffViewerPanel({
 
 	const handleDismissHighlight = useCallback(() => {
 		setLineHighlight(null);
-		setToolbarPos(null);
 		window.getSelection()?.removeAllRanges();
 	}, []);
 
@@ -950,20 +920,6 @@ export function DiffViewerPanel({
 		document.addEventListener("keydown", handleKey);
 		return () => document.removeEventListener("keydown", handleKey);
 	}, [handleDismissHighlight, lineHighlight]);
-
-	// Dismiss highlight when native selection collapses
-	useEffect(() => {
-		const handleSelectionChange = () => {
-			const sel = window.getSelection();
-			if (sel?.isCollapsed && lineHighlight && lineHighlight.anchor.filePath === "") {
-				// This was a text-selection-based highlight
-				setLineHighlight(null);
-				setToolbarPos(null);
-			}
-		};
-		document.addEventListener("selectionchange", handleSelectionChange);
-		return () => document.removeEventListener("selectionchange", handleSelectionChange);
-	}, [lineHighlight]);
 
 	const hasAnyComments = comments.size > 0;
 	const nonEmptyCount = nonEmptyComments.length;
@@ -1040,9 +996,7 @@ export function DiffViewerPanel({
 					<div
 						ref={scrollContainerRef}
 						onScroll={handleDiffScroll}
-						onMouseUp={handleMouseUp}
 						style={{
-							position: "relative",
 							flex: "1 1 0",
 							minHeight: 0,
 							overflowY: "auto",
@@ -1050,26 +1004,6 @@ export function DiffViewerPanel({
 							padding: "0 12px 12px",
 						}}
 					>
-						{highlightRange && toolbarPos && (onAddToTerminal || onSendToTerminal) ? (
-							<DiffSelectionToolbar
-								range={highlightRange}
-								anchorTop={toolbarPos.top}
-								anchorLeft={toolbarPos.left}
-								onAddToChat={(formatted) => {
-									onAddToTerminal?.(formatted);
-									handleDismissHighlight();
-								}}
-								onSendToAgent={
-									onSendToTerminal
-										? (formatted) => {
-												onSendToTerminal(formatted);
-												handleDismissHighlight();
-											}
-										: undefined
-								}
-								onDismiss={handleDismissHighlight}
-							/>
-						) : null}
 						{groupedByPath.map((group) => {
 							const isExpanded = expandedPaths[group.path] ?? true;
 							const hasBinaryEntry = group.entries.some((entry) => entry.isBinary);
@@ -1148,7 +1082,7 @@ export function DiffViewerPanel({
 															oldText={entry.oldText}
 															newText={entry.newText}
 															comments={comments}
-															onAddComment={(lineNumber, lineText, variant) =>
+															_onAddComment={(lineNumber, lineText, variant) =>
 																handleAddComment(group.path, lineNumber, lineText, variant)
 															}
 															onUpdateComment={(lineNumber, variant, text) =>
@@ -1159,6 +1093,17 @@ export function DiffViewerPanel({
 															}
 															highlightedKeys={highlightedKeys}
 															onLineNumberClick={handleLineNumberClick}
+															lastHighlightedRowKey={lastHighlightedRowKey}
+															highlightRange={highlightRange}
+															onSendHighlightComment={
+																onSendToTerminal
+																	? (f) => {
+																			onSendToTerminal(f);
+																			handleDismissHighlight();
+																		}
+																	: undefined
+															}
+															onDismissHighlight={handleDismissHighlight}
 														/>
 													)}
 												</div>

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -394,7 +394,6 @@ function SplitDiff({
 	oldText: string | null | undefined;
 	newText: string;
 	comments: Map<string, DiffLineComment>;
-	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
 }): React.ReactElement {
@@ -850,10 +849,10 @@ export function DiffViewerPanel({
 					return;
 				}
 				const anchor = lineHighlight.anchor;
-				const anchorKey = rowIdKey(anchor.filePath, anchor.lineNumber, anchor.variant);
-				const clickedKey = rowIdKey(filePath, lineNumber, variant);
-				const anchorIdx = allRows.findIndex((r) => rowIdKey(r.filePath, r.lineNumber, r.variant) === anchorKey);
-				const clickedIdx = allRows.findIndex((r) => rowIdKey(r.filePath, r.lineNumber, r.variant) === clickedKey);
+				const anchorIdx = allRows.findIndex(
+					(r) => r.lineNumber === anchor.lineNumber && r.variant === anchor.variant,
+				);
+				const clickedIdx = allRows.findIndex((r) => r.lineNumber === lineNumber && r.variant === variant);
 				if (anchorIdx === -1 || clickedIdx === -1) {
 					return;
 				}
@@ -1059,9 +1058,6 @@ export function DiffViewerPanel({
 															oldText={entry.oldText}
 															newText={entry.newText}
 															comments={comments}
-															onAddComment={(lineNumber, lineText, variant) =>
-																handleAddComment(group.path, lineNumber, lineText, variant)
-															}
 															onUpdateComment={(lineNumber, variant, text) =>
 																handleUpdateComment(group.path, lineNumber, variant, text)
 															}

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, Command, CornerDownLeft, MessageSquare, X } 
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { type DiffHighlightRange, DiffSelectionToolbar } from "@/components/detail-panels/diff-selection-toolbar";
 import {
 	buildDisplayItems,
 	buildHighlightedLineMap,
@@ -20,6 +21,26 @@ import type { RuntimeWorkspaceFileChange } from "@/runtime/types";
 import { buildFileTree } from "@/utils/file-tree";
 import { isBinaryFilePath } from "@/utils/is-binary-file-path";
 import { isMacPlatform } from "@/utils/platform";
+
+/** Identifies a single row for highlight tracking. */
+interface RowIdentity {
+	filePath: string;
+	lineNumber: number;
+	variant: "added" | "removed" | "context";
+	text: string;
+}
+
+/** State for the current line-number-based highlight. */
+interface LineHighlightState {
+	/** The row that was clicked first (anchor). */
+	anchor: RowIdentity;
+	/** All rows currently in the highlighted range (inclusive). */
+	rows: RowIdentity[];
+}
+
+function rowIdKey(filePath: string, lineNumber: number, variant: string): string {
+	return `${filePath}:${variant}:${lineNumber}`;
+}
 
 interface FileDiffGroup {
 	path: string;
@@ -128,6 +149,8 @@ function UnifiedDiff({
 	onAddComment,
 	onUpdateComment,
 	onDeleteComment,
+	highlightedKeys,
+	onLineNumberClick,
 }: {
 	path: string;
 	oldText: string | null | undefined;
@@ -136,6 +159,14 @@ function UnifiedDiff({
 	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
+	highlightedKeys?: ReadonlySet<string>;
+	onLineNumberClick?: (
+		filePath: string,
+		lineNumber: number,
+		variant: "added" | "removed" | "context",
+		text: string,
+		shiftKey: boolean,
+	) => void;
 }): React.ReactElement {
 	const { expandedBlocks, expandTop, expandBottom, expandAll } = useIncrementalExpand();
 	const prismLanguage = useMemo(() => resolvePrismLanguage(path), [path]);
@@ -161,8 +192,14 @@ function UnifiedDiff({
 				: row.variant === "removed"
 					? "kb-diff-row kb-diff-row-removed"
 					: "kb-diff-row kb-diff-row-context";
-		const rowClass = hasComment ? `${baseClass} kb-diff-row-commented` : baseClass;
-		const canClickRow = row.lineNumber != null && !hasComment;
+		const isHighlighted = row.lineNumber != null && highlightedKeys?.has(rowIdKey(path, row.lineNumber, row.variant));
+		const rowClass = [
+			baseClass,
+			hasComment ? "kb-diff-row-commented" : "",
+			isHighlighted ? "kb-diff-row-highlighted" : "",
+		]
+			.filter(Boolean)
+			.join(" ");
 		const highlightedLineHtml =
 			row.lineNumber == null
 				? null
@@ -170,17 +207,24 @@ function UnifiedDiff({
 					? (highlightedOldByLine.get(row.lineNumber) ?? null)
 					: (highlightedNewByLine.get(row.lineNumber) ?? null);
 
-		const handleRowClick =
-			row.lineNumber != null && !hasComment
-				? () => {
-						onAddComment(row.lineNumber!, row.text, row.variant);
-					}
-				: undefined;
-
 		return (
-			<div key={row.key}>
-				<div className={rowClass} style={canClickRow ? undefined : { cursor: "default" }} onClick={handleRowClick}>
-					<span className="kb-diff-line-number" style={{ color: "var(--color-text-tertiary)" }}>
+			<div
+				key={row.key}
+				data-diff-row-id={row.lineNumber != null ? rowIdKey(path, row.lineNumber, row.variant) : undefined}
+			>
+				<div className={rowClass}>
+					<span
+						className={`kb-diff-line-number${onLineNumberClick && row.lineNumber != null ? " kb-diff-line-number-selectable" : ""}`}
+						style={{ color: "var(--color-text-tertiary)" }}
+						onClick={
+							onLineNumberClick && row.lineNumber != null
+								? (e) => {
+										e.stopPropagation();
+										onLineNumberClick(path, row.lineNumber!, row.variant, row.text, e.shiftKey);
+									}
+								: undefined
+						}
+					>
 						<span className="kb-diff-line-number-text">{row.lineNumber ?? ""}</span>
 						{row.lineNumber != null ? (
 							<span
@@ -331,6 +375,8 @@ function SplitDiff({
 	onAddComment,
 	onUpdateComment,
 	onDeleteComment,
+	highlightedKeys,
+	onLineNumberClick,
 }: {
 	path: string;
 	oldText: string | null | undefined;
@@ -339,6 +385,14 @@ function SplitDiff({
 	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
+	highlightedKeys?: ReadonlySet<string>;
+	onLineNumberClick?: (
+		filePath: string,
+		lineNumber: number,
+		variant: "added" | "removed" | "context",
+		text: string,
+		shiftKey: boolean,
+	) => void;
 }): React.ReactElement {
 	const { expandedBlocks, expandTop, expandBottom, expandAll } = useIncrementalExpand();
 	const prismLanguage = useMemo(() => resolvePrismLanguage(path), [path]);
@@ -752,6 +806,176 @@ export function DiffViewerPanel({
 		onCommentsChange(new Map());
 	}, [onCommentsChange]);
 
+	// --- Line-number highlight state ---
+	const [lineHighlight, setLineHighlight] = useState<LineHighlightState | null>(null);
+	const [toolbarPos, setToolbarPos] = useState<{ top: number; left: number } | null>(null);
+
+	const highlightedKeys = useMemo(() => {
+		if (!lineHighlight) {
+			return undefined;
+		}
+		const keys = new Set<string>();
+		for (const r of lineHighlight.rows) {
+			keys.add(rowIdKey(r.filePath, r.lineNumber, r.variant));
+		}
+		return keys;
+	}, [lineHighlight]);
+
+	const handleLineNumberClick = useCallback(
+		(
+			filePath: string,
+			lineNumber: number,
+			variant: "added" | "removed" | "context",
+			text: string,
+			shiftKey: boolean,
+		) => {
+			const clickedRow: RowIdentity = { filePath, lineNumber, variant, text };
+			if (
+				shiftKey &&
+				lineHighlight &&
+				lineHighlight.anchor.filePath === filePath &&
+				lineHighlight.anchor.variant === variant
+			) {
+				// Extend range from anchor to clicked line — need all rows from the diff
+				// We already track the anchor, so we look up all rows from the grouped data
+				const group = groupedByPath.find((g) => g.path === filePath);
+				if (!group) {
+					return;
+				}
+				// Build all rows for this file
+				const allRows: RowIdentity[] = [];
+				for (const entry of group.entries) {
+					if (entry.isBinary) {
+						continue;
+					}
+					const diffRows = buildUnifiedDiffRows(entry.oldText, entry.newText);
+					for (const r of diffRows) {
+						if (r.lineNumber != null) {
+							allRows.push({ filePath, lineNumber: r.lineNumber, variant: r.variant, text: r.text });
+						}
+					}
+				}
+				const anchor = lineHighlight.anchor;
+				const startLine = Math.min(anchor.lineNumber, lineNumber);
+				const endLine = Math.max(anchor.lineNumber, lineNumber);
+				const rangeRows = allRows.filter(
+					(r) => r.variant === variant && r.lineNumber >= startLine && r.lineNumber <= endLine,
+				);
+				if (rangeRows.length > 0) {
+					setLineHighlight({ anchor, rows: rangeRows });
+				}
+			} else {
+				// New anchor — single line
+				setLineHighlight({ anchor: clickedRow, rows: [clickedRow] });
+			}
+		},
+		[groupedByPath, lineHighlight],
+	);
+
+	// Position toolbar below the last highlighted row
+	useEffect(() => {
+		if (!lineHighlight || lineHighlight.rows.length === 0) {
+			setToolbarPos(null);
+			return;
+		}
+		const container = scrollContainerRef.current;
+		if (!container) {
+			return;
+		}
+		// Find the last highlighted row's DOM element via data attribute
+		const lastRow = lineHighlight.rows[lineHighlight.rows.length - 1]!;
+		const selector = `[data-diff-row-id="${rowIdKey(lastRow.filePath, lastRow.lineNumber, lastRow.variant)}"]`;
+		const el = container.querySelector(selector);
+		if (!el) {
+			return;
+		}
+		const containerRect = container.getBoundingClientRect();
+		const elRect = el.getBoundingClientRect();
+		setToolbarPos({
+			top: elRect.bottom - containerRect.top + container.scrollTop + 4,
+			left: elRect.left - containerRect.left + elRect.width / 2,
+		});
+	}, [lineHighlight]);
+
+	// Also handle native text selection → show toolbar
+	const handleMouseUp = useCallback(() => {
+		if (!onAddToTerminal && !onSendToTerminal) {
+			return;
+		}
+		requestAnimationFrame(() => {
+			const sel = window.getSelection();
+			if (!sel || sel.isCollapsed || lineHighlight) {
+				return;
+			}
+			const text = sel.toString().trim();
+			if (text.length === 0) {
+				return;
+			}
+			const container = scrollContainerRef.current;
+			if (!container) {
+				return;
+			}
+			const range = sel.getRangeAt(0);
+			const rect = range.getBoundingClientRect();
+			const containerRect = container.getBoundingClientRect();
+			// Build a synthetic highlight from the text selection
+			setLineHighlight({
+				anchor: { filePath: "", lineNumber: 0, variant: "context", text },
+				rows: [{ filePath: "", lineNumber: 0, variant: "context", text }],
+			});
+			setToolbarPos({
+				top: rect.bottom - containerRect.top + container.scrollTop + 4,
+				left: rect.left - containerRect.left + rect.width / 2,
+			});
+		});
+	}, [lineHighlight, onAddToTerminal, onSendToTerminal]);
+
+	const highlightRange: DiffHighlightRange | null = useMemo(() => {
+		if (!lineHighlight || lineHighlight.rows.length === 0) {
+			return null;
+		}
+		const rows = lineHighlight.rows;
+		const filePath = rows[0]!.filePath;
+		const startLine = Math.min(...rows.map((r) => r.lineNumber));
+		const endLine = Math.max(...rows.map((r) => r.lineNumber));
+		const text = rows.map((r) => r.text).join("\n");
+		return { filePath, startLine, endLine, text };
+	}, [lineHighlight]);
+
+	const handleDismissHighlight = useCallback(() => {
+		setLineHighlight(null);
+		setToolbarPos(null);
+		window.getSelection()?.removeAllRanges();
+	}, []);
+
+	// Dismiss on Escape
+	useEffect(() => {
+		if (!lineHighlight) {
+			return;
+		}
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				handleDismissHighlight();
+			}
+		};
+		document.addEventListener("keydown", handleKey);
+		return () => document.removeEventListener("keydown", handleKey);
+	}, [handleDismissHighlight, lineHighlight]);
+
+	// Dismiss highlight when native selection collapses
+	useEffect(() => {
+		const handleSelectionChange = () => {
+			const sel = window.getSelection();
+			if (sel?.isCollapsed && lineHighlight && lineHighlight.anchor.filePath === "") {
+				// This was a text-selection-based highlight
+				setLineHighlight(null);
+				setToolbarPos(null);
+			}
+		};
+		document.addEventListener("selectionchange", handleSelectionChange);
+		return () => document.removeEventListener("selectionchange", handleSelectionChange);
+	}, [lineHighlight]);
+
 	const hasAnyComments = comments.size > 0;
 	const nonEmptyCount = nonEmptyComments.length;
 
@@ -827,7 +1051,9 @@ export function DiffViewerPanel({
 					<div
 						ref={scrollContainerRef}
 						onScroll={handleDiffScroll}
+						onMouseUp={handleMouseUp}
 						style={{
+							position: "relative",
 							flex: "1 1 0",
 							minHeight: 0,
 							overflowY: "auto",
@@ -835,6 +1061,26 @@ export function DiffViewerPanel({
 							padding: "0 12px 12px",
 						}}
 					>
+						{highlightRange && toolbarPos && (onAddToTerminal || onSendToTerminal) ? (
+							<DiffSelectionToolbar
+								range={highlightRange}
+								anchorTop={toolbarPos.top}
+								anchorLeft={toolbarPos.left}
+								onAddToChat={(formatted) => {
+									onAddToTerminal?.(formatted);
+									handleDismissHighlight();
+								}}
+								onSendToAgent={
+									onSendToTerminal
+										? (formatted) => {
+												onSendToTerminal(formatted);
+												handleDismissHighlight();
+											}
+										: undefined
+								}
+								onDismiss={handleDismissHighlight}
+							/>
+						) : null}
 						{groupedByPath.map((group) => {
 							const isExpanded = expandedPaths[group.path] ?? true;
 							const hasBinaryEntry = group.entries.some((entry) => entry.isBinary);
@@ -904,6 +1150,8 @@ export function DiffViewerPanel({
 															onDeleteComment={(lineNumber, variant) =>
 																handleDeleteComment(group.path, lineNumber, variant)
 															}
+															highlightedKeys={highlightedKeys}
+															onLineNumberClick={handleLineNumberClick}
 														/>
 													) : (
 														<UnifiedDiff
@@ -920,6 +1168,8 @@ export function DiffViewerPanel({
 															onDeleteComment={(lineNumber, variant) =>
 																handleDeleteComment(group.path, lineNumber, variant)
 															}
+															highlightedKeys={highlightedKeys}
+															onLineNumberClick={handleLineNumberClick}
 														/>
 													)}
 												</div>

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -421,22 +421,11 @@ function SplitDiff({
 			: canCommentOnSide
 				? baseClass
 				: `${baseClass} kb-diff-row-noncommentable`;
-		const canClickRow = canCommentOnSide && !hasComment;
 		const highlightedLineHtml = getHighlightedLineHtml(row.text, prismGrammar, prismLanguage);
 
 		return (
 			<div style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
-				<div
-					className={rowClass}
-					style={canClickRow ? undefined : { cursor: "default" }}
-					onClick={
-						canClickRow
-							? () => {
-									onAddComment(rowLineNumber, row.text, row.variant);
-								}
-							: undefined
-					}
-				>
+				<div className={rowClass}>
 					<span className="kb-diff-line-number" style={{ color: "var(--color-text-tertiary)" }}>
 						<span className="kb-diff-line-number-text">{rowLineNumber}</span>
 						{canCommentOnSide ? (

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -387,6 +387,7 @@ function SplitDiff({
 	oldText,
 	newText,
 	comments,
+	onAddComment,
 	onUpdateComment,
 	onDeleteComment,
 }: {
@@ -394,6 +395,7 @@ function SplitDiff({
 	oldText: string | null | undefined;
 	newText: string;
 	comments: Map<string, DiffLineComment>;
+	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
 }): React.ReactElement {
@@ -434,15 +436,15 @@ function SplitDiff({
 						{canCommentOnSide ? (
 							<span
 								className="kb-diff-comment-gutter"
-								onClick={
-									hasComment
-										? (event) => {
-												event.stopPropagation();
-												onDeleteComment(rowLineNumber, row.variant);
-											}
-										: undefined
-								}
-								style={hasComment ? { cursor: "pointer" } : undefined}
+								onClick={(event) => {
+									event.stopPropagation();
+									if (hasComment) {
+										onDeleteComment(rowLineNumber, row.variant);
+									} else {
+										onAddComment(rowLineNumber, row.text, row.variant);
+									}
+								}}
+								style={{ cursor: "pointer" }}
 							>
 								<span className="kb-diff-gutter-icon-comment">
 									<MessageSquare size={12} />
@@ -1058,6 +1060,9 @@ export function DiffViewerPanel({
 															oldText={entry.oldText}
 															newText={entry.newText}
 															comments={comments}
+															onAddComment={(lineNumber, lineText, variant) =>
+																handleAddComment(group.path, lineNumber, lineText, variant)
+															}
 															onUpdateComment={(lineNumber, variant, text) =>
 																handleUpdateComment(group.path, lineNumber, variant, text)
 															}

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -1083,7 +1083,7 @@ export function DiffViewerPanel({
 																handleDeleteComment(group.path, lineNumber, variant)
 															}
 															highlightedKeys={highlightedKeys}
-															onLineNumberClick={handleLineNumberClick}
+															onLineNumberClick={onSendToTerminal ? handleLineNumberClick : undefined}
 															lastHighlightedRowKey={lastHighlightedRowKey}
 															highlightRange={highlightRange}
 															onSendHighlightComment={

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -2,11 +2,7 @@ import { ChevronDown, ChevronRight, Command, CornerDownLeft, MessageSquare, X } 
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import {
-	DiffHighlightCommentBox,
-	type DiffHighlightRange,
-	formatSnippetReference,
-} from "@/components/detail-panels/diff-selection-toolbar";
+import { DiffHighlightCommentBox, type DiffHighlightRange } from "@/components/detail-panels/diff-selection-toolbar";
 import {
 	buildDisplayItems,
 	buildHighlightedLineMap,
@@ -150,7 +146,6 @@ function UnifiedDiff({
 	oldText,
 	newText,
 	comments,
-	_onAddComment,
 	onUpdateComment,
 	onDeleteComment,
 	highlightedKeys,
@@ -164,7 +159,6 @@ function UnifiedDiff({
 	oldText: string | null | undefined;
 	newText: string;
 	comments: Map<string, DiffLineComment>;
-	_onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
 	highlightedKeys?: ReadonlySet<string>;
@@ -393,11 +387,8 @@ function SplitDiff({
 	oldText,
 	newText,
 	comments,
-	onAddComment,
 	onUpdateComment,
 	onDeleteComment,
-	highlightedKeys,
-	onLineNumberClick,
 }: {
 	path: string;
 	oldText: string | null | undefined;
@@ -406,14 +397,6 @@ function SplitDiff({
 	onAddComment: (lineNumber: number, lineText: string, variant: "added" | "removed" | "context") => void;
 	onUpdateComment: (lineNumber: number, variant: "added" | "removed" | "context", text: string) => void;
 	onDeleteComment: (lineNumber: number, variant: "added" | "removed" | "context") => void;
-	highlightedKeys?: ReadonlySet<string>;
-	onLineNumberClick?: (
-		filePath: string,
-		lineNumber: number,
-		variant: "added" | "removed" | "context",
-		text: string,
-		shiftKey: boolean,
-	) => void;
 }): React.ReactElement {
 	const { expandedBlocks, expandTop, expandBottom, expandAll } = useIncrementalExpand();
 	const prismLanguage = useMemo(() => resolvePrismLanguage(path), [path]);
@@ -830,6 +813,27 @@ export function DiffViewerPanel({
 		return keys;
 	}, [lineHighlight]);
 
+	/** Memoized map of filePath → all RowIdentity[] for the file, used by shift+click range selection. */
+	const allRowsByPath = useMemo(() => {
+		const map = new Map<string, RowIdentity[]>();
+		for (const group of groupedByPath) {
+			const rows: RowIdentity[] = [];
+			for (const entry of group.entries) {
+				if (entry.isBinary) {
+					continue;
+				}
+				const diffRows = buildUnifiedDiffRows(entry.oldText, entry.newText);
+				for (const r of diffRows) {
+					if (r.lineNumber != null) {
+						rows.push({ filePath: group.path, lineNumber: r.lineNumber, variant: r.variant, text: r.text });
+					}
+				}
+			}
+			map.set(group.path, rows);
+		}
+		return map;
+	}, [groupedByPath]);
+
 	const handleLineNumberClick = useCallback(
 		(
 			filePath: string,
@@ -839,37 +843,23 @@ export function DiffViewerPanel({
 			shiftKey: boolean,
 		) => {
 			const clickedRow: RowIdentity = { filePath, lineNumber, variant, text };
-			if (
-				shiftKey &&
-				lineHighlight &&
-				lineHighlight.anchor.filePath === filePath &&
-				lineHighlight.anchor.variant === variant
-			) {
-				// Extend range from anchor to clicked line — need all rows from the diff
-				// We already track the anchor, so we look up all rows from the grouped data
-				const group = groupedByPath.find((g) => g.path === filePath);
-				if (!group) {
+			if (shiftKey && lineHighlight && lineHighlight.anchor.filePath === filePath) {
+				// Extend range from anchor to clicked line (contiguous, cross-variant)
+				const allRows = allRowsByPath.get(filePath);
+				if (!allRows || allRows.length === 0) {
 					return;
 				}
-				// Build all rows for this file
-				const allRows: RowIdentity[] = [];
-				for (const entry of group.entries) {
-					if (entry.isBinary) {
-						continue;
-					}
-					const diffRows = buildUnifiedDiffRows(entry.oldText, entry.newText);
-					for (const r of diffRows) {
-						if (r.lineNumber != null) {
-							allRows.push({ filePath, lineNumber: r.lineNumber, variant: r.variant, text: r.text });
-						}
-					}
-				}
 				const anchor = lineHighlight.anchor;
-				const startLine = Math.min(anchor.lineNumber, lineNumber);
-				const endLine = Math.max(anchor.lineNumber, lineNumber);
-				const rangeRows = allRows.filter(
-					(r) => r.variant === variant && r.lineNumber >= startLine && r.lineNumber <= endLine,
-				);
+				const anchorKey = rowIdKey(anchor.filePath, anchor.lineNumber, anchor.variant);
+				const clickedKey = rowIdKey(filePath, lineNumber, variant);
+				const anchorIdx = allRows.findIndex((r) => rowIdKey(r.filePath, r.lineNumber, r.variant) === anchorKey);
+				const clickedIdx = allRows.findIndex((r) => rowIdKey(r.filePath, r.lineNumber, r.variant) === clickedKey);
+				if (anchorIdx === -1 || clickedIdx === -1) {
+					return;
+				}
+				const startIdx = Math.min(anchorIdx, clickedIdx);
+				const endIdx = Math.max(anchorIdx, clickedIdx);
+				const rangeRows = allRows.slice(startIdx, endIdx + 1);
 				if (rangeRows.length > 0) {
 					setLineHighlight({ anchor, rows: rangeRows });
 				}
@@ -878,7 +868,7 @@ export function DiffViewerPanel({
 				setLineHighlight({ anchor: clickedRow, rows: [clickedRow] });
 			}
 		},
-		[groupedByPath, lineHighlight],
+		[allRowsByPath, lineHighlight],
 	);
 
 	/** The key identifying the last row in the highlight — the comment box renders after this row. */
@@ -907,15 +897,20 @@ export function DiffViewerPanel({
 		window.getSelection()?.removeAllRanges();
 	}, []);
 
-	// Dismiss on Escape
+	// Dismiss on Escape — skip if focus is inside the comment box (which has its own Escape handler)
 	useEffect(() => {
 		if (!lineHighlight) {
 			return;
 		}
 		const handleKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				handleDismissHighlight();
+			if (e.key !== "Escape") {
+				return;
 			}
+			const target = e.target as HTMLElement | null;
+			if (target?.closest(".kb-diff-highlight-comment-box")) {
+				return;
+			}
+			handleDismissHighlight();
 		};
 		document.addEventListener("keydown", handleKey);
 		return () => document.removeEventListener("keydown", handleKey);
@@ -1073,8 +1068,6 @@ export function DiffViewerPanel({
 															onDeleteComment={(lineNumber, variant) =>
 																handleDeleteComment(group.path, lineNumber, variant)
 															}
-															highlightedKeys={highlightedKeys}
-															onLineNumberClick={handleLineNumberClick}
 														/>
 													) : (
 														<UnifiedDiff
@@ -1082,9 +1075,6 @@ export function DiffViewerPanel({
 															oldText={entry.oldText}
 															newText={entry.newText}
 															comments={comments}
-															_onAddComment={(lineNumber, lineText, variant) =>
-																handleAddComment(group.path, lineNumber, lineText, variant)
-															}
 															onUpdateComment={(lineNumber, variant, text) =>
 																handleUpdateComment(group.path, lineNumber, variant, text)
 															}

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -810,7 +810,7 @@ body.kb-dependency-link-mode {
 }
 
 .kb-diff-ask-dialog-backdrop {
-	position: absolute;
+	position: fixed;
 	inset: 0;
 	z-index: 60;
 	display: flex;

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -788,8 +788,9 @@ body.kb-dependency-link-mode {
 	padding: 4px 6px;
 }
 
-.kb-diff-row-highlighted {
-	background: rgba(0, 132, 255, 0.12) !important;
+.kb-diff-row.kb-diff-row-highlighted,
+.kb-diff-row.kb-diff-row-highlighted:hover {
+	background: rgba(0, 132, 255, 0.12);
 }
 
 .kb-diff-line-number-selectable {

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -798,8 +798,10 @@ body.kb-dependency-link-mode {
 }
 
 .kb-diff-highlight-comment-box {
-	padding: 6px 8px;
-	border-top: 1px solid var(--color-border);
+	margin: 4px 6px;
+	padding: 8px;
+	border: 1px solid var(--color-border-bright);
+	border-radius: var(--radius-md);
 	background: var(--color-surface-1);
 }
 

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -796,68 +796,18 @@ body.kb-dependency-link-mode {
 	cursor: pointer;
 }
 
-.kb-diff-selection-toolbar {
-	position: absolute;
-	z-index: 50;
-	display: flex;
-	align-items: center;
-	gap: 4px;
-	padding: 4px;
-	border-radius: 6px;
-	border: 1px solid var(--color-border-bright);
-	background: var(--color-surface-2);
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-.kb-diff-ask-dialog-backdrop {
-	position: fixed;
-	inset: 0;
-	z-index: 60;
-	display: flex;
-	align-items: flex-start;
-	justify-content: center;
-	padding-top: 80px;
-	background: rgba(0, 0, 0, 0.45);
-}
-
-.kb-diff-ask-dialog {
-	width: 100%;
-	max-width: 520px;
-	border-radius: 8px;
-	border: 1px solid var(--color-border-bright);
+.kb-diff-highlight-comment-box {
+	padding: 6px 8px;
+	border-top: 1px solid var(--color-border);
 	background: var(--color-surface-1);
-	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-	overflow: hidden;
 }
 
-.kb-diff-ask-dialog-header {
-	padding: 10px 12px 6px;
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--color-text-primary);
-}
-
-.kb-diff-ask-dialog-code {
-	margin: 0 12px 8px;
-	padding: 8px;
-	border-radius: 4px;
-	background: var(--color-surface-0);
-	font-size: 11px;
-	line-height: 1.5;
-	color: var(--color-text-secondary);
-	max-height: 120px;
-	overflow-y: auto;
-	white-space: pre-wrap;
-	word-break: break-all;
-}
-
-.kb-diff-ask-dialog-footer {
+.kb-diff-highlight-comment-actions {
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	gap: 6px;
-	padding: 8px 12px;
-	border-top: 1px solid var(--color-border);
+	padding-top: 6px;
 }
 
 .kb-diff-comments-footer {

--- a/web-ui/src/styles/globals.css
+++ b/web-ui/src/styles/globals.css
@@ -544,7 +544,7 @@ body.kb-dependency-link-mode {
 	padding: 1px 2px 1px 0;
 	line-height: 1.6;
 	font-size: 12px;
-	cursor: pointer;
+	cursor: default;
 }
 
 .kb-diff-row:hover {
@@ -571,6 +571,7 @@ body.kb-dependency-link-mode {
 	display: none;
 	align-items: center;
 	justify-content: center;
+	cursor: pointer;
 }
 
 .kb-diff-row:hover .kb-diff-comment-gutter {
@@ -785,6 +786,78 @@ body.kb-dependency-link-mode {
 
 .kb-diff-inline-comment {
 	padding: 4px 6px;
+}
+
+.kb-diff-row-highlighted {
+	background: rgba(0, 132, 255, 0.12) !important;
+}
+
+.kb-diff-line-number-selectable {
+	cursor: pointer;
+}
+
+.kb-diff-selection-toolbar {
+	position: absolute;
+	z-index: 50;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px;
+	border-radius: 6px;
+	border: 1px solid var(--color-border-bright);
+	background: var(--color-surface-2);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.kb-diff-ask-dialog-backdrop {
+	position: absolute;
+	inset: 0;
+	z-index: 60;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding-top: 80px;
+	background: rgba(0, 0, 0, 0.45);
+}
+
+.kb-diff-ask-dialog {
+	width: 100%;
+	max-width: 520px;
+	border-radius: 8px;
+	border: 1px solid var(--color-border-bright);
+	background: var(--color-surface-1);
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+	overflow: hidden;
+}
+
+.kb-diff-ask-dialog-header {
+	padding: 10px 12px 6px;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--color-text-primary);
+}
+
+.kb-diff-ask-dialog-code {
+	margin: 0 12px 8px;
+	padding: 8px;
+	border-radius: 4px;
+	background: var(--color-surface-0);
+	font-size: 11px;
+	line-height: 1.5;
+	color: var(--color-text-secondary);
+	max-height: 120px;
+	overflow-y: auto;
+	white-space: pre-wrap;
+	word-break: break-all;
+}
+
+.kb-diff-ask-dialog-footer {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 6px;
+	padding: 8px 12px;
+	border-top: 1px solid var(--color-border);
 }
 
 .kb-diff-comments-footer {


### PR DESCRIPTION
- Shift + Click on lines to select multiple comments (similar to github)
- Instead of clicking anywhere on the line to open a comment box, you must click on the line number
- Adds file path, line number, column numbers in addition to code snippet


https://github.com/user-attachments/assets/e51d8798-edc4-4e60-8bdc-43cd03effeed

