### PR TITLE
dev-full: default to skip shutdown cleanup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,6 +50,12 @@ Use `npm run dev:full` when you are actively developing Kanban and want fast ite
 
 By default, `dev:full` now starts Kanban with `--skip-shutdown-cleanup` so stopping a debug/dev instance does not move cards to Trash or delete task worktrees from your active boards.
 
+To opt back into shutdown cleanup while using `dev:full`, run:
+
+```bash
+npm run dev:full -- --with-shutdown-cleanup
+```
+
 If `node_modules` has not been installed in this worktree, `dev:full` auto-runs `npm ci` before launch.
 
 Use `npm run dogfood` when you want to validate the latest built CLI behavior more realistically. It builds the current checkout and launches `dist/cli.js`, which is better for checking packaged behavior, startup and shutdown flows, multi-instance dogfooding, and launch behavior against a target project.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,6 +48,10 @@ Use `http://127.0.0.1:4173` while developing UI so changes hot reload.
 
 Use `npm run dev:full` when you are actively developing Kanban and want fast iteration. It runs the source checkout with `tsx watch` plus the Vite web UI dev server, so runtime changes reload and web UI changes get HMR.
 
+By default, `dev:full` now starts Kanban with `--skip-shutdown-cleanup` so stopping a debug/dev instance does not move cards to Trash or delete task worktrees from your active boards.
+
+If `node_modules` has not been installed in this worktree, `dev:full` auto-runs `npm ci` before launch.
+
 Use `npm run dogfood` when you want to validate the latest built CLI behavior more realistically. It builds the current checkout and launches `dist/cli.js`, which is better for checking packaged behavior, startup and shutdown flows, multi-instance dogfooding, and launch behavior against a target project.
 
 ## VS Code F5 debugging
@@ -56,6 +60,10 @@ The repo includes `.vscode/launch.json` with two configurations:
 
 - `Dev (Full Stack)`: Launches the same workflow as `npm run dev:full`, starting both the runtime and Vite in one terminal.
 - `Run Tests`: Runs `vitest run` with the debugger so you can set breakpoints in tests.
+
+Shutdown cleanup flags:
+
+- `--skip-shutdown-cleanup`: do not move sessions to trash or delete task worktrees on shutdown
 
 ## Build and run packaged CLI
 

--- a/scripts/dev-full.mjs
+++ b/scripts/dev-full.mjs
@@ -4,11 +4,32 @@
  * VS Code "Dev (Full Stack)" launch config.
  */
 import { createServer, connect } from "node:net";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
 import { spawn } from "node:child_process";
 import treeKill from "tree-kill";
 import open from "open";
 
 const isWindows = process.platform === "win32";
+
+async function ensureDependenciesInstalled() {
+	const lockIndicator = join(process.cwd(), "node_modules", ".package-lock.json");
+	try {
+		await access(lockIndicator);
+	} catch {
+		console.warn("node_modules not installed in this worktree. Running npm ci...");
+		await run("npm", ["ci"]);
+		await run("npm", ["--prefix", "web-ui", "ci"]);
+	}
+}
+
+function run(command, args) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { stdio: "inherit", shell: isWindows });
+		child.on("error", reject);
+		child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${command} exited ${code}`))));
+	});
+}
 
 function findPort(start, reserved = new Set()) {
 	if (reserved.has(start)) {
@@ -44,8 +65,19 @@ function waitForPort(port, timeout = 15000) {
 	});
 }
 
+await ensureDependenciesInstalled();
+
 const runtimePort = await findPort(3484);
 const webUiPort = await findPort(4173, new Set([runtimePort]));
+const requestedRuntimeArgs = process.argv.slice(2);
+const hasExplicitCleanupArg = requestedRuntimeArgs.some((arg) => arg === "--skip-shutdown-cleanup");
+const runtimeCliArgs = [
+	"--port",
+	String(runtimePort),
+	"--no-open",
+	...(hasExplicitCleanupArg ? [] : ["--skip-shutdown-cleanup"]),
+	...requestedRuntimeArgs,
+];
 
 console.log(`\n  Runtime port: ${runtimePort}`);
 console.log(`  Web UI:       http://127.0.0.1:${webUiPort}\n`);
@@ -57,7 +89,7 @@ const env = {
 };
 
 const tsxBin = isWindows ? "node_modules/.bin/tsx.cmd" : "node_modules/.bin/tsx";
