### PR TITLE
persist column collapse state

### DIFF
--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -802,6 +802,7 @@ export function CardDetailView({
 						<ColumnContextPanel
 							selection={selection}
 							workspacePath={workspacePath}
+							projectId={currentProjectId}
 							onCardSelect={onCardSelect}
 							taskSessions={taskSessions}
 							onTaskDragEnd={onTaskDragEnd}

--- a/web-ui/src/components/detail-panels/column-context-panel.tsx
+++ b/web-ui/src/components/detail-panels/column-context-panel.tsx
@@ -6,14 +6,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { BoardCard } from "@/components/board-card";
 import { Button } from "@/components/ui/button";
 import { ColumnIndicator } from "@/components/ui/column-indicator";
+import { useColumnCollapseState } from "@/hooks/use-column-collapse-state";
 import type { RuntimeTaskSessionSummary } from "@/runtime/types";
 import { findCardColumnId, isCardDropDisabled } from "@/state/drag-rules";
-import type { BoardCard as BoardCardModel, BoardColumn, BoardColumnId, CardSelection } from "@/types";
+import type { BoardCard as BoardCardModel, BoardColumn, BoardColumnId, CardSelection } from "@/types/board";
 
 function ColumnSection({
 	column,
 	selectedCardId,
-	defaultOpen,
+	isOpen,
+	onToggle,
 	onCardClick,
 	taskSessions,
 	onCreateTask,
@@ -37,7 +39,8 @@ function ColumnSection({
 }: {
 	column: BoardColumn;
 	selectedCardId: string;
-	defaultOpen: boolean;
+	isOpen: boolean;
+	onToggle?: (columnId: BoardColumnId, open: boolean) => void;
 	onCardClick: (card: BoardCardModel) => void;
 	taskSessions: Record<string, RuntimeTaskSessionSummary>;
 	onCreateTask?: () => void;
@@ -59,19 +62,34 @@ function ColumnSection({
 	workspacePath?: string | null;
 	defaultClineModelId?: string | null;
 }): React.ReactElement {
-	const [open, setOpen] = useState(defaultOpen);
+	const [open, setOpen] = useState(isOpen);
 	const canCreate = column.id === "backlog" && onCreateTask;
 	const canStartAllTasks = column.id === "backlog" && onStartAllTasks;
 	const canClearTrash = column.id === "trash" && onClearTrash;
 	const cardDropType = "CARD";
 	const isDropDisabled = isCardDropDisabled(column.id, activeDragSourceColumnId ?? null);
 
+	// Sync with external isOpen state (from persisted state)
+	useEffect(() => {
+		setOpen(isOpen);
+	}, [isOpen]);
+
+	// Auto-expand when card is selected (does not persist)
 	useEffect(() => {
 		if (!column.cards.some((card) => card.id === selectedCardId)) {
 			return;
 		}
 		setOpen(true);
 	}, [column.cards, selectedCardId]);
+
+	// Handle toggle with persistence
+	const handleToggle = useCallback(() => {
+		setOpen((prev) => {
+			const newOpen = !prev;
+			onToggle?.(column.id, newOpen);
+			return newOpen;
+		});
+	}, [column.id, onToggle]);
 
 	return (
 		<div className="bg-surface-1 rounded-lg shrink-0 border border-border">
@@ -84,7 +102,7 @@ function ColumnSection({
 			>
 				<button
 					type="button"
-					onClick={() => setOpen((prev) => !prev)}
+					onClick={handleToggle}
 					className="hover:bg-surface-0 rounded-md"
 					style={{
 						height: 32,
@@ -230,6 +248,7 @@ function ColumnSection({
 export function ColumnContextPanel({
 	selection,
 	workspacePath,
+	projectId,
 	defaultClineModelId,
 	onCardSelect,
 	taskSessions,
@@ -253,6 +272,7 @@ export function ColumnContextPanel({
 }: {
 	selection: CardSelection;
 	workspacePath?: string | null;
+	projectId?: string | null;
 	onCardSelect: (taskId: string) => void;
 	taskSessions: Record<string, RuntimeTaskSessionSummary>;
 	onTaskDragEnd: (result: DropResult) => void;
@@ -276,6 +296,7 @@ export function ColumnContextPanel({
 }): React.ReactElement {
 	const [activeDragSourceColumnId, setActiveDragSourceColumnId] = useState<BoardColumnId | null>(null);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const { collapseState, toggleColumn } = useColumnCollapseState(projectId);
 
 	const handleBeforeCapture = useCallback(
 		(start: BeforeCapture) => {
@@ -342,7 +363,8 @@ export function ColumnContextPanel({
 							key={column.id}
 							column={column}
 							selectedCardId={selection.card.id}
-							defaultOpen={column.id !== "trash"}
+							isOpen={collapseState[column.id]}
+							onToggle={toggleColumn}
 							onCardClick={(card) => onCardSelect(card.id)}
 							taskSessions={taskSessions}
 							onCreateTask={column.id === "backlog" ? onCreateTask : undefined}

--- a/web-ui/src/hooks/use-column-collapse-state.test.tsx
+++ b/web-ui/src/hooks/use-column-collapse-state.test.tsx
@@ -1,0 +1,417 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useColumnCollapseState } from "@/hooks/use-column-collapse-state";
+import { LocalStorageKey } from "@/storage/local-storage-store";
+
+vi.mock("@/storage/local-storage-store", () => ({
+	LocalStorageKey: {
+		TaskDetailColumnsCollapsed: "kanban.task-detail-columns-collapsed",
+	},
+	readLocalStorageItem: vi.fn(),
+	writeLocalStorageItem: vi.fn(),
+}));
+
+import { readLocalStorageItem, writeLocalStorageItem } from "@/storage/local-storage-store";
+
+const mockReadLocalStorageItem = vi.mocked(readLocalStorageItem);
+const mockWriteLocalStorageItem = vi.mocked(writeLocalStorageItem);
+
+type ColumnCollapseStateResult = ReturnType<typeof useColumnCollapseState>;
+
+function HookHarness({
+	projectId,
+	onResult,
+}: {
+	projectId: string | null | undefined;
+	onResult: (result: ColumnCollapseStateResult) => void;
+}): null {
+	const result = useColumnCollapseState(projectId);
+	onResult(result);
+	return null;
+}
+
+function getResult(result: ColumnCollapseStateResult | null): ColumnCollapseStateResult {
+	if (result === null) {
+		throw new Error("Expected hook result.");
+	}
+	return result;
+}
+
+describe("useColumnCollapseState", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let previousActEnvironment: boolean | undefined;
+
+	beforeEach(() => {
+		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+		mockReadLocalStorageItem.mockReset();
+		mockWriteLocalStorageItem.mockReset();
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		vi.restoreAllMocks();
+		container.remove();
+		if (previousActEnvironment === undefined) {
+			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+		} else {
+			(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+				previousActEnvironment;
+		}
+	});
+
+	describe("default state", () => {
+		it("returns default collapse state when no projectId provided", async () => {
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId={null}
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: true,
+				in_progress: true,
+				review: true,
+				trash: false,
+			});
+			expect(mockReadLocalStorageItem).not.toHaveBeenCalled();
+		});
+
+		it("returns default collapse state when projectId is undefined", async () => {
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId={undefined}
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: true,
+				in_progress: true,
+				review: true,
+				trash: false,
+			});
+		});
+	});
+
+	describe("loading persisted state", () => {
+		it("loads persisted state for a project", async () => {
+			mockReadLocalStorageItem.mockReturnValue(
+				JSON.stringify({
+					"project-a": { backlog: false, in_progress: true, review: false, trash: true },
+				}),
+			);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			expect(mockReadLocalStorageItem).toHaveBeenCalledWith(LocalStorageKey.TaskDetailColumnsCollapsed);
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: false,
+				in_progress: true,
+				review: false,
+				trash: true,
+			});
+		});
+
+		it("returns default state when localStorage is empty", async () => {
+			mockReadLocalStorageItem.mockReturnValue(null);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-b"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: true,
+				in_progress: true,
+				review: true,
+				trash: false,
+			});
+		});
+
+		it("returns default state when project not in storage", async () => {
+			mockReadLocalStorageItem.mockReturnValue(JSON.stringify({ "project-a": { backlog: false } }));
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-b"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: true,
+				in_progress: true,
+				review: true,
+				trash: false,
+			});
+		});
+
+		it("returns default state on JSON parse error", async () => {
+			mockReadLocalStorageItem.mockReturnValue("invalid-json");
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-c"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: true,
+				in_progress: true,
+				review: true,
+				trash: false,
+			});
+		});
+
+		it("merges stored values with defaults for missing columns", async () => {
+			mockReadLocalStorageItem.mockReturnValue(
+				JSON.stringify({
+					"project-a": { backlog: false, trash: true },
+				}),
+			);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			const result = getResult(hookResult);
+			expect(result.collapseState).toEqual({
+				backlog: false,
+				in_progress: true,
+				review: true,
+				trash: true,
+			});
+		});
+	});
+
+	describe("toggleColumn", () => {
+		it("toggles column state and persists", async () => {
+			mockReadLocalStorageItem.mockReturnValue(null);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			expect(getResult(hookResult).collapseState.backlog).toBe(true);
+
+			await act(async () => {
+				getResult(hookResult).toggleColumn("backlog");
+			});
+
+			expect(getResult(hookResult).collapseState.backlog).toBe(false);
+			expect(mockWriteLocalStorageItem).toHaveBeenCalledWith(
+				LocalStorageKey.TaskDetailColumnsCollapsed,
+				JSON.stringify({ "project-a": { backlog: false, in_progress: true, review: true, trash: false } }),
+			);
+		});
+
+		it("does nothing when projectId is null", async () => {
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId={null}
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			await act(async () => {
+				getResult(hookResult).toggleColumn("backlog");
+			});
+
+			expect(mockWriteLocalStorageItem).not.toHaveBeenCalled();
+			expect(getResult(hookResult).collapseState.backlog).toBe(true);
+		});
+
+		it("preserves state for other projects", async () => {
+			mockReadLocalStorageItem.mockReturnValue(
+				JSON.stringify({
+					"project-a": { backlog: false },
+					"project-b": { review: false },
+				}),
+			);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			await act(async () => {
+				getResult(hookResult).toggleColumn("in_progress");
+			});
+
+			expect(mockWriteLocalStorageItem).toHaveBeenCalledWith(
+				LocalStorageKey.TaskDetailColumnsCollapsed,
+				JSON.stringify({
+					"project-a": { backlog: false, in_progress: false, review: true, trash: false },
+					"project-b": { review: false },
+				}),
+			);
+		});
+	});
+
+	describe("setColumnOpen", () => {
+		it("sets column open state and persists when changed", async () => {
+			mockReadLocalStorageItem.mockReturnValue(null);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			expect(getResult(hookResult).collapseState.trash).toBe(false);
+
+			await act(async () => {
+				getResult(hookResult).setColumnOpen("trash", true);
+			});
+
+			expect(getResult(hookResult).collapseState.trash).toBe(true);
+			expect(mockWriteLocalStorageItem).toHaveBeenCalled();
+		});
+
+		it("does not persist when value unchanged", async () => {
+			mockReadLocalStorageItem.mockReturnValue(null);
+
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId="project-a"
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			expect(getResult(hookResult).collapseState.backlog).toBe(true);
+
+			await act(async () => {
+				getResult(hookResult).setColumnOpen("backlog", true);
+			});
+
+			expect(mockWriteLocalStorageItem).not.toHaveBeenCalled();
+		});
+
+		it("does nothing when projectId is null", async () => {
+			let hookResult: ColumnCollapseStateResult | null = null;
+
+			await act(async () => {
+				root.render(
+					<HookHarness
+						projectId={null}
+						onResult={(result) => {
+							hookResult = result;
+						}}
+					/>,
+				);
+			});
+
+			await act(async () => {
+				getResult(hookResult).setColumnOpen("trash", true);
+			});
+
+			expect(mockWriteLocalStorageItem).not.toHaveBeenCalled();
+			expect(getResult(hookResult).collapseState.trash).toBe(false);
+		});
+	});
+});

--- a/web-ui/src/hooks/use-column-collapse-state.ts
+++ b/web-ui/src/hooks/use-column-collapse-state.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from "react";
+
+import { LocalStorageKey, readLocalStorageItem, writeLocalStorageItem } from "@/storage/local-storage-store";
+import type { BoardColumnId } from "@/types/board";
+
+const DEFAULT_STATE: Record<BoardColumnId, boolean> = {
+	backlog: true,
+	in_progress: true,
+	review: true,
+	trash: false,
+};
+
+function loadColumnCollapseState(projectId: string): Record<BoardColumnId, boolean> {
+	const stored = readLocalStorageItem(LocalStorageKey.TaskDetailColumnsCollapsed);
+	if (!stored) {
+		return DEFAULT_STATE;
+	}
+
+	try {
+		const parsed = JSON.parse(stored) as Record<string, Record<BoardColumnId, boolean>>;
+		const projectState = parsed[projectId];
+		if (!projectState) {
+			return DEFAULT_STATE;
+		}
+		return { ...DEFAULT_STATE, ...projectState };
+	} catch {
+		return DEFAULT_STATE;
+	}
+}
+
+function persistColumnCollapseState(projectId: string, state: Record<BoardColumnId, boolean>): void {
+	const stored = readLocalStorageItem(LocalStorageKey.TaskDetailColumnsCollapsed);
+	let parsed: Record<string, Record<BoardColumnId, boolean>> = {};
+
+	if (stored) {
+		try {
+			parsed = JSON.parse(stored) as Record<string, Record<BoardColumnId, boolean>>;
+		} catch {
+			// Ignore parse errors
+		}
+	}
+
+	parsed[projectId] = state;
+	writeLocalStorageItem(LocalStorageKey.TaskDetailColumnsCollapsed, JSON.stringify(parsed));
+}
+
+export function useColumnCollapseState(projectId: string | null | undefined) {
+	const [state, setState] = useState<Record<BoardColumnId, boolean>>(() => {
+		if (!projectId) {
+			return DEFAULT_STATE;
+		}
+		return loadColumnCollapseState(projectId);
+	});
+
+	const toggleColumn = useCallback(
+		(columnId: BoardColumnId) => {
+			if (!projectId) {
+				return;
+			}
+
+			setState((prev) => {
+				const newState = { ...prev, [columnId]: !prev[columnId] };
+				persistColumnCollapseState(projectId, newState);
+				return newState;
+			});
+		},
+		[projectId],
+	);
+
+	const setColumnOpen = useCallback(
+		(columnId: BoardColumnId, open: boolean) => {
+			if (!projectId) {
+				return;
+			}
+
+			setState((prev) => {
+				if (prev[columnId] === open) {
+					return prev;
+				}
+				const newState = { ...prev, [columnId]: open };
+				persistColumnCollapseState(projectId, newState);
+				return newState;
+			});
+		},
+		[projectId],
+	);
+
+	return {
+		collapseState: state,
+		toggleColumn,
+		setColumnOpen,
+	};
+}

--- a/web-ui/src/storage/local-storage-store.ts
+++ b/web-ui/src/storage/local-storage-store.ts
@@ -20,6 +20,7 @@ export enum LocalStorageKey {
 	NotificationBadgeClearEvent = "kanban.notification-badge-clear.v1",
 	TabVisibilityPresence = "kanban.tab-visibility-presence.v1",
 	Theme = "kanban.theme",
+	TaskDetailColumnsCollapsed = "kanban.task-detail-columns-collapsed",
 }
 
 export const LAYOUT_CUSTOMIZATION_LOCAL_STORAGE_KEYS = [


### PR DESCRIPTION
<img width="1742" height="1220" alt="image" src="https://github.com/user-attachments/assets/261de1d0-18b0-4168-b36d-37b4feaaa948" />

- Add localStorage key for TaskDetailColumnsCollapsed
- Create useColumnCollapseState hook for managing collapse state
- Modify ColumnSection to use persisted state (isOpen/onToggle)
- Pass projectId from CardDetailView to ColumnContextPanel
- Default: Backlog, In Progress, Review expanded; Trash collapsed
- Auto-expand on card selection does not trigger persistence