### PR TITLE
fix: restore review session resume after restart or crash

### DIFF
--- a/src/cline-sdk/cline-session-state.ts
+++ b/src/cline-sdk/cline-session-state.ts
@@ -75,6 +75,17 @@ export function cloneSummary(summary: RuntimeTaskSessionSummary): RuntimeTaskSes
 		latestHookActivity: summary.latestHookActivity ? { ...summary.latestHookActivity } : null,
 		latestTurnCheckpoint: summary.latestTurnCheckpoint ? { ...summary.latestTurnCheckpoint } : null,
 		previousTurnCheckpoint: summary.previousTurnCheckpoint ? { ...summary.previousTurnCheckpoint } : null,
+		persistedReviewContext: summary.persistedReviewContext
+			? {
+					...summary.persistedReviewContext,
+					workspaceDiff: summary.persistedReviewContext.workspaceDiff
+						? {
+								...summary.persistedReviewContext.workspaceDiff,
+								files: summary.persistedReviewContext.workspaceDiff.files.map((file) => ({ ...file })),
+							}
+						: null,
+				}
+			: null,
 	};
 }
 
@@ -104,6 +115,7 @@ export function createDefaultSummary(taskId: string): RuntimeTaskSessionSummary 
 		warningMessage: null,
 		latestTurnCheckpoint: null,
 		previousTurnCheckpoint: null,
+		persistedReviewContext: null,
 	};
 }
 

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -1174,6 +1174,7 @@ export const runtimeTerminalWsRestoreMessageSchema = z.object({
 	snapshot: z.string(),
 	cols: z.number().int().positive().nullable().optional(),
 	rows: z.number().int().positive().nullable().optional(),
+	requiresResume: z.boolean().optional(),
 });
 export type RuntimeTerminalWsRestoreMessage = z.infer<typeof runtimeTerminalWsRestoreMessageSchema>;
 

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -271,6 +271,34 @@ export const runtimeTaskTurnCheckpointSchema = z.object({
 });
 export type RuntimeTaskTurnCheckpoint = z.infer<typeof runtimeTaskTurnCheckpointSchema>;
 