-const runtime = spawn(tsxBin, ["watch", "src/cli.ts", "--port", String(runtimePort), "--no-open"], {
+const runtime = spawn(tsxBin, ["watch", "src/cli.ts", ...runtimeCliArgs], {
 	env,
 	stdio: "inherit",
 });

--- a/scripts/dev-full.mjs
+++ b/scripts/dev-full.mjs
@@ -69,13 +69,16 @@ await ensureDependenciesInstalled();
 
 const runtimePort = await findPort(3484);
 const webUiPort = await findPort(4173, new Set([runtimePort]));
-const requestedRuntimeArgs = process.argv.slice(2);
-const hasExplicitCleanupArg = requestedRuntimeArgs.some((arg) => arg === "--skip-shutdown-cleanup");
+const requestedDevFullArgs = process.argv.slice(2);
+const withShutdownCleanupFlag = "--with-shutdown-cleanup";
+const requestedRuntimeArgs = requestedDevFullArgs.filter((arg) => arg !== withShutdownCleanupFlag);
+const hasExplicitSkipCleanupArg = requestedRuntimeArgs.some((arg) => arg === "--skip-shutdown-cleanup");
+const shouldDefaultSkipShutdownCleanup = !requestedDevFullArgs.includes(withShutdownCleanupFlag);
 const runtimeCliArgs = [
 	"--port",
 	String(runtimePort),
 	"--no-open",
-	...(hasExplicitCleanupArg ? [] : ["--skip-shutdown-cleanup"]),
+	...(shouldDefaultSkipShutdownCleanup && !hasExplicitSkipCleanupArg ? ["--skip-shutdown-cleanup"] : []),
 	...requestedRuntimeArgs,
 ];
 

--- a/scripts/dev-full.mjs
+++ b/scripts/dev-full.mjs
@@ -6,9 +6,7 @@
 import { createServer, connect } from "node:net";
 import { access } from "node:fs/promises";
 import { join } from "node:path";
-import { spawn } from "node:child_process";
-import treeKill from "tree-kill";
-import open from "open";
+import { spawn, spawnSync } from "node:child_process";
 
 const isWindows = process.platform === "win32";
 
@@ -16,20 +14,28 @@ async function ensureDependenciesInstalled() {
 	const lockIndicator = join(process.cwd(), "node_modules", ".package-lock.json");
 	try {
 		await access(lockIndicator);
+		return;
 	} catch {
-		console.warn("node_modules not installed in this worktree. Running npm ci...");
-		await run("npm", ["ci"]);
-		await run("npm", ["--prefix", "web-ui", "ci"]);
+		// node_modules is missing; fall through to install below.
+	}
+	console.warn("node_modules not installed in this worktree. Running npm ci...");
+	for (const args of [["ci"], ["--prefix", "web-ui", "ci"]]) {
+		const result = spawnSync("npm", args, { stdio: "inherit", shell: isWindows });
+		if (result.status !== 0) {
+			process.exit(result.status ?? 1);
+		}
 	}
 }
 
-function run(command, args) {
-	return new Promise((resolve, reject) => {
-		const child = spawn(command, args, { stdio: "inherit", shell: isWindows });
-		child.on("error", reject);
-		child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${command} exited ${code}`))));
-	});
-}
+// Must run before importing any third-party modules so a fresh worktree with
+// an empty node_modules can bootstrap itself using only node: built-ins.
+await ensureDependenciesInstalled();
+
+// Deferred until after ensureDependenciesInstalled so these resolve against
+// the freshly-installed node_modules. Static top-level imports would be
+// resolved before any code runs and fail with ERR_MODULE_NOT_FOUND.
+const { default: treeKill } = await import("tree-kill");
+const { default: open } = await import("open");
 
 function findPort(start, reserved = new Set()) {
 	if (reserved.has(start)) {
@@ -64,8 +70,6 @@ function waitForPort(port, timeout = 15000) {
 		attempt();
 	});
 }
-
-await ensureDependenciesInstalled();
 
 const runtimePort = await findPort(3484);
 const webUiPort = await findPort(4173, new Set([runtimePort]));


### PR DESCRIPTION
## Summary
- default `scripts/dev-full.mjs` to pass `--skip-shutdown-cleanup` unless explicitly overridden
- add a `--with-shutdown-cleanup` opt-in for `dev:full` so shutdown cleanup behavior can still be tested
- make `dev:full` auto-install dependencies (`npm ci` + `npm --prefix web-ui ci`) when `node_modules` is missing
- document both default behavior and opt-in override in `DEVELOPMENT.md`

## Testing
- `node --check scripts/dev-full.mjs`