+export const runtimeTaskPersistedReviewFileSchema = z.object({
+	path: z.string(),
+	previousPath: z.string().optional(),
+	status: runtimeWorkspaceFileStatusSchema,
+	additions: z.number().int().nonnegative(),
+	deletions: z.number().int().nonnegative(),
+});
+export type RuntimeTaskPersistedReviewFile = z.infer<typeof runtimeTaskPersistedReviewFileSchema>;
+
+export const runtimeTaskPersistedReviewWorkspaceDiffSchema = z.object({
+	mode: runtimeWorkspaceChangesModeSchema,
+	generatedAt: z.number(),
+	changedFiles: z.number().int().nonnegative(),
+	additions: z.number().int().nonnegative(),
+	deletions: z.number().int().nonnegative(),
+	files: z.array(runtimeTaskPersistedReviewFileSchema).default([]),
+});
+export type RuntimeTaskPersistedReviewWorkspaceDiff = z.infer<typeof runtimeTaskPersistedReviewWorkspaceDiffSchema>;
+
+export const runtimeTaskPersistedReviewContextSchema = z.object({
+	capturedAt: z.number(),
+	terminalSnapshot: z.string().nullable().default(null),
+	terminalCols: z.number().int().positive().nullable().default(null),
+	terminalRows: z.number().int().positive().nullable().default(null),
+	workspaceDiff: runtimeTaskPersistedReviewWorkspaceDiffSchema.nullable().default(null),
+});
+export type RuntimeTaskPersistedReviewContext = z.infer<typeof runtimeTaskPersistedReviewContextSchema>;
+
 export const runtimeTaskSessionSummarySchema = z.object({
 	taskId: z.string(),
 	state: runtimeTaskSessionStateSchema,
@@ -288,6 +316,7 @@ export const runtimeTaskSessionSummarySchema = z.object({
 	warningMessage: z.string().nullable().optional(),
 	latestTurnCheckpoint: runtimeTaskTurnCheckpointSchema.nullable().optional(),
 	previousTurnCheckpoint: runtimeTaskTurnCheckpointSchema.nullable().optional(),
+	persistedReviewContext: runtimeTaskPersistedReviewContextSchema.nullable().optional(),
 });
 export type RuntimeTaskSessionSummary = z.infer<typeof runtimeTaskSessionSummarySchema>;
 

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -4,13 +4,15 @@ import type {
 	RuntimeBoardData,
 	RuntimeProjectSummary,
 	RuntimeProjectTaskCounts,
+	RuntimeTaskSessionSummary,
 	RuntimeWorkspaceStateResponse,
 } from "../core/api-contract";
+import { getTaskColumnId, moveTaskToColumn } from "../core/task-board-mutations";
 import {
 	listWorkspaceIndexEntries,
 	loadWorkspaceBoardById,
 	loadWorkspaceContext,
-	loadWorkspaceState,
+	mutateWorkspaceState,
 	type RuntimeWorkspaceIndexEntry,
 	removeWorkspaceIndexEntry,
 	removeWorkspaceStateFiles,
@@ -167,6 +169,80 @@ function applyLiveSessionStateToProjectTaskCounts(
 	return next;
 }
 
+function createPersistedReviewSummary(
+	taskId: string,
+	agentId: RuntimeTaskSessionSummary["agentId"] = null,
+): RuntimeTaskSessionSummary {
+	return {
+		taskId,
+		state: "awaiting_review",
+		agentId,
+		workspacePath: null,
+		pid: null,
+		startedAt: null,
+		updatedAt: Date.now(),
+		lastOutputAt: null,
+		reviewReason: "hook",
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+		warningMessage: null,
+		latestTurnCheckpoint: null,
+		previousTurnCheckpoint: null,
+	};
+}
+
+function reconcilePersistedReviewState(
+	board: RuntimeBoardData,
+	sessions: Record<string, RuntimeTaskSessionSummary>,
+): { board: RuntimeBoardData; sessions: Record<string, RuntimeTaskSessionSummary>; changed: boolean } {
+	let nextBoard = board;
+	let nextSessions = sessions;
+	let changed = false;
+
+	const reviewColumn = board.columns.find((column) => column.id === "review");
+	for (const card of reviewColumn?.cards ?? []) {
+		const existing = nextSessions[card.id];
+		if (existing?.state === "awaiting_review") {
+			continue;
+		}
+		if (nextSessions === sessions) {
+			nextSessions = { ...sessions };
+		}
+		nextSessions[card.id] = existing
+			? {
+					...existing,
+					state: "awaiting_review",
+					reviewReason: existing.reviewReason ?? "hook",
+					pid: null,
+				}
+			: createPersistedReviewSummary(card.id, card.agentId ?? null);
+		changed = true;
+	}
+
+	for (const summary of Object.values(nextSessions)) {
+		if (summary.state !== "awaiting_review") {
+			continue;
+		}
+		const columnId = getTaskColumnId(nextBoard, summary.taskId);
+		if (columnId !== "in_progress") {
+			continue;
+		}
+		const moved = moveTaskToColumn(nextBoard, summary.taskId, "review");
+		if (!moved.moved) {
+			continue;
+		}
+		nextBoard = moved.board;
+		changed = true;
+	}
+
+	return {
+		board: nextBoard,
+		sessions: nextSessions,
+		changed,
+	};
+}
+
 function toProjectSummary(project: {
 	workspaceId: string;
 	repoPath: string;
@@ -205,6 +281,26 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 	const terminalManagersByWorkspaceId = new Map<string, TerminalSessionManager>();
 	const terminalManagerLoadPromises = new Map<string, Promise<TerminalSessionManager>>();
 
+	const loadAndRepairWorkspaceState = async (workspacePath: string): Promise<RuntimeWorkspaceStateResponse> => {
+		const mutation = await mutateWorkspaceState(workspacePath, (state) => {
+			const repaired = reconcilePersistedReviewState(state.board, state.sessions);
+			if (!repaired.changed) {
+				return {
+					board: state.board,
+					sessions: state.sessions,
+					value: null,
+					save: false,
+				};
+			}
+			return {
+				board: repaired.board,
+				sessions: repaired.sessions,
+				value: null,
+			};
+		});
+		return mutation.state;
+	};
+
 	const rememberWorkspace = (workspaceId: string, repoPath: string): void => {
 		workspacePathsById.set(workspaceId, repoPath);
 	};
@@ -236,7 +332,7 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 		const loading = (async () => {
 			const manager = new TerminalSessionManager();
 			try {
-				const existingWorkspace = await loadWorkspaceState(repoPath);
+				const existingWorkspace = await loadAndRepairWorkspaceState(repoPath);
 				manager.hydrateFromRecord(existingWorkspace.sessions);
 			} catch {
 				// Workspace state will be created on demand.
@@ -293,7 +389,10 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 		_repoPath: string,
 	): Promise<RuntimeProjectTaskCounts> => {
 		try {
-			const board = await loadWorkspaceBoardById(workspaceId);
+			const workspacePath = workspacePathsById.get(workspaceId);
+			const board = workspacePath
+				? (await loadAndRepairWorkspaceState(workspacePath)).board
+				: await loadWorkspaceBoardById(workspaceId);
 			const persistedCounts = countTasksByColumn(board);
 			const terminalManager = getTerminalManagerForWorkspace(workspaceId);
 			if (!terminalManager) {
@@ -316,7 +415,7 @@ export async function createWorkspaceRegistry(deps: CreateWorkspaceRegistryDepen
 		workspaceId: string,
 		workspacePath: string,
 	): Promise<RuntimeWorkspaceStateResponse> => {
-		const response = await loadWorkspaceState(workspacePath);
+		const response = await loadAndRepairWorkspaceState(workspacePath);
 		const terminalManager = await ensureTerminalManagerForWorkspace(workspaceId, workspacePath);
 		for (const summary of terminalManager.listSummaries()) {
 			response.sessions[summary.taskId] = summary;

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -189,6 +189,7 @@ function createPersistedReviewSummary(
 		warningMessage: null,
 		latestTurnCheckpoint: null,
 		previousTurnCheckpoint: null,
+		persistedReviewContext: null,
 	};
 }
 

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -145,6 +145,40 @@ function isActiveState(state: RuntimeTaskSessionState): boolean {
 	return state === "running" || state === "awaiting_review";
 }
 
+function buildPersistedReviewRestoreSnapshot(summary: RuntimeTaskSessionSummary) {
+	if (summary.state !== "awaiting_review") {
+		return null;
+	}
+
+	const lines = ["[kanban] Restored persisted review session."];
+	const finalMessage = summary.latestHookActivity?.finalMessage?.trim();
+	const activityText = summary.latestHookActivity?.activityText?.trim();
+	const warningMessage = summary.warningMessage?.trim();
+	const latestCheckpoint = summary.latestTurnCheckpoint?.commit?.trim();
+
+	if (finalMessage) {
+		lines.push("", finalMessage);
+	} else if (activityText) {
+		lines.push("", activityText);
+	} else {
+		lines.push("", "Waiting for review.");
+	}
+
+	if (warningMessage) {
+		lines.push("", `Warning: ${warningMessage}`);
+	}
+
+	if (latestCheckpoint) {
+		lines.push("", `Latest checkpoint: ${latestCheckpoint}`);
+	}
+
+	return {
+		snapshot: `${lines.join("\r\n")}\r\n`,
+		cols: 120,
+		rows: 40,
+	};
+}
+
 function cloneStartTaskSessionRequest(request: StartTaskSessionRequest): StartTaskSessionRequest {
 	return {
 		...request,
@@ -286,8 +320,11 @@ export class TerminalSessionManager implements TerminalSessionService {
 
 	async getRestoreSnapshot(taskId: string) {
 		const entry = this.entries.get(taskId);
-		if (!entry?.terminalStateMirror) {
+		if (!entry) {
 			return null;
+		}
+		if (!entry.terminalStateMirror) {
+			return buildPersistedReviewRestoreSnapshot(entry.summary);
 		}
 		return await entry.terminalStateMirror.getSnapshot();
 	}
@@ -708,6 +745,9 @@ export class TerminalSessionManager implements TerminalSessionService {
 			return null;
 		}
 		if (entry.active || !isActiveState(entry.summary.state)) {
+			return cloneSummary(entry.summary);
+		}
+		if (entry.summary.state === "awaiting_review") {
 			return cloneSummary(entry.summary);
 		}
 

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -4,6 +4,8 @@
 import type {
 	RuntimeTaskHookActivity,
 	RuntimeTaskImage,
+	RuntimeTaskPersistedReviewContext,
+	RuntimeTaskPersistedReviewWorkspaceDiff,
 	RuntimeTaskSessionReviewReason,
 	RuntimeTaskSessionState,
 	RuntimeTaskSessionSummary,
@@ -123,12 +125,27 @@ function createDefaultSummary(taskId: string): RuntimeTaskSessionSummary {
 		warningMessage: null,
 		latestTurnCheckpoint: null,
 		previousTurnCheckpoint: null,
+		persistedReviewContext: null,
 	};
 }
 
 function cloneSummary(summary: RuntimeTaskSessionSummary): RuntimeTaskSessionSummary {
 	return {
 		...summary,
+		latestHookActivity: summary.latestHookActivity ? { ...summary.latestHookActivity } : null,
+		latestTurnCheckpoint: summary.latestTurnCheckpoint ? { ...summary.latestTurnCheckpoint } : null,
+		previousTurnCheckpoint: summary.previousTurnCheckpoint ? { ...summary.previousTurnCheckpoint } : null,
+		persistedReviewContext: summary.persistedReviewContext
+			? {
+					...summary.persistedReviewContext,
+					workspaceDiff: summary.persistedReviewContext.workspaceDiff
+						? {
+								...summary.persistedReviewContext.workspaceDiff,
+								files: summary.persistedReviewContext.workspaceDiff.files.map((file) => ({ ...file })),
+							}
+						: null,
+				}
+			: null,
 	};
 }
 
@@ -150,11 +167,24 @@ function buildPersistedReviewRestoreSnapshot(summary: RuntimeTaskSessionSummary)
 		return null;
 	}
 
+	const persistedContext = summary.persistedReviewContext ?? null;
+	if (persistedContext?.terminalSnapshot) {
+		return {
+			snapshot: persistedContext.terminalSnapshot,
+			cols: persistedContext.terminalCols ?? 120,
+			rows: persistedContext.terminalRows ?? 40,
+		};
+	}
+
 	const lines = ["[kanban] Restored persisted review session."];
 	const finalMessage = summary.latestHookActivity?.finalMessage?.trim();
 	const activityText = summary.latestHookActivity?.activityText?.trim();
+	const toolName = summary.latestHookActivity?.toolName?.trim();
+	const toolInputSummary = summary.latestHookActivity?.toolInputSummary?.trim();
 	const warningMessage = summary.warningMessage?.trim();
-	const latestCheckpoint = summary.latestTurnCheckpoint?.commit?.trim();
+	const latestCheckpoint = summary.latestTurnCheckpoint;
+	const previousCheckpoint = summary.previousTurnCheckpoint;
+	const workspaceDiff = persistedContext?.workspaceDiff ?? null;
 
 	if (finalMessage) {
 		lines.push("", finalMessage);
@@ -168,8 +198,27 @@ function buildPersistedReviewRestoreSnapshot(summary: RuntimeTaskSessionSummary)
 		lines.push("", `Warning: ${warningMessage}`);
 	}
 
-	if (latestCheckpoint) {
-		lines.push("", `Latest checkpoint: ${latestCheckpoint}`);
+	if (toolName) {
+		lines.push("", `Latest tool: ${toolName}${toolInputSummary ? ` (${toolInputSummary})` : ""}`);
+	}
+
+	if (workspaceDiff && workspaceDiff.changedFiles > 0) {
+		lines.push(
+			"",
+			`Workspace diff: ${workspaceDiff.changedFiles} file${workspaceDiff.changedFiles === 1 ? "" : "s"} changed (+${workspaceDiff.additions} -${workspaceDiff.deletions})`,
+		);
+		for (const file of workspaceDiff.files) {
+			const renameSuffix = file.previousPath ? ` <- ${file.previousPath}` : "";
+			lines.push(`- ${file.path}${renameSuffix} [${file.status}] (+${file.additions} -${file.deletions})`);
+		}
+	}
+
+	if (latestCheckpoint?.commit?.trim()) {
+		lines.push("", `Latest checkpoint: turn ${latestCheckpoint.turn} @ ${latestCheckpoint.commit.trim()}`);
+	}
+
+	if (previousCheckpoint?.commit?.trim()) {
+		lines.push(`Previous checkpoint: turn ${previousCheckpoint.turn} @ ${previousCheckpoint.commit.trim()}`);
 	}
 
 	return {
@@ -536,6 +585,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 				latestHookActivity: null,
 				latestTurnCheckpoint: null,
 				previousTurnCheckpoint: null,
+				persistedReviewContext: null,
 			});
 			this.emitSummary(summary);
 			throw new Error(formatSpawnFailure(commandBinary, error));
@@ -567,6 +617,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		entry.terminalStateMirror = terminalStateMirror;
 
 		const startedAt = now();
+		const persistedReviewContext = request.resumeFromTrash ? (entry.summary.persistedReviewContext ?? null) : null;
 		updateSummary(entry, {
 			state: request.resumeFromTrash ? "awaiting_review" : "running",
 			agentId: request.agentId,
@@ -581,6 +632,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			warningMessage: null,
 			latestTurnCheckpoint: null,
 			previousTurnCheckpoint: null,
+			persistedReviewContext,
 		});
 		this.emitSummary(entry.summary);
 
@@ -695,6 +747,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 				latestHookActivity: null,
 				latestTurnCheckpoint: null,
 				previousTurnCheckpoint: null,
+				persistedReviewContext: null,
 			});
 			this.emitSummary(summary);
 			throw new Error(formatShellSpawnFailure(request.binary, error));
@@ -733,6 +786,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			warningMessage: null,
 			latestTurnCheckpoint: null,
 			previousTurnCheckpoint: null,
+			persistedReviewContext: null,
 		});
 		this.emitSummary(entry.summary);
 
@@ -765,6 +819,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			latestHookActivity: null,
 			latestTurnCheckpoint: null,
 			previousTurnCheckpoint: null,
+			persistedReviewContext: null,
 		});
 
 		for (const listener of entry.listeners.values()) {
@@ -929,6 +984,51 @@ export class TerminalSessionManager implements TerminalSessionService {
 		return cloneSummary(summary);
 	}
 
+	async capturePersistedReviewContext(
+		taskId: string,
+		input: {
+			workspaceDiff?: RuntimeTaskPersistedReviewWorkspaceDiff | null;
+		} = {},
+	): Promise<RuntimeTaskSessionSummary | null> {
+		const entry = this.entries.get(taskId);
+		if (!entry) {
+			return null;
+		}
+
+		const previousContext = entry.summary.persistedReviewContext ?? null;
+		let terminalSnapshot = previousContext?.terminalSnapshot ?? null;
+		let terminalCols = previousContext?.terminalCols ?? null;
+		let terminalRows = previousContext?.terminalRows ?? null;
+
+		if (entry.terminalStateMirror) {
+			try {
+				const snapshot = await entry.terminalStateMirror.getSnapshot();
+				terminalSnapshot = snapshot.snapshot;
+				terminalCols = snapshot.cols;
+				terminalRows = snapshot.rows;
+			} catch {
+				// Best effort snapshot capture only.
+			}
+		}
+
+		const summary = updateSummary(entry, {
+			persistedReviewContext: {
+				capturedAt: now(),
+				terminalSnapshot,
+				terminalCols,
+				terminalRows,
+				workspaceDiff: input.workspaceDiff ?? previousContext?.workspaceDiff ?? null,
+			} satisfies RuntimeTaskPersistedReviewContext,
+		});
+		if (entry.active) {
+			for (const listener of entry.listeners.values()) {
+				listener.onState?.(cloneSummary(summary));
+			}
+		}
+		this.emitSummary(summary);
+		return cloneSummary(summary);
+	}
+
 	applyTurnCheckpoint(taskId: string, checkpoint: RuntimeTaskTurnCheckpoint): RuntimeTaskSessionSummary | null {
 		const entry = this.entries.get(taskId);
 		if (!entry) {
@@ -993,10 +1093,17 @@ export class TerminalSessionManager implements TerminalSessionService {
 				entry.active.workspaceTrustBuffer = "";
 			}
 		}
+		const patch =
+			transition.patch.state === "running"
+				? {
+						...transition.patch,
+						persistedReviewContext: null,
+					}
+				: transition.patch;
 		if (entry.active && transition.changed && transition.patch.state === "awaiting_review") {
 			entry.active.awaitingCodexPromptAfterEnter = false;
 		}
-		return updateSummary(entry, transition.patch);
+		return updateSummary(entry, patch);
 	}
 
 	private ensureEntry(taskId: string): SessionEntry {

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -378,6 +378,10 @@ export class TerminalSessionManager implements TerminalSessionService {
 		return await entry.terminalStateMirror.getSnapshot();
 	}
 
+	hasActiveSession(taskId: string): boolean {
+		return this.entries.get(taskId)?.active != null;
+	}
+
 	async startTaskSession(request: StartTaskSessionRequest): Promise<RuntimeTaskSessionSummary> {
 		const entry = this.ensureEntry(request.taskId);
 		entry.restartRequest = {

--- a/src/terminal/terminal-session-service.ts
+++ b/src/terminal/terminal-session-service.ts
@@ -10,6 +10,7 @@ export interface TerminalSessionListener {
 export interface TerminalSessionService {
 	attach(taskId: string, listener: TerminalSessionListener): (() => void) | null;
 	getRestoreSnapshot(taskId: string): Promise<TerminalRestoreSnapshot | null>;
+	hasActiveSession(taskId: string): boolean;
 	recoverStaleSession(taskId: string): RuntimeTaskSessionSummary | null;
 	writeInput(taskId: string, data: Buffer): RuntimeTaskSessionSummary | null;
 	resize(taskId: string, cols: number, rows: number, pixelWidth?: number, pixelHeight?: number): boolean;

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -439,6 +439,18 @@ export function createTerminalWebSocketBridge({
 			try {
 				const summary = terminalManager.writeInput(taskId, rawDataToBuffer(rawMessage));
 				if (!summary) {
+					const recoveredSummary = terminalManager.recoverStaleSession(taskId);
+					const requiresResume =
+						!terminalManager.hasActiveSession(taskId) && recoveredSummary?.state === "awaiting_review";
+					if (requiresResume) {
+						ws.send(
+							Buffer.from(
+								"\r\n[kanban] Review session is restored but not running. Use Resume to reconnect before sending input.\r\n",
+								"utf8",
+							),
+						);
+						return;
+					}
 					ws.close(1011, "Task session is not running.");
 				}
 			} catch (error) {
@@ -464,7 +476,7 @@ export function createTerminalWebSocketBridge({
 		const clientId = (context as TerminalWebSocketConnectionContext).clientId;
 		const terminalManager = (context as TerminalWebSocketConnectionContext).terminalManager;
 		const connectionKey = buildConnectionKey(workspaceId, taskId);
-		terminalManager.recoverStaleSession(taskId);
+		const recoveredSummary = terminalManager.recoverStaleSession(taskId);
 		const streamState = getOrCreateTerminalStreamState(connectionKey);
 		const viewerState = getOrCreateViewerState(streamState, clientId);
 		const previousControlSocket = viewerState.controlSocket;
@@ -491,6 +503,8 @@ export function createTerminalWebSocketBridge({
 			previousControlSocket.close(1000, "Replaced by newer terminal control connection.");
 		}
 
+		const requiresResume = !terminalManager.hasActiveSession(taskId) && recoveredSummary?.state === "awaiting_review";
+
 		void terminalManager
 			.getRestoreSnapshot(taskId)
 			.then((snapshot) => {
@@ -499,6 +513,7 @@ export function createTerminalWebSocketBridge({
 					snapshot: snapshot?.snapshot ?? "",
 					cols: snapshot?.cols ?? null,
 					rows: snapshot?.rows ?? null,
+					requiresResume,
 				});
 			})
 			.catch(() => {
@@ -507,6 +522,7 @@ export function createTerminalWebSocketBridge({
 					snapshot: "",
 					cols: null,
 					rows: null,
+					requiresResume,
 				});
 			});
 

--- a/src/trpc/hooks-api.ts
+++ b/src/trpc/hooks-api.ts
@@ -1,12 +1,18 @@
 import type {
 	RuntimeHookEvent,
 	RuntimeHookIngestResponse,
+	RuntimeTaskPersistedReviewWorkspaceDiff,
 	RuntimeTaskSessionSummary,
 	RuntimeTaskTurnCheckpoint,
 } from "../core/api-contract";
 import { parseHookIngestRequest } from "../core/api-validation";
 import { loadWorkspaceContextById } from "../state/workspace-state";
 import type { TerminalSessionManager } from "../terminal/session-manager";
+import {
+	getWorkspaceChanges,
+	getWorkspaceChangesBetweenRefs,
+	getWorkspaceChangesFromRef,
+} from "../workspace/get-workspace-changes";
 import { captureTaskTurnCheckpoint, deleteTaskTurnCheckpointRef } from "../workspace/turn-checkpoints";
 import type { RuntimeTrpcContext } from "./app-router";
 
@@ -34,6 +40,61 @@ function canTransitionTaskForHookEvent(summary: RuntimeTaskSessionSummary, event
 		summary.state === "awaiting_review" &&
 		(summary.reviewReason === "attention" || summary.reviewReason === "hook" || summary.reviewReason === "error")
 	);
+}
+
+const MAX_PERSISTED_REVIEW_DIFF_FILES = 6;
+
+function summarizePersistedReviewWorkspaceDiff(
+	mode: RuntimeTaskPersistedReviewWorkspaceDiff["mode"],
+	response: Awaited<ReturnType<typeof getWorkspaceChanges>>,
+): RuntimeTaskPersistedReviewWorkspaceDiff {
+	const files = response.files.slice(0, MAX_PERSISTED_REVIEW_DIFF_FILES).map((file) => ({
+		path: file.path,
+		previousPath: file.previousPath,
+		status: file.status,
+		additions: file.additions,
+		deletions: file.deletions,
+	}));
+	return {
+		mode,
+		generatedAt: response.generatedAt,
+		changedFiles: response.files.length,
+		additions: response.files.reduce((total, file) => total + file.additions, 0),
+		deletions: response.files.reduce((total, file) => total + file.deletions, 0),
+		files,
+	};
+}
+
+async function capturePersistedReviewWorkspaceDiff(
+	cwd: string,
+	summary: RuntimeTaskSessionSummary,
+): Promise<RuntimeTaskPersistedReviewWorkspaceDiff | null> {
+	try {
+		const toCheckpoint = summary.latestTurnCheckpoint;
+		const fromCheckpoint = summary.previousTurnCheckpoint;
+		if (!toCheckpoint) {
+			return summarizePersistedReviewWorkspaceDiff("working_copy", await getWorkspaceChanges(cwd));
+		}
+		if (summary.state === "running" || !fromCheckpoint) {
+			return summarizePersistedReviewWorkspaceDiff(
+				"working_copy",
+				await getWorkspaceChangesFromRef({
+					cwd,
+					fromRef: toCheckpoint.commit,
+				}),
+			);
+		}
+		return summarizePersistedReviewWorkspaceDiff(
+			"last_turn",
+			await getWorkspaceChangesBetweenRefs({
+				cwd,
+				fromRef: fromCheckpoint.commit,
+				toRef: toCheckpoint.commit,
+			}),
+		);
+	} catch {
+		return null;
+	}
 }
 
 export function createHooksApi(deps: CreateHooksApiDependencies): RuntimeTrpcContext["hooksApi"] {
@@ -75,7 +136,7 @@ export function createHooksApi(deps: CreateHooksApiDependencies): RuntimeTrpcCon
 					} satisfies RuntimeHookIngestResponse;
 				}
 
-				const transitionedSummary =
+				let transitionedSummary =
 					event === "to_review" ? manager.transitionToReview(taskId, "hook") : manager.transitionToRunning(taskId);
 				if (!transitionedSummary) {
 					return {
@@ -94,7 +155,7 @@ export function createHooksApi(deps: CreateHooksApiDependencies): RuntimeTrpcCon
 							taskId,
 							turn: nextTurn,
 						});
-						manager.applyTurnCheckpoint(taskId, checkpoint);
+						transitionedSummary = manager.applyTurnCheckpoint(taskId, checkpoint) ?? transitionedSummary;
 						if (staleRef) {
 							void checkpointRefDelete({
 								cwd: checkpointCwd,
@@ -109,7 +170,17 @@ export function createHooksApi(deps: CreateHooksApiDependencies): RuntimeTrpcCon
 				}
 
 				if (body.metadata) {
-					manager.applyHookActivity(taskId, body.metadata);
+					transitionedSummary = manager.applyHookActivity(taskId, body.metadata) ?? transitionedSummary;
+				}
+
+				if (event === "to_review") {
+					const diffSummary = await capturePersistedReviewWorkspaceDiff(
+						transitionedSummary.workspacePath ?? workspacePath,
+						transitionedSummary,
+					);
+					await manager.capturePersistedReviewContext(taskId, {
+						workspaceDiff: diffSummary,
+					});
 				}
 
 				void deps.broadcastRuntimeWorkspaceStateUpdated(workspaceId, workspacePath);

--- a/test/integration/workspace-registry.integration.test.ts
+++ b/test/integration/workspace-registry.integration.test.ts
@@ -1,0 +1,175 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { RuntimeConfigState } from "../../src/config/runtime-config";
+import type { RuntimeBoardData, RuntimeTaskSessionSummary } from "../../src/core/api-contract";
+import { createWorkspaceRegistry } from "../../src/server/workspace-registry";
+import { loadWorkspaceState, saveWorkspaceState } from "../../src/state/workspace-state";
+import { createGitTestEnv } from "../utilities/git-env";
+import { createTempDir } from "../utilities/temp-dir";
+
+async function withTemporaryHome<T>(run: () => Promise<T>): Promise<T> {
+	const { path: tempHome, cleanup } = createTempDir("kanban-home-workspace-registry-");
+	const previousHome = process.env.HOME;
+	const previousUserProfile = process.env.USERPROFILE;
+	process.env.HOME = tempHome;
+	process.env.USERPROFILE = tempHome;
+	try {
+		return await run();
+	} finally {
+		if (previousHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = previousHome;
+		}
+		if (previousUserProfile === undefined) {
+			delete process.env.USERPROFILE;
+		} else {
+			process.env.USERPROFILE = previousUserProfile;
+		}
+		cleanup();
+	}
+}
+
+function initGitRepository(path: string): void {
+	const init = spawnSync("git", ["init"], {
+		cwd: path,
+		stdio: "ignore",
+		env: createGitTestEnv(),
+	});
+	if (init.status !== 0) {
+		throw new Error(`Failed to initialize git repository at ${path}`);
+	}
+}
+
+function createCard(taskId: string, agentId: RuntimeTaskSessionSummary["agentId"] = "codex") {
+	return {
+		id: taskId,
+		title: `Task ${taskId}`,
+		prompt: `Task ${taskId}`,
+		startInPlanMode: false,
+		baseRef: "main",
+		agentId: agentId ?? undefined,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function createBoard(): RuntimeBoardData {
+	return {
+		columns: [
+			{ id: "backlog", title: "Backlog", cards: [] },
+			{
+				id: "in_progress",
+				title: "In Progress",
+				cards: [createCard("summary-awaiting-review")],
+			},
+			{
+				id: "review",
+				title: "Review",
+				cards: [createCard("board-review-stale-session")],
+			},
+			{ id: "trash", title: "Trash", cards: [] },
+		],
+		dependencies: [],
+	};
+}
+
+function createSession(
+	taskId: string,
+	state: RuntimeTaskSessionSummary["state"],
+	reviewReason: RuntimeTaskSessionSummary["reviewReason"],
+): RuntimeTaskSessionSummary {
+	return {
+		taskId,
+		state,
+		agentId: "codex",
+		workspacePath: `/tmp/${taskId}`,
+		pid: state === "idle" ? null : 1234,
+		startedAt: state === "idle" ? null : Date.now() - 1_000,
+		updatedAt: Date.now(),
+		lastOutputAt: state === "idle" ? null : Date.now(),
+		reviewReason,
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+		warningMessage: null,
+		latestTurnCheckpoint: null,
+		previousTurnCheckpoint: null,
+	};
+}
+
+function createRuntimeConfigState(): RuntimeConfigState {
+	return {
+		globalConfigPath: "/tmp/global-config.json",
+		projectConfigPath: null,
+		selectedAgentId: "codex",
+		selectedShortcutLabel: null,
+		agentAutonomousModeEnabled: true,
+		readyForReviewNotificationsEnabled: true,
+		shortcuts: [],
+		commitPromptTemplate: "commit",
+		openPrPromptTemplate: "pr",
+		commitPromptTemplateDefault: "commit",
+		openPrPromptTemplateDefault: "pr",
+	};
+}
+
+describe.sequential("workspace registry persisted review repair", () => {
+	it("repairs stale review persistence on startup", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-workspace-registry-");
+			try {
+				const projectPath = join(sandboxRoot, "project");
+				mkdirSync(projectPath, { recursive: true });
+				initGitRepository(projectPath);
+
+				const initial = await loadWorkspaceState(projectPath);
+				await saveWorkspaceState(projectPath, {
+					board: createBoard(),
+					sessions: {
+						"board-review-stale-session": createSession("board-review-stale-session", "idle", null),
+						"summary-awaiting-review": createSession("summary-awaiting-review", "awaiting_review", "hook"),
+					},
+					expectedRevision: initial.revision,
+				});
+
+				const registry = await createWorkspaceRegistry({
+					cwd: projectPath,
+					loadGlobalRuntimeConfig: async () => createRuntimeConfigState(),
+					loadRuntimeConfig: async () => createRuntimeConfigState(),
+					hasGitRepository: (path) => statSync(join(path, ".git")).isDirectory(),
+					pathIsDirectory: async (path) => statSync(path).isDirectory(),
+				});
+
+				const workspaceId = registry.getActiveWorkspaceId();
+				expect(workspaceId).toBeTruthy();
+
+				const snapshot = await registry.buildWorkspaceStateSnapshot(workspaceId ?? "", projectPath);
+				const repaired = await loadWorkspaceState(projectPath);
+
+				const reviewIds = snapshot.board.columns
+					.find((column) => column.id === "review")
+					?.cards.map((card) => card.id)
+					.sort();
+
+				expect(reviewIds).toEqual(["board-review-stale-session", "summary-awaiting-review"]);
+				expect(snapshot.sessions["board-review-stale-session"]?.state).toBe("awaiting_review");
+				expect(snapshot.sessions["board-review-stale-session"]?.reviewReason).toBe("hook");
+				expect(snapshot.sessions["summary-awaiting-review"]?.state).toBe("awaiting_review");
+				expect(repaired.sessions["board-review-stale-session"]?.state).toBe("awaiting_review");
+				expect(
+					repaired.board.columns
+						.find((column) => column.id === "review")
+						?.cards.map((card) => card.id)
+						.sort(),
+				).toEqual(["board-review-stale-session", "summary-awaiting-review"]);
+			} finally {
+				cleanup();
+			}
+		});
+	}, 30_000);
+});

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -289,15 +289,163 @@ describe("TerminalSessionManager", () => {
 					commit: "3333333",
 					createdAt: 3,
 				},
+				previousTurnCheckpoint: {
+					turn: 2,
+					ref: "refs/kanban/checkpoints/task-restore/turn/2",
+					commit: "2222222",
+					createdAt: 2,
+				},
+				persistedReviewContext: {
+					capturedAt: 4,
+					terminalSnapshot: null,
+					terminalCols: null,
+					terminalRows: null,
+					workspaceDiff: {
+						mode: "last_turn",
+						generatedAt: 5,
+						changedFiles: 2,
+						additions: 11,
+						deletions: 4,
+						files: [
+							{
+								path: "src/session-manager.ts",
+								status: "modified",
+								additions: 8,
+								deletions: 3,
+							},
+							{
+								path: "src/ws-server.ts",
+								status: "added",
+								additions: 3,
+								deletions: 1,
+							},
+						],
+					},
+				},
 			}),
 		});
 
 		const snapshot = await manager.getRestoreSnapshot("task-restore");
 
 		expect(snapshot).toEqual({
-			snapshot: "[kanban] Restored persisted review session.\r\n\r\nShip it\r\n\r\nLatest checkpoint: 3333333\r\n",
+			snapshot:
+				"[kanban] Restored persisted review session.\r\n\r\nShip it\r\n\r\nWorkspace diff: 2 files changed (+11 -4)\r\n- src/session-manager.ts [modified] (+8 -3)\r\n- src/ws-server.ts [added] (+3 -1)\r\n\r\nLatest checkpoint: turn 3 @ 3333333\r\nPrevious checkpoint: turn 2 @ 2222222\r\n",
 			cols: 120,
 			rows: 40,
 		});
+	});
+
+	it("prefers a persisted terminal snapshot when restoring a review session", async () => {
+		const manager = new TerminalSessionManager();
+		manager.hydrateFromRecord({
+			"task-restore": createSummary({
+				taskId: "task-restore",
+				state: "awaiting_review",
+				reviewReason: "hook",
+				persistedReviewContext: {
+					capturedAt: 4,
+					terminalSnapshot: "serialized persisted terminal",
+					terminalCols: 132,
+					terminalRows: 44,
+					workspaceDiff: null,
+				},
+			}),
+		});
+
+		const snapshot = await manager.getRestoreSnapshot("task-restore");
+
+		expect(snapshot).toEqual({
+			snapshot: "serialized persisted terminal",
+			cols: 132,
+			rows: 44,
+		});
+	});
+
+	it("captures persisted review context from the live terminal snapshot", async () => {
+		const manager = new TerminalSessionManager();
+		const entry = {
+			summary: createSummary({ taskId: "task-review", state: "awaiting_review", reviewReason: "hook" }),
+			active: null,
+			terminalStateMirror: {
+				getSnapshot: vi.fn(async () => ({
+					snapshot: "live review terminal",
+					cols: 140,
+					rows: 48,
+				})),
+			},
+			listenerIdCounter: 1,
+			listeners: new Map(),
+			restartRequest: null,
+			suppressAutoRestartOnExit: false,
+			autoRestartTimestamps: [],
+			pendingAutoRestart: null,
+		};
+		(
+			manager as unknown as {
+				entries: Map<string, typeof entry>;
+			}
+		).entries.set("task-review", entry);
+
+		const updated = await manager.capturePersistedReviewContext("task-review", {
+			workspaceDiff: {
+				mode: "last_turn",
+				generatedAt: 5,
+				changedFiles: 1,
+				additions: 2,
+				deletions: 1,
+				files: [
+					{
+						path: "src/task.ts",
+						status: "modified",
+						additions: 2,
+						deletions: 1,
+					},
+				],
+			},
+		});
+
+		expect(updated?.persistedReviewContext).toEqual({
+			capturedAt: expect.any(Number),
+			terminalSnapshot: "live review terminal",
+			terminalCols: 140,
+			terminalRows: 48,
+			workspaceDiff: {
+				mode: "last_turn",
+				generatedAt: 5,
+				changedFiles: 1,
+				additions: 2,
+				deletions: 1,
+				files: [
+					{
+						path: "src/task.ts",
+						status: "modified",
+						additions: 2,
+						deletions: 1,
+					},
+				],
+			},
+		});
+	});
+
+	it("clears persisted review context when returning to running", () => {
+		const manager = new TerminalSessionManager();
+		manager.hydrateFromRecord({
+			"task-1": createSummary({
+				state: "awaiting_review",
+				reviewReason: "hook",
+				persistedReviewContext: {
+					capturedAt: 4,
+					terminalSnapshot: "serialized persisted terminal",
+					terminalCols: 132,
+					terminalRows: 44,
+					workspaceDiff: null,
+				},
+			}),
+		});
+
+		const updated = manager.transitionToRunning("task-1");
+
+		expect(updated?.state).toBe("running");
+		expect(updated?.persistedReviewContext).toBeNull();
 	});
 });

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -84,6 +84,38 @@ describe("TerminalSessionManager", () => {
 		expect(recovered?.reviewReason).toBeNull();
 	});
 
+	it("preserves persisted awaiting-review sessions when recovering a stale reconnect", () => {
+		const manager = new TerminalSessionManager();
+		manager.hydrateFromRecord({
+			"task-1": createSummary({
+				state: "awaiting_review",
+				reviewReason: "hook",
+				latestHookActivity: {
+					activityText: "Final: Review the diff",
+					toolName: null,
+					toolInputSummary: null,
+					finalMessage: "Review the diff",
+					hookEventName: null,
+					notificationType: null,
+					source: "codex",
+				},
+				latestTurnCheckpoint: {
+					turn: 2,
+					ref: "refs/kanban/checkpoints/task-1/turn/2",
+					commit: "2222222",
+					createdAt: 2,
+				},
+			}),
+		});
+
+		const recovered = manager.recoverStaleSession("task-1");
+
+		expect(recovered?.state).toBe("awaiting_review");
+		expect(recovered?.reviewReason).toBe("hook");
+		expect(recovered?.latestHookActivity?.finalMessage).toBe("Review the diff");
+		expect(recovered?.latestTurnCheckpoint?.commit).toBe("2222222");
+	});
+
 	it("tracks only the latest two turn checkpoints", () => {
 		const manager = new TerminalSessionManager();
 		manager.hydrateFromRecord({
@@ -233,5 +265,39 @@ describe("TerminalSessionManager", () => {
 			rows: 40,
 		});
 		expect(getSnapshotSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("builds a restore snapshot for persisted awaiting-review sessions without a PTY mirror", async () => {
+		const manager = new TerminalSessionManager();
+		manager.hydrateFromRecord({
+			"task-restore": createSummary({
+				taskId: "task-restore",
+				state: "awaiting_review",
+				reviewReason: "hook",
+				latestHookActivity: {
+					activityText: "Final: Ship it",
+					toolName: null,
+					toolInputSummary: null,
+					finalMessage: "Ship it",
+					hookEventName: null,
+					notificationType: null,
+					source: "codex",
+				},
+				latestTurnCheckpoint: {
+					turn: 3,
+					ref: "refs/kanban/checkpoints/task-restore/turn/3",
+					commit: "3333333",
+					createdAt: 3,
+				},
+			}),
+		});
+
+		const snapshot = await manager.getRestoreSnapshot("task-restore");
+
+		expect(snapshot).toEqual({
+			snapshot: "[kanban] Restored persisted review session.\r\n\r\nShip it\r\n\r\nLatest checkpoint: 3333333\r\n",
+			cols: 120,
+			rows: 40,
+		});
 	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -47,6 +47,7 @@ function rawDataToBuffer(data: RawData): Buffer {
 
 class FakeTerminalManager implements TerminalSessionService {
 	private readonly listenersByTaskId = new Map<string, Set<TerminalSessionListener>>();
+	readonly activeTaskIds = new Set<string>([TASK_ID]);
 
 	attach(taskId: string, listener: TerminalSessionListener): (() => void) | null {
 		const listeners = this.listenersByTaskId.get(taskId) ?? new Set<TerminalSessionListener>();
@@ -68,6 +69,7 @@ class FakeTerminalManager implements TerminalSessionService {
 			rows: 24,
 		}),
 	);
+	hasActiveSession = vi.fn((taskId: string) => this.activeTaskIds.has(taskId));
 	recoverStaleSession = vi.fn(() => createSummary());
 	writeInput = vi.fn(() => createSummary());
 	resize = vi.fn(() => true);
@@ -496,6 +498,50 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(secondControl.socket);
 	});
 
+	it("keeps restored review sockets open until the user resumes the session", async () => {
+		terminalManager = new TerminalSessionManager() as unknown as FakeTerminalManager;
+		(terminalManager as unknown as TerminalSessionManager).hydrateFromRecord({
+			[TASK_ID]: {
+				...createSummary(),
+				state: "awaiting_review",
+				reviewReason: "hook",
+				persistedReviewContext: {
+					capturedAt: 2,
+					terminalSnapshot: "persisted review terminal",
+					terminalCols: 120,
+					terminalRows: 40,
+					workspaceDiff: null,
+				},
+			},
+		});
+		const ioUrl = `${runtimeUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=resume-client`;
+		const controlUrl = `${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=resume-client`;
+
+		const ioSocket = await openQueuedWebSocket(ioUrl);
+		const controlSocket = await openQueuedWebSocket(controlUrl);
+		const restore = await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+
+		expect(restore).toMatchObject({
+			type: "restore",
+			requiresResume: true,
+		});
+
+		ioSocket.socket.send(Buffer.from("\r", "utf8"));
+		const hint = await waitForIoMessage(ioSocket);
+		expect(hint.toString("utf8")).toContain("Use Resume to reconnect before sending input.");
+
+		await new Promise<void>((resolve, reject) => {
+			const timeoutId = setTimeout(resolve, 100);
+			ioSocket.socket.once("close", () => {
+				clearTimeout(timeoutId);
+				reject(new Error("Expected restored review IO socket to remain open."));
+			});
+		});
+
+		await closeSocket(ioSocket.socket);
+		await closeSocket(controlSocket.socket);
+	});
+
 	it("sends the persisted terminal snapshot through the restore control message", async () => {
 		terminalManager = new TerminalSessionManager() as unknown as FakeTerminalManager;
 		(terminalManager as unknown as TerminalSessionManager).hydrateFromRecord({
@@ -516,11 +562,12 @@ describe("createTerminalWebSocketBridge", () => {
 		const control = await openQueuedWebSocket(controlUrl);
 		const restore = await waitForControlMessage(control, (message) => message.type === "restore");
 
-		expect(restore).toEqual({
+		expect(restore).toMatchObject({
 			type: "restore",
 			snapshot: "persisted review terminal",
 			cols: 132,
 			rows: 40,
+			requiresResume: true,
 		});
 
 		await closeSocket(control.socket);

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -495,4 +495,34 @@ describe("createTerminalWebSocketBridge", () => {
 
 		await closeSocket(secondControl.socket);
 	});
+
+	it("sends the persisted terminal snapshot through the restore control message", async () => {
+		terminalManager = new TerminalSessionManager() as unknown as FakeTerminalManager;
+		(terminalManager as unknown as TerminalSessionManager).hydrateFromRecord({
+			[TASK_ID]: {
+				...createSummary(),
+				state: "awaiting_review",
+				reviewReason: "hook",
+				persistedReviewContext: {
+					capturedAt: 2,
+					terminalSnapshot: "persisted review terminal",
+					terminalCols: 132,
+					terminalRows: 40,
+					workspaceDiff: null,
+				},
+			},
+		});
+		const controlUrl = `${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=persisted-snapshot-client`;
+		const control = await openQueuedWebSocket(controlUrl);
+		const restore = await waitForControlMessage(control, (message) => message.type === "restore");
+
+		expect(restore).toEqual({
+			type: "restore",
+			snapshot: "persisted review terminal",
+			cols: 132,
+			rows: 40,
+		});
+
+		await closeSocket(control.socket);
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -7,6 +7,7 @@ import type { RawData } from "ws";
 import { WebSocket } from "ws";
 
 import type { RuntimeTaskSessionSummary, RuntimeTerminalWsServerMessage } from "../../../src/core/api-contract";
+import { TerminalSessionManager } from "../../../src/terminal/session-manager";
 import type { TerminalSessionListener, TerminalSessionService } from "../../../src/terminal/terminal-session-service";
 import type { TerminalRestoreSnapshot } from "../../../src/terminal/terminal-state-mirror";
 import { createTerminalWebSocketBridge, type TerminalWebSocketBridge } from "../../../src/terminal/ws-server";
@@ -451,5 +452,47 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(controlSocketA.socket);
 		await closeSocket(ioSocketB.socket);
 		await closeSocket(controlSocketB.socket);
+	});
+
+	it("keeps persisted awaiting-review sessions coherent across websocket reconnects", async () => {
+		terminalManager = new TerminalSessionManager() as unknown as FakeTerminalManager;
+		(terminalManager as unknown as TerminalSessionManager).hydrateFromRecord({
+			[TASK_ID]: {
+				...createSummary(),
+				state: "awaiting_review",
+				reviewReason: "hook",
+				latestHookActivity: {
+					activityText: "Final: Review the persisted session",
+					toolName: null,
+					toolInputSummary: null,
+					finalMessage: "Review the persisted session",
+					hookEventName: null,
+					notificationType: null,
+					source: "codex",
+				},
+				pid: 1234,
+			},
+		});
+		const controlUrl = `${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=reconnect-client`;
+		const firstControl = await openQueuedWebSocket(controlUrl);
+		const firstState = await waitForControlMessage(firstControl, (message) => message.type === "state");
+		const firstRestore = await waitForControlMessage(firstControl, (message) => message.type === "restore");
+
+		expect(firstState.type).toBe("state");
+		expect(firstState.type === "state" ? firstState.summary.state : null).toBe("awaiting_review");
+		expect(firstRestore.type).toBe("restore");
+		expect(firstRestore.type === "restore" ? firstRestore.snapshot : "").toContain("Review the persisted session");
+
+		await closeSocket(firstControl.socket);
+
+		const secondControl = await openQueuedWebSocket(controlUrl);
+		const secondState = await waitForControlMessage(secondControl, (message) => message.type === "state");
+		const secondRestore = await waitForControlMessage(secondControl, (message) => message.type === "restore");
+
+		expect(secondState.type).toBe("state");
+		expect(secondState.type === "state" ? secondState.summary.state : null).toBe("awaiting_review");
+		expect(secondRestore.type === "restore" ? secondRestore.snapshot : "").toContain("Review the persisted session");
+
+		await closeSocket(secondControl.socket);
 	});
 });

--- a/test/runtime/trpc/hooks-api.test.ts
+++ b/test/runtime/trpc/hooks-api.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RuntimeTaskSessionSummary } from "../../../src/core/api-contract";
 import type { TerminalSessionManager } from "../../../src/terminal/session-manager";
+
+const workspaceChangesMocks = vi.hoisted(() => ({
+	getWorkspaceChanges: vi.fn(),
+	getWorkspaceChangesBetweenRefs: vi.fn(),
+	getWorkspaceChangesFromRef: vi.fn(),
+}));
+
+vi.mock("../../../src/workspace/get-workspace-changes.js", () => ({
+	getWorkspaceChanges: workspaceChangesMocks.getWorkspaceChanges,
+	getWorkspaceChangesBetweenRefs: workspaceChangesMocks.getWorkspaceChangesBetweenRefs,
+	getWorkspaceChangesFromRef: workspaceChangesMocks.getWorkspaceChangesFromRef,
+}));
+
 import { createHooksApi } from "../../../src/trpc/hooks-api";
 
 function createSummary(overrides: Partial<RuntimeTaskSessionSummary> = {}): RuntimeTaskSessionSummary {
@@ -23,12 +36,34 @@ function createSummary(overrides: Partial<RuntimeTaskSessionSummary> = {}): Runt
 }
 
 describe("createHooksApi", () => {
+	beforeEach(() => {
+		workspaceChangesMocks.getWorkspaceChanges.mockReset();
+		workspaceChangesMocks.getWorkspaceChangesBetweenRefs.mockReset();
+		workspaceChangesMocks.getWorkspaceChangesFromRef.mockReset();
+		workspaceChangesMocks.getWorkspaceChanges.mockResolvedValue({
+			repoRoot: "/tmp/worktree",
+			generatedAt: 10,
+			files: [],
+		});
+		workspaceChangesMocks.getWorkspaceChangesBetweenRefs.mockResolvedValue({
+			repoRoot: "/tmp/worktree",
+			generatedAt: 20,
+			files: [],
+		});
+		workspaceChangesMocks.getWorkspaceChangesFromRef.mockResolvedValue({
+			repoRoot: "/tmp/worktree",
+			generatedAt: 30,
+			files: [],
+		});
+	});
+
 	it("treats ineligible hook transitions as successful no-ops", async () => {
 		const manager = {
 			getSummary: vi.fn(() => createSummary({ state: "running" })),
 			transitionToReview: vi.fn(),
 			transitionToRunning: vi.fn(),
 			applyHookActivity: vi.fn(),
+			capturePersistedReviewContext: vi.fn(),
 		} as unknown as TerminalSessionManager;
 
 		const api = createHooksApi({
@@ -56,6 +91,7 @@ describe("createHooksApi", () => {
 			transitionToRunning: vi.fn(),
 			applyHookActivity: vi.fn(),
 			applyTurnCheckpoint: vi.fn(),
+			capturePersistedReviewContext: vi.fn(),
 		} as unknown as TerminalSessionManager;
 
 		const api = createHooksApi({
@@ -107,7 +143,17 @@ describe("createHooksApi", () => {
 			transitionToReview: vi.fn(() => transitionedSummary),
 			transitionToRunning: vi.fn(),
 			applyHookActivity: vi.fn(),
-			applyTurnCheckpoint: vi.fn(),
+			applyTurnCheckpoint: vi.fn((taskId, checkpoint) =>
+				createSummary({
+					taskId,
+					state: "awaiting_review",
+					reviewReason: "hook",
+					workspacePath: "/tmp/worktree",
+					latestTurnCheckpoint: checkpoint,
+					previousTurnCheckpoint: transitionedSummary.latestTurnCheckpoint,
+				}),
+			),
+			capturePersistedReviewContext: vi.fn(async () => transitionedSummary),
 		} as unknown as TerminalSessionManager;
 
 		const captureTaskTurnCheckpoint = vi.fn(async () => ({
@@ -143,6 +189,93 @@ describe("createHooksApi", () => {
 		expect(deleteTaskTurnCheckpointRef).toHaveBeenCalledWith({
 			cwd: "/tmp/worktree",
 			ref: "refs/kanban/checkpoints/task-1/turn/1",
+		});
+		expect(workspaceChangesMocks.getWorkspaceChangesBetweenRefs).toHaveBeenCalledWith({
+			cwd: "/tmp/worktree",
+			fromRef: "2222222",
+			toRef: "3333333",
+		});
+		expect(manager.capturePersistedReviewContext).toHaveBeenCalledWith("task-1", {
+			workspaceDiff: {
+				mode: "last_turn",
+				generatedAt: 20,
+				changedFiles: 0,
+				additions: 0,
+				deletions: 0,
+				files: [],
+			},
+		});
+	});
+
+	it("falls back to working copy diff summary when the previous checkpoint is unavailable", async () => {
+		const transitionedSummary = createSummary({
+			state: "awaiting_review",
+			reviewReason: "hook",
+			workspacePath: "/tmp/worktree",
+			latestTurnCheckpoint: {
+				turn: 3,
+				ref: "refs/kanban/checkpoints/task-1/turn/3",
+				commit: "3333333",
+				createdAt: 3,
+			},
+			previousTurnCheckpoint: null,
+		});
+		workspaceChangesMocks.getWorkspaceChangesFromRef.mockResolvedValue({
+			repoRoot: "/tmp/worktree",
+			generatedAt: 40,
+			files: [
+				{
+					path: "src/review.ts",
+					status: "modified",
+					additions: 4,
+					deletions: 2,
+					oldText: null,
+					newText: null,
+				},
+			],
+		});
+		const manager = {
+			getSummary: vi.fn(() => createSummary({ state: "running" })),
+			transitionToReview: vi.fn(() => transitionedSummary),
+			transitionToRunning: vi.fn(),
+			applyHookActivity: vi.fn(),
+			applyTurnCheckpoint: vi.fn(),
+			capturePersistedReviewContext: vi.fn(async () => transitionedSummary),
+		} as unknown as TerminalSessionManager;
+		const api = createHooksApi({
+			getWorkspacePathById: vi.fn(() => "/tmp/repo"),
+			ensureTerminalManagerForWorkspace: vi.fn(async () => manager),
+			broadcastRuntimeWorkspaceStateUpdated: vi.fn(),
+			broadcastTaskReadyForReview: vi.fn(),
+		});
+
+		await api.ingest({
+			taskId: "task-1",
+			workspaceId: "workspace-1",
+			event: "to_review",
+		});
+
+		expect(workspaceChangesMocks.getWorkspaceChangesFromRef).toHaveBeenCalledWith({
+			cwd: "/tmp/worktree",
+			fromRef: "3333333",
+		});
+		expect(manager.capturePersistedReviewContext).toHaveBeenCalledWith("task-1", {
+			workspaceDiff: {
+				mode: "working_copy",
+				generatedAt: 40,
+				changedFiles: 1,
+				additions: 4,
+				deletions: 2,
+				files: [
+					{
+						path: "src/review.ts",
+						status: "modified",
+						additions: 4,
+						deletions: 2,
+						previousPath: undefined,
+					},
+				],
+			},
 		});
 	});
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -572,6 +572,7 @@ export default function App(): ReactElement {
 		handleMoveToTrash,
 		handleMoveReviewCardToTrash,
 		handleRestoreTaskFromTrash,
+		handleResumeReviewTask,
 		handleCancelAutomaticTaskAction,
 		handleOpenClearTrash,
 		handleConfirmClearTrash,
@@ -1044,6 +1045,7 @@ export default function App(): ReactElement {
 									moveToTrashLoadingById={moveToTrashLoadingById}
 									onMoveReviewCardToTrash={handleMoveReviewCardToTrash}
 									onRestoreTaskFromTrash={handleRestoreTaskFromTrash}
+									onResumeReviewTask={handleResumeReviewTask}
 									onCancelAutomaticTaskAction={handleCancelAutomaticTaskAction}
 									onAddReviewComments={(taskId: string, text: string) => {
 										void handleAddReviewComments(taskId, text);

--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -15,7 +15,13 @@ const {
 	mockClineAppendToDraft,
 	mockClineSendText,
 } = vi.hoisted(() => ({
-	mockAgentTerminalPanel: vi.fn((_props: { panelBackgroundColor?: string; terminalBackgroundColor?: string }) => null),
+	mockAgentTerminalPanel: vi.fn(
+		(_props: {
+			panelBackgroundColor?: string;
+			terminalBackgroundColor?: string;
+			onResumePersistedReviewSession?: () => void;
+		}) => null,
+	),
 	mockClineAgentChatPanel: vi.fn((..._args: unknown[]) => null),
 	mockDiffViewerPanel: vi.fn((..._args: unknown[]) => null),
 	mockClineAppendToDraft: vi.fn(),
@@ -494,6 +500,55 @@ describe("CardDetailView", () => {
 			panelBackgroundColor: "var(--color-surface-0)",
 			terminalBackgroundColor: TERMINAL_THEME_COLORS.surfacePrimary,
 		});
+	});
+
+	it("passes a persisted-review resume handler to the terminal panel", async () => {
+		const onResumeReviewTask = vi.fn();
+
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					selectedAgentId="claude"
+					sessionSummary={{
+						taskId: "task-1",
+						state: "awaiting_review",
+						agentId: "claude",
+						workspacePath: null,
+						pid: null,
+						startedAt: null,
+						updatedAt: Date.now(),
+						lastOutputAt: null,
+						reviewReason: "hook",
+						exitCode: null,
+						lastHookAt: null,
+						latestHookActivity: null,
+						warningMessage: null,
+					}}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					onResumeReviewTask={onResumeReviewTask}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const lastCall = mockAgentTerminalPanel.mock.calls.at(-1);
+		expect(lastCall?.[0]).toMatchObject({
+			onResumePersistedReviewSession: expect.any(Function),
+		});
+
+		const resumeHandler = lastCall?.[0]?.onResumePersistedReviewSession as (() => void) | undefined;
+		expect(resumeHandler).toBeTypeOf("function");
+		resumeHandler?.();
+		expect(onResumeReviewTask).toHaveBeenCalledWith("task-1");
 	});
 
 	it("queues Add diff comments into the cline composer without sending them", async () => {

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -130,6 +130,7 @@ function BottomTerminalSection({
 	onCollapse,
 	isExpanded,
 	onToggleExpand,
+	onResumePersistedReviewSession,
 }: {
 	taskId: string;
 	workspaceId: string | null;
@@ -146,6 +147,7 @@ function BottomTerminalSection({
 	onCollapse?: () => void;
 	isExpanded?: boolean;
 	onToggleExpand?: () => void;
+	onResumePersistedReviewSession?: () => void;
 }): React.ReactElement {
 	return (
 		<ResizableBottomPane
@@ -174,6 +176,7 @@ function BottomTerminalSection({
 					onSendAgentCommand={onSendAgentCommand}
 					isExpanded={isExpanded}
 					onToggleExpand={onToggleExpand}
+					onResumePersistedReviewSession={onResumePersistedReviewSession}
 				/>
 			</div>
 		</ResizableBottomPane>
@@ -324,6 +327,7 @@ export function CardDetailView({
 	onAgentOpenPrTask,
 	onMoveReviewCardToTrash,
 	onRestoreTaskFromTrash,
+	onResumeReviewTask,
 	onCancelAutomaticTaskAction,
 	commitTaskLoadingById,
 	openPrTaskLoadingById,
@@ -382,6 +386,7 @@ export function CardDetailView({
 	onAgentOpenPrTask?: (taskId: string) => void;
 	onMoveReviewCardToTrash?: (taskId: string) => void;
 	onRestoreTaskFromTrash?: (taskId: string) => void;
+	onResumeReviewTask?: (taskId: string) => void;
 	onCancelAutomaticTaskAction?: (taskId: string) => void;
 	commitTaskLoadingById?: Record<string, boolean>;
 	openPrTaskLoadingById?: Record<string, boolean>;
@@ -689,6 +694,7 @@ export function CardDetailView({
 			terminalBackgroundColor={terminalThemeColors.surfacePrimary}
 			cursorColor={terminalThemeColors.textPrimary}
 			taskColumnId={selection.column.id}
+			onResumePersistedReviewSession={onResumeReviewTask ? () => onResumeReviewTask(selection.card.id) : undefined}
 		/>
 	);
 
@@ -777,6 +783,11 @@ export function CardDetailView({
 								onCollapse={onBottomTerminalCollapse}
 								isExpanded={isBottomTerminalExpanded}
 								onToggleExpand={onBottomTerminalToggleExpand}
+								onResumePersistedReviewSession={
+									onResumeReviewTask && bottomTerminalTaskId
+										? () => onResumeReviewTask(bottomTerminalTaskId)
+										: undefined
+								}
 							/>
 						</div>
 					) : null}

--- a/web-ui/src/components/detail-panels/agent-terminal-panel.tsx
+++ b/web-ui/src/components/detail-panels/agent-terminal-panel.tsx
@@ -17,6 +17,7 @@ interface AgentTerminalSessionControls {
 	containerRef: MutableRefObject<HTMLDivElement | null>;
 	isStopping: boolean;
 	lastError: string | null;
+	resumeRequired: boolean;
 	stopTerminal: () => Promise<void>;
 }
 
@@ -50,6 +51,7 @@ export interface AgentTerminalPanelProps {
 	onSendAgentCommand?: () => void;
 	isExpanded?: boolean;
 	onToggleExpand?: () => void;
+	onResumePersistedReviewSession?: () => void;
 }
 
 function describeState(summary: RuntimeTaskSessionSummary | null): string {
@@ -170,9 +172,10 @@ function AgentTerminalPanelLayout({
 	onSendAgentCommand,
 	isExpanded = false,
 	onToggleExpand,
+	onResumePersistedReviewSession,
 	sessionControls,
 }: AgentTerminalPanelProps & { sessionControls: AgentTerminalSessionControls }): ReactElement {
-	const { containerRef, lastError, isStopping, clearTerminal, stopTerminal } = sessionControls;
+	const { containerRef, lastError, resumeRequired, isStopping, clearTerminal, stopTerminal } = sessionControls;
 	const canStop = summary?.state === "running" || summary?.state === "awaiting_review";
 	const statusLabel = useMemo(() => describeState(summary), [summary]);
 	const statusTagStyle = useMemo(() => getStateTagStyle(summary), [summary]);
@@ -300,6 +303,16 @@ function AgentTerminalPanelLayout({
 							aria-label="Close terminal"
 						/>
 					</div>
+				</div>
+			) : null}
+			{resumeRequired && summary?.state === "awaiting_review" && onResumePersistedReviewSession ? (
+				<div className="flex items-center justify-between gap-3 border-t border-status-orange/30 bg-status-orange/10 px-3 py-2">
+					<p className="text-[12px] text-text-secondary">
+						This review snapshot was restored after restart. Resume to reconnect a live terminal.
+					</p>
+					<Button variant="primary" size="sm" onClick={onResumePersistedReviewSession}>
+						Resume
+					</Button>
 				</div>
 			) : null}
 			<div style={{ flex: "1 1 0", minHeight: 0, overflow: "hidden", padding: "3px 1.5px 3px 3px" }}>

--- a/web-ui/src/hooks/use-board-interactions.test.tsx
+++ b/web-ui/src/hooks/use-board-interactions.test.tsx
@@ -1,3 +1,4 @@
+import type { DropResult } from "@hello-pangea/dnd";
 import { act, type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -70,6 +71,7 @@ interface HookSnapshot {
 	handleResumeReviewTask: (taskId: string) => void;
 	handleStartTask: (taskId: string) => void;
 	handleCardSelect: (taskId: string) => void;
+	handleDragEnd: (result: DropResult) => void;
 }
 
 function createRect(width: number, height: number): DOMRect {
@@ -93,6 +95,7 @@ function HookHarness({
 	startTaskSession,
 	selectedCard = null,
 	setSelectedTaskIdOverride,
+	initialSessions,
 	onSnapshot,
 }: {
 	board: BoardData;
@@ -101,9 +104,10 @@ function HookHarness({
 	startTaskSession: UseTaskSessionsResult["startTaskSession"];
 	selectedCard?: { card: BoardCard; column: { id: "backlog" | "in_progress" | "review" | "trash" } } | null;
 	setSelectedTaskIdOverride?: Dispatch<SetStateAction<string | null>>;
+	initialSessions?: Record<string, RuntimeTaskSessionSummary>;
 	onSnapshot?: (snapshot: HookSnapshot) => void;
 }): null {
-	const [sessions, setSessions] = useState<Record<string, RuntimeTaskSessionSummary>>({});
+	const [sessions, setSessions] = useState<Record<string, RuntimeTaskSessionSummary>>(initialSessions ?? {});
 	const [, setSelectedTaskId] = useState<string | null>(null);
 	const [, setIsClearTrashDialogOpen] = useState(false);
 	const [, setIsGitHistoryOpen] = useState(false);
@@ -136,9 +140,11 @@ function HookHarness({
 			handleResumeReviewTask: actions.handleResumeReviewTask,
 			handleStartTask: actions.handleStartTask,
 			handleCardSelect: actions.handleCardSelect,
+			handleDragEnd: actions.handleDragEnd,
 		});
 	}, [
 		actions.handleCardSelect,
+		actions.handleDragEnd,
 		actions.handleRestoreTaskFromTrash,
 		actions.handleResumeReviewTask,
 		actions.handleStartTask,
@@ -168,6 +174,23 @@ describe("useBoardInteractions", () => {
 		showAppToastMock.mockReset();
 		useLinkedBacklogTaskActionsMock.mockReset();
 		useProgrammaticCardMovesMock.mockReset();
+		useProgrammaticCardMovesMock.mockReturnValue({
+			handleProgrammaticCardMoveReady: () => {},
+			setRequestMoveTaskToTrashHandler: () => {},
+			tryProgrammaticCardMove: () => "unavailable",
+			consumeProgrammaticCardMove: () => ({}),
+			resolvePendingProgrammaticTrashMove: () => {},
+			waitForProgrammaticCardMoveAvailability: async () => {},
+			resetProgrammaticCardMoves: () => {},
+			requestMoveTaskToTrashWithAnimation: async () => {},
+			programmaticCardMoveCycle: 0,
+		});
+		useLinkedBacklogTaskActionsMock.mockReturnValue({
+			handleCreateDependency: () => {},
+			handleDeleteDependency: () => {},
+			confirmMoveTaskToTrash: async () => {},
+			requestMoveTaskToTrash: async () => {},
+		});
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -320,6 +343,22 @@ describe("useBoardInteractions", () => {
 					setBoard={setBoard}
 					ensureTaskWorkspace={ensureTaskWorkspace}
 					startTaskSession={startTaskSession}
+					initialSessions={{
+						"task-trash": {
+							taskId: "task-trash",
+							state: "running",
+							agentId: "codex",
+							workspacePath: "/tmp/task-trash",
+							pid: null,
+							startedAt: 1,
+							updatedAt: 2,
+							lastOutputAt: null,
+							reviewReason: null,
+							exitCode: null,
+							lastHookAt: null,
+							latestHookActivity: null,
+						},
+					}}
 					onSnapshot={(snapshot) => {
 						latestSnapshot = snapshot;
 					}}
@@ -456,7 +495,7 @@ describe("useBoardInteractions", () => {
 		});
 
 		const trashTask = createTask("task-trash", "Trash task", 2);
-		const board: BoardData = {
+		let currentBoard: BoardData = {
 			columns: [
 				{ id: "backlog", title: "Backlog", cards: [] },
 				{ id: "in_progress", title: "In Progress", cards: [] },
@@ -465,8 +504,9 @@ describe("useBoardInteractions", () => {
 			],
 			dependencies: [],
 		};
-		const setBoard = vi.fn<Dispatch<SetStateAction<BoardData>>>((_nextBoard) => {
-			// The optimistic move is not part of this assertion.
+		const setBoard = vi.fn<Dispatch<SetStateAction<BoardData>>>((nextBoard) => {
+			currentBoard = typeof nextBoard === "function" ? nextBoard(currentBoard) : nextBoard;
+			return currentBoard;
 		});
 		const ensureTaskWorkspace = vi.fn(async () => ({
 			ok: true as const,
@@ -483,10 +523,26 @@ describe("useBoardInteractions", () => {
 		await act(async () => {
 			root.render(
 				<HookHarness
-					board={board}
+					board={currentBoard}
 					setBoard={setBoard}
 					ensureTaskWorkspace={ensureTaskWorkspace}
 					startTaskSession={startTaskSession}
+					initialSessions={{
+						"task-trash": {
+							taskId: "task-trash",
+							state: "running",
+							agentId: "codex",
+							workspacePath: "/tmp/task-trash",
+							pid: null,
+							startedAt: 1,
+							updatedAt: 2,
+							lastOutputAt: null,
+							reviewReason: null,
+							exitCode: null,
+							lastHookAt: null,
+							latestHookActivity: null,
+						},
+					}}
 					onSnapshot={(snapshot) => {
 						latestSnapshot = snapshot;
 					}}
@@ -522,6 +578,125 @@ describe("useBoardInteractions", () => {
 			message: "Saved task changes could not be reapplied automatically.",
 			timeout: 7000,
 		});
+		expect(currentBoard.columns.find((column) => column.id === "in_progress")?.cards.map((card) => card.id)).toEqual([
+			"task-trash",
+		]);
+		expect(currentBoard.columns.find((column) => column.id === "review")?.cards).toHaveLength(0);
+	});
+
+	it("restores a trashed awaiting-review task back to review", async () => {
+		let latestSnapshot: HookSnapshot | null = null;
+		const trashTask = createTask("task-trash-review", "Review restore", 2);
+		let currentBoard: BoardData = {
+			columns: [
+				{ id: "backlog", title: "Backlog", cards: [] },
+				{ id: "in_progress", title: "In Progress", cards: [] },
+				{ id: "review", title: "Review", cards: [] },
+				{ id: "trash", title: "Trash", cards: [trashTask] },
+			],
+			dependencies: [],
+		};
+		const setBoard = vi.fn<Dispatch<SetStateAction<BoardData>>>((nextBoard) => {
+			currentBoard = typeof nextBoard === "function" ? nextBoard(currentBoard) : nextBoard;
+			return currentBoard;
+		});
+		const startTaskSession = vi.fn(async () => ({ ok: true as const }));
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={currentBoard}
+					setBoard={setBoard}
+					ensureTaskWorkspace={async () => ({ ok: true as const })}
+					startTaskSession={startTaskSession}
+					initialSessions={{
+						"task-trash-review": {
+							taskId: "task-trash-review",
+							state: "awaiting_review",
+							agentId: "codex",
+							workspacePath: "/tmp/task-trash-review",
+							pid: null,
+							startedAt: 1,
+							updatedAt: 2,
+							lastOutputAt: null,
+							reviewReason: "attention",
+							exitCode: null,
+							lastHookAt: null,
+							latestHookActivity: null,
+						},
+					}}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+		});
+
+		if (!latestSnapshot) {
+			throw new Error("Expected a hook snapshot.");
+		}
+
+		await act(async () => {
+			latestSnapshot!.handleRestoreTaskFromTrash("task-trash-review");
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+		});
+
+		expect(startTaskSession).toHaveBeenCalledWith(expect.objectContaining({ id: "task-trash-review" }), {
+			resumeFromTrash: true,
+		});
+		expect(currentBoard.columns.find((column) => column.id === "review")?.cards.map((card) => card.id)).toEqual([
+			"task-trash-review",
+		]);
+		expect(currentBoard.columns.find((column) => column.id === "in_progress")?.cards).toHaveLength(0);
+	});
+
+	it("falls back to review when restoring a trashed task without a saved summary", async () => {
+		let latestSnapshot: HookSnapshot | null = null;
+		const trashTask = createTask("task-trash-fallback", "Fallback restore", 2);
+		let currentBoard: BoardData = {
+			columns: [
+				{ id: "backlog", title: "Backlog", cards: [] },
+				{ id: "in_progress", title: "In Progress", cards: [] },
+				{ id: "review", title: "Review", cards: [] },
+				{ id: "trash", title: "Trash", cards: [trashTask] },
+			],
+			dependencies: [],
+		};
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={currentBoard}
+					setBoard={(updater) => {
+						currentBoard = typeof updater === "function" ? updater(currentBoard) : updater;
+						return currentBoard;
+					}}
+					ensureTaskWorkspace={async () => ({ ok: true as const })}
+					startTaskSession={async () => ({ ok: true as const })}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+		});
+
+		if (!latestSnapshot) {
+			throw new Error("Expected a hook snapshot.");
+		}
+
+		await act(async () => {
+			latestSnapshot!.handleRestoreTaskFromTrash("task-trash-fallback");
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+		});
+
+		expect(currentBoard.columns.find((column) => column.id === "review")?.cards.map((card) => card.id)).toEqual([
+			"task-trash-fallback",
+		]);
+		expect(currentBoard.columns.find((column) => column.id === "in_progress")?.cards).toHaveLength(0);
 	});
 
 	it("preserves model fields when restoring a trashed task", async () => {
@@ -693,6 +868,87 @@ describe("useBoardInteractions", () => {
 			"task-review",
 		]);
 		expect(currentBoard.columns.find((column) => column.id === "trash")?.cards).toHaveLength(0);
+	});
+
+	it("uses the saved running state for drag restore from trash", async () => {
+		let latestSnapshot: HookSnapshot | null = null;
+		const trashTask = createTask("task-trash-drag", "Drag restore", 2);
+		let currentBoard: BoardData = {
+			columns: [
+				{ id: "backlog", title: "Backlog", cards: [] },
+				{ id: "in_progress", title: "In Progress", cards: [] },
+				{ id: "review", title: "Review", cards: [] },
+				{ id: "trash", title: "Trash", cards: [trashTask] },
+			],
+			dependencies: [],
+		};
+		const startTaskSession = vi.fn(async () => ({ ok: true as const }));
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={currentBoard}
+					setBoard={(updater) => {
+						currentBoard = typeof updater === "function" ? updater(currentBoard) : updater;
+						return currentBoard;
+					}}
+					ensureTaskWorkspace={async () => ({ ok: true as const })}
+					startTaskSession={startTaskSession}
+					initialSessions={{
+						"task-trash-drag": {
+							taskId: "task-trash-drag",
+							state: "running",
+							agentId: "codex",
+							workspacePath: "/tmp/task-trash-drag",
+							pid: null,
+							startedAt: 1,
+							updatedAt: 2,
+							lastOutputAt: null,
+							reviewReason: null,
+							exitCode: null,
+							lastHookAt: null,
+							latestHookActivity: null,
+						},
+					}}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+		});
+
+		if (!latestSnapshot) {
+			throw new Error("Expected a hook snapshot.");
+		}
+
+		await act(async () => {
+			latestSnapshot!.handleDragEnd({
+				draggableId: "task-trash-drag",
+				type: "CARD",
+				source: {
+					droppableId: "trash",
+					index: 0,
+				},
+				destination: {
+					droppableId: "review",
+					index: 0,
+				},
+				reason: "DROP",
+				mode: "FLUID",
+				combine: null,
+			});
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+		});
+
+		expect(startTaskSession).toHaveBeenCalledWith(expect.objectContaining({ id: "task-trash-drag" }), {
+			resumeFromTrash: true,
+		});
+		expect(currentBoard.columns.find((column) => column.id === "in_progress")?.cards.map((card) => card.id)).toEqual([
+			"task-trash-drag",
+		]);
+		expect(currentBoard.columns.find((column) => column.id === "review")?.cards).toHaveLength(0);
 	});
 
 	it("ignores card selection requests for trashed tasks", async () => {

--- a/web-ui/src/hooks/use-board-interactions.test.tsx
+++ b/web-ui/src/hooks/use-board-interactions.test.tsx
@@ -67,6 +67,7 @@ const NOOP_RUN_AUTO_REVIEW = async (): Promise<boolean> => false;
 
 interface HookSnapshot {
 	handleRestoreTaskFromTrash: (taskId: string) => void;
+	handleResumeReviewTask: (taskId: string) => void;
 	handleStartTask: (taskId: string) => void;
 	handleCardSelect: (taskId: string) => void;
 }
@@ -132,10 +133,17 @@ function HookHarness({
 	useEffect(() => {
 		onSnapshot?.({
 			handleRestoreTaskFromTrash: actions.handleRestoreTaskFromTrash,
+			handleResumeReviewTask: actions.handleResumeReviewTask,
 			handleStartTask: actions.handleStartTask,
 			handleCardSelect: actions.handleCardSelect,
 		});
-	}, [actions.handleCardSelect, actions.handleRestoreTaskFromTrash, actions.handleStartTask, onSnapshot]);
+	}, [
+		actions.handleCardSelect,
+		actions.handleRestoreTaskFromTrash,
+		actions.handleResumeReviewTask,
+		actions.handleStartTask,
+		onSnapshot,
+	]);
 
 	return null;
 }
@@ -616,6 +624,75 @@ describe("useBoardInteractions", () => {
 			modelId: "my-model",
 		});
 		expect(restoredTask?.agentId).toBe("codex");
+	});
+
+	it("resumes a review task in place when the restored terminal requires reconnect", async () => {
+		let latestSnapshot: HookSnapshot | null = null;
+		let currentBoard: BoardData = {
+			columns: [
+				{ id: "backlog", title: "Backlog", cards: [] },
+				{ id: "in_progress", title: "In Progress", cards: [] },
+				{ id: "review", title: "Review", cards: [createTask("task-review", "Review task", 2)] },
+				{ id: "trash", title: "Trash", cards: [] },
+			],
+			dependencies: [],
+		};
+		const startTaskSession = vi.fn(async () => ({ ok: true as const }));
+
+		useProgrammaticCardMovesMock.mockReturnValue({
+			handleProgrammaticCardMoveReady: () => {},
+			setRequestMoveTaskToTrashHandler: () => {},
+			tryProgrammaticCardMove: () => "unavailable",
+			consumeProgrammaticCardMove: () => ({}),
+			resolvePendingProgrammaticTrashMove: () => {},
+			waitForProgrammaticCardMoveAvailability: async () => {},
+			resetProgrammaticCardMoves: () => {},
+			requestMoveTaskToTrashWithAnimation: async () => {},
+			programmaticCardMoveCycle: 0,
+		});
+
+		useLinkedBacklogTaskActionsMock.mockReturnValue({
+			handleCreateDependency: () => {},
+			handleDeleteDependency: () => {},
+			confirmMoveTaskToTrash: async () => {},
+			requestMoveTaskToTrash: async () => {},
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={currentBoard}
+					setBoard={(updater) => {
+						currentBoard = typeof updater === "function" ? updater(currentBoard) : updater;
+						return currentBoard;
+					}}
+					ensureTaskWorkspace={async () => ({ ok: true as const })}
+					startTaskSession={startTaskSession}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+		});
+
+		if (!latestSnapshot) {
+			throw new Error("Expected a hook snapshot.");
+		}
+
+		await act(async () => {
+			latestSnapshot!.handleResumeReviewTask("task-review");
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+		});
+
+		expect(startTaskSession).toHaveBeenCalledWith(expect.objectContaining({ id: "task-review" }), {
+			resumeFromTrash: true,
+		});
+		expect(currentBoard.columns.find((column) => column.id === "review")?.cards.map((card) => card.id)).toEqual([
+			"task-review",
+		]);
+		expect(currentBoard.columns.find((column) => column.id === "trash")?.cards).toHaveLength(0);
 	});
 
 	it("ignores card selection requests for trashed tasks", async () => {

--- a/web-ui/src/hooks/use-board-interactions.ts
+++ b/web-ui/src/hooks/use-board-interactions.ts
@@ -84,6 +84,7 @@ export interface UseBoardInteractionsResult {
 	handleMoveToTrash: () => void;
 	handleMoveReviewCardToTrash: (taskId: string) => void;
 	handleRestoreTaskFromTrash: (taskId: string) => void;
+	handleResumeReviewTask: (taskId: string) => void;
 	handleCancelAutomaticTaskAction: (taskId: string) => void;
 	handleOpenClearTrash: () => void;
 	handleConfirmClearTrash: () => void;
@@ -797,6 +798,17 @@ export function useBoardInteractions({
 		[board, resumeTaskFromTrash, setBoard, tryProgrammaticCardMove],
 	);
 
+	const handleResumeReviewTask = useCallback(
+		(taskId: string) => {
+			const selection = findCardSelection(board, taskId);
+			if (!selection || selection.column.id !== "review") {
+				return;
+			}
+			void resumeTaskFromTrash(selection.card, taskId);
+		},
+		[board, resumeTaskFromTrash],
+	);
+
 	const handleCancelAutomaticTaskAction = useCallback(
 		(taskId: string) => {
 			setBoard((currentBoard) => {
@@ -894,6 +906,7 @@ export function useBoardInteractions({
 		handleMoveToTrash,
 		handleMoveReviewCardToTrash,
 		handleRestoreTaskFromTrash,
+		handleResumeReviewTask,
 		handleCancelAutomaticTaskAction,
 		handleOpenClearTrash,
 		handleConfirmClearTrash,

--- a/web-ui/src/hooks/use-board-interactions.ts
+++ b/web-ui/src/hooks/use-board-interactions.ts
@@ -45,6 +45,12 @@ interface PendingProgrammaticStartMoveCompletion {
 	timeoutId: number;
 }
 
+function getRestoreTargetColumnId(
+	summary: RuntimeTaskSessionSummary | undefined,
+): Extract<BoardColumnId, "in_progress" | "review"> {
+	return summary?.state === "running" ? "in_progress" : "review";
+}
+
 interface UseBoardInteractionsInput {
 	board: BoardData;
 	setBoard: Dispatch<SetStateAction<BoardData>>;
@@ -622,8 +628,15 @@ export function useBoardInteractions({
 			}
 
 			if (moveEvent.fromColumnId === "trash" && moveEvent.toColumnId === "review") {
-				setBoard(applied.board);
-				const movedSelection = findCardSelection(applied.board, moveEvent.taskId);
+				const restoreTargetColumnId = getRestoreTargetColumnId(sessions[moveEvent.taskId]);
+				const restoredBoard =
+					restoreTargetColumnId === "review"
+						? applied.board
+						: moveTaskToColumn(applied.board, moveEvent.taskId, restoreTargetColumnId, {
+								insertAtTop: true,
+							}).board;
+				setBoard(restoredBoard);
+				const movedSelection = findCardSelection(restoredBoard, moveEvent.taskId);
 				if (!movedSelection) {
 					return;
 				}
@@ -664,6 +677,7 @@ export function useBoardInteractions({
 			resumeTaskFromTrash,
 			resolvePendingProgrammaticStartMove,
 			resolvePendingProgrammaticTrashMove,
+			sessions,
 			setBoard,
 			setSelectedTaskId,
 		],
@@ -774,7 +788,8 @@ export function useBoardInteractions({
 
 	const handleRestoreTaskFromTrash = useCallback(
 		(taskId: string) => {
-			const programmaticMoveAttempt = tryProgrammaticCardMove(taskId, "trash", "review");
+			const restoreTargetColumnId = getRestoreTargetColumnId(sessions[taskId]);
+			const programmaticMoveAttempt = tryProgrammaticCardMove(taskId, "trash", restoreTargetColumnId);
 			if (programmaticMoveAttempt === "started" || programmaticMoveAttempt === "blocked") {
 				return;
 			}
@@ -784,7 +799,7 @@ export function useBoardInteractions({
 				return;
 			}
 
-			const moved = moveTaskToColumn(board, taskId, "review", { insertAtTop: true });
+			const moved = moveTaskToColumn(board, taskId, restoreTargetColumnId, { insertAtTop: true });
 			if (!moved.moved) {
 				return;
 			}
@@ -795,7 +810,7 @@ export function useBoardInteractions({
 			}
 			void resumeTaskFromTrash(movedSelection.card, taskId, { optimisticMoveApplied: true });
 		},
-		[board, resumeTaskFromTrash, setBoard, tryProgrammaticCardMove],
+		[board, resumeTaskFromTrash, sessions, setBoard, tryProgrammaticCardMove],
 	);
 
 	const handleResumeReviewTask = useCallback(

--- a/web-ui/src/state/drag-rules.test.ts
+++ b/web-ui/src/state/drag-rules.test.ts
@@ -57,4 +57,33 @@ describe("drag rules", () => {
 	it("allows manual trash to review drops", () => {
 		expect(isCardDropDisabled("review", "trash")).toBe(false);
 	});
+
+	it("keeps manual trash to in-progress drops disabled", () => {
+		expect(isCardDropDisabled("in_progress", "trash")).toBe(true);
+	});
+
+	it("allows the matching programmatic trash to in-progress drop", () => {
+		const move: ProgrammaticCardMoveInFlight = {
+			taskId: "task-1",
+			fromColumnId: "trash",
+			toColumnId: "in_progress",
+			insertAtTop: true,
+		};
+
+		expect(
+			isCardDropDisabled("in_progress", "trash", {
+				activeDragTaskId: "task-1",
+				programmaticCardMoveInFlight: move,
+			}),
+		).toBe(false);
+		expect(
+			isCardDropDisabled("in_progress", "trash", {
+				activeDragTaskId: "task-1",
+				programmaticCardMoveInFlight: {
+					...move,
+					toColumnId: "review",
+				},
+			}),
+		).toBe(true);
+	});
 });

--- a/web-ui/src/state/drag-rules.ts
+++ b/web-ui/src/state/drag-rules.ts
@@ -39,6 +39,14 @@ export function isAllowedCrossColumnCardMove(
 	if (fromColumnId === "trash" && toColumnId === "review") {
 		return true;
 	}
+	if (fromColumnId === "trash" && toColumnId === "in_progress") {
+		return isMatchingProgrammaticCardMove(
+			options?.taskId,
+			fromColumnId,
+			toColumnId,
+			options?.programmaticCardMoveInFlight,
+		);
+	}
 	if (
 		(fromColumnId === "in_progress" && toColumnId === "review") ||
 		(fromColumnId === "review" && toColumnId === "in_progress")

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -35,6 +35,7 @@ interface PersistentTerminalAppearance {
 interface PersistentTerminalSubscriber {
 	onConnectionReady?: (taskId: string) => void;
 	onLastError?: (message: string | null) => void;
+	onResumeRequiredChange?: (required: boolean) => void;
 	onSummary?: (summary: RuntimeTaskSessionSummary) => void;
 	onOutputText?: (text: string) => void;
 }
@@ -152,6 +153,7 @@ class PersistentTerminal {
 	private appearance: PersistentTerminalAppearance;
 	private latestSummary: RuntimeTaskSessionSummary | null = null;
 	private lastError: string | null = null;
+	private resumeRequired = false;
 	private resizeObserver: ResizeObserver | null = null;
 	private resizeTimer: ReturnType<typeof setTimeout> | null = null;
 	private visibleContainer: HTMLDivElement | null = null;
@@ -241,8 +243,18 @@ class PersistentTerminal {
 
 	private notifySummary(summary: RuntimeTaskSessionSummary): void {
 		this.latestSummary = summary;
+		if (summary.state !== "awaiting_review" && this.resumeRequired) {
+			this.resumeRequired = false;
+			this.notifyResumeRequired();
+		}
 		for (const subscriber of this.subscribers) {
 			subscriber.onSummary?.(summary);
+		}
+	}
+
+	private notifyResumeRequired(): void {
+		for (const subscriber of this.subscribers) {
+			subscriber.onResumeRequiredChange?.(this.resumeRequired);
 		}
 	}
 
@@ -421,6 +433,11 @@ class PersistentTerminal {
 
 			if (payload.type === "restore") {
 				this.restoreCompleted = false;
+				const nextResumeRequired = payload.requiresResume === true;
+				if (this.resumeRequired !== nextResumeRequired) {
+					this.resumeRequired = nextResumeRequired;
+					this.notifyResumeRequired();
+				}
 				void this.applyRestore(payload.snapshot, payload.cols, payload.rows)
 					.then(() => {
 						if (this.disposed || this.controlSocket !== controlSocket) {
@@ -508,6 +525,7 @@ class PersistentTerminal {
 	subscribe(subscriber: PersistentTerminalSubscriber): () => void {
 		this.subscribers.add(subscriber);
 		subscriber.onLastError?.(this.lastError);
+		subscriber.onResumeRequiredChange?.(this.resumeRequired);
 		if (this.latestSummary) {
 			subscriber.onSummary?.(this.latestSummary);
 		}

--- a/web-ui/src/terminal/use-persistent-terminal-session.ts
+++ b/web-ui/src/terminal/use-persistent-terminal-session.ts
@@ -22,6 +22,7 @@ interface UsePersistentTerminalSessionInput {
 export interface UsePersistentTerminalSessionResult {
 	containerRef: MutableRefObject<HTMLDivElement | null>;
 	lastError: string | null;
+	resumeRequired: boolean;
 	isStopping: boolean;
 	clearTerminal: () => void;
 	stopTerminal: () => Promise<void>;
@@ -56,6 +57,7 @@ export function usePersistentTerminalSession({
 		sessionStartedAt: number | null;
 	} | null>(null);
 	const [lastError, setLastError] = useState<string | null>(null);
+	const [resumeRequired, setResumeRequired] = useState(false);
 	const [isStopping, setIsStopping] = useState(false);
 	callbackRef.current = {
 		onSummary,
@@ -72,6 +74,7 @@ export function usePersistentTerminalSession({
 			terminalRef.current = null;
 			previousSessionRef.current = null;
 			setLastError(null);
+			setResumeRequired(false);
 			setIsStopping(false);
 			return;
 		}
@@ -85,6 +88,7 @@ export function usePersistentTerminalSession({
 			terminalRef.current = null;
 			previousSessionRef.current = null;
 			setLastError("No project selected.");
+			setResumeRequired(false);
 			return;
 		}
 		const container = containerRef.current;
@@ -119,6 +123,7 @@ export function usePersistentTerminalSession({
 				callbackRef.current.onConnectionReady?.(connectedTaskId);
 			},
 			onLastError: setLastError,
+			onResumeRequiredChange: setResumeRequired,
 			onSummary: (summary) => {
 				callbackRef.current.onSummary?.(summary);
 			},
@@ -186,6 +191,7 @@ export function usePersistentTerminalSession({
 	return {
 		containerRef,
 		lastError,
+		resumeRequired,
 		isStopping,
 		clearTerminal,
 		stopTerminal,


### PR DESCRIPTION
## Summary

Fix review-session recovery after a Kanban restart, daemon shutdown, or crash.

This change preserves enough review recovery state to reconnect persisted review cards back to their workspace and terminal session, so cards left in `in_progress` or `review` can resume cleanly instead of getting stranded.

## What changed

- persist review recovery state needed to reconstruct the session
- restore workspace/session linkage during persisted review recovery
- reconnect terminal resume flow for restored review cards
- wire the web UI back into the recovered persisted-review session path

## Validation

- `npm run test:fast`
- `npm run test:integration`
- `npm run web:test`
- `npm run typecheck`
- `npm run web:typecheck`

All passed locally.

## Related

Related discussion: https://github.com/cline/kanban/discussions/323
