### PR TITLE
fix: remove live title preview from task creation, fix card click-through on title input

### DIFF
--- a/src/core/task-title.ts
+++ b/src/core/task-title.ts
@@ -14,13 +14,25 @@ function truncateTaskTitle(value: string, maxChars: number): string {
 	return `${value.slice(0, maxChars).trimEnd()}…`;
 }
 
+function stripOuterUserInputTag(value: string): string {
+	return value
+		.replace(/^<user_input(?:\s[^>]*)?>/u, "")
+		.replace(/<\/user_input>$/u, "")
+		.trim();
+}
+
 export function deriveTaskTitleFromPrompt(prompt: string, maxChars = DEFAULT_TASK_TITLE_MAX_CHARS): string {
 	const firstNonEmptyLine =
 		prompt
 			.split(/\r?\n/u)
 			.map((line) => line.trim())
 			.find((line) => line.length > 0) ?? "";
-	const normalizedLine = normalizeTaskTitleWhitespace(firstNonEmptyLine);
+	// Strip leading/trailing XML/HTML tags (e.g. <user_input mode="act">…</user_input>) if present.
+	const strippedLine = firstNonEmptyLine
+		.replace(/^<[^>]+>/u, "")
+		.replace(/<\/[^>]+>$/u, "")
+		.trim();
+	const normalizedLine = normalizeTaskTitleWhitespace(strippedLine);
 	if (!normalizedLine) {
 		return "";
 	}
@@ -32,7 +44,11 @@ export function deriveTaskTitleFromPrompt(prompt: string, maxChars = DEFAULT_TAS
 export function resolveTaskTitle(title: string | null | undefined, prompt: string): string {
 	const normalizedTitle = normalizeTaskTitleWhitespace(title ?? "");
 	if (normalizedTitle) {
-		return truncateTaskTitle(normalizedTitle, DEFAULT_TASK_TITLE_MAX_CHARS);
+		const strippedTitle = stripOuterUserInputTag(normalizedTitle);
+		if (strippedTitle) {
+			return truncateTaskTitle(strippedTitle, DEFAULT_TASK_TITLE_MAX_CHARS);
+		}
+		return deriveTaskTitleFromPrompt(prompt);
 	}
 	return deriveTaskTitleFromPrompt(prompt);
 }

--- a/test/runtime/task-title.test.ts
+++ b/test/runtime/task-title.test.ts
@@ -19,7 +19,43 @@ describe("task title helpers", () => {
 		expect(resolveTaskTitle("  Custom title  ", "Prompt body")).toBe("Custom title");
 	});
 
+	it("strips user_input wrapper tags from an explicit stored title", () => {
+		expect(resolveTaskTitle('<user_input mode="act">Fix the login bug</user_input>', "Prompt body")).toBe(
+			"Fix the login bug",
+		);
+	});
+
+	it("strips a leading user_input tag from an explicit stored title", () => {
+		expect(resolveTaskTitle('<user_input mode="act">Fix the login bug', "Prompt body")).toBe("Fix the login bug");
+	});
+
+	it("falls back to the prompt when explicit title only contains user_input wrapper tags", () => {
+		expect(resolveTaskTitle('<user_input mode="act"></user_input>', "Prompt body")).toBe("Prompt body");
+	});
+
 	it("falls back to the prompt when the title is blank", () => {
 		expect(resolveTaskTitle("   ", "Prompt body")).toBe("Prompt body");
+	});
+
+	it("does not alter explicit titles that contain XML-like text in the middle", () => {
+		expect(resolveTaskTitle("Investigate React <Component> rendering", "Prompt body")).toBe(
+			"Investigate React <Component> rendering",
+		);
+	});
+
+	it("strips a leading XML tag when deriving from a prompt", () => {
+		expect(deriveTaskTitleFromPrompt('<user_input mode="act">Fix the login bug\nWith extra details')).toBe(
+			"Fix the login bug",
+		);
+	});
+
+	it("strips both leading and trailing XML tags on a single-line prompt", () => {
+		expect(deriveTaskTitleFromPrompt('<user_input mode="act">Fix the login bug</user_input>')).toBe(
+			"Fix the login bug",
+		);
+	});
+
+	it("handles a prompt that is only an XML tag", () => {
+		expect(deriveTaskTitleFromPrompt("<user_input>")).toBe("");
 	});
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -286,8 +286,6 @@ export default function App(): ReactElement {
 
 	const {
 		isInlineTaskCreateOpen,
-		newTaskTitle,
-		setNewTaskTitle,
 		newTaskPrompt,
 		setNewTaskPrompt,
 		newTaskImages,
@@ -306,8 +304,6 @@ export default function App(): ReactElement {
 		newTaskClineSettings,
 		setNewTaskClineSettings,
 		editingTaskId,
-		editTaskTitle,
-		setEditTaskTitle,
 		editTaskPrompt,
 		setEditTaskPrompt,
 		editTaskImages,
@@ -766,8 +762,6 @@ export default function App(): ReactElement {
 
 	const inlineTaskEditor = editingTaskId ? (
 		<TaskInlineCreateCard
-			title={editTaskTitle}
-			onTitleChange={setEditTaskTitle}
 			prompt={editTaskPrompt}
 			onPromptChange={setEditTaskPrompt}
 			images={editTaskImages}
@@ -1114,8 +1108,6 @@ export default function App(): ReactElement {
 				<TaskCreateDialog
 					open={isInlineTaskCreateOpen}
 					onOpenChange={handleCreateDialogOpenChange}
-					title={newTaskTitle}
-					onTitleChange={setNewTaskTitle}
 					prompt={newTaskPrompt}
 					onPromptChange={setNewTaskPrompt}
 					images={newTaskImages}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -548,6 +548,10 @@ export function BoardCard({
 							if (event.metaKey || event.ctrlKey) {
 								return;
 							}
+							const target = event.target as HTMLElement | null;
+							if (target?.closest("button, a, input, textarea, [contenteditable='true']")) {
+								return;
+							}
 							if (!snapshot.isDragging && onClick) {
 								onClick();
 							}

--- a/web-ui/src/components/task-create-dialog.tsx
+++ b/web-ui/src/components/task-create-dialog.tsx
@@ -1,7 +1,7 @@
 import * as RadixCheckbox from "@radix-ui/react-checkbox";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as RadixSwitch from "@radix-ui/react-switch";
-import { deriveTaskTitleFromPrompt } from "@runtime-task-title";
+
 import {
 	ArrowBigUp,
 	ArrowLeft,
@@ -99,8 +99,6 @@ function parseListItems(text: string): string[] {
 export function TaskCreateDialog({
 	open,
 	onOpenChange,
-	title,
-	onTitleChange,
 	prompt,
 	onPromptChange,
 	images,
@@ -132,8 +130,6 @@ export function TaskCreateDialog({
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	title: string;
-	onTitleChange: (value: string) => void;
 	prompt: string;
 	onPromptChange: (value: string) => void;
 	images: TaskImage[];
@@ -437,18 +433,6 @@ export function TaskCreateDialog({
 			<DialogBody>
 				{mode === "single" ? (
 					<div>
-						<div className="mb-3">
-							<label htmlFor="task-title-input" className="mb-1 block text-[12px] text-text-secondary">
-								Title
-							</label>
-							<input
-								id="task-title-input"
-								value={title}
-								onChange={(event) => onTitleChange(event.currentTarget.value)}
-								placeholder={deriveTaskTitleFromPrompt(prompt) || "Auto-generated from prompt"}
-								className="h-9 w-full rounded-md border border-border-bright bg-surface-2 px-3 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-focus focus:outline-none"
-							/>
-						</div>
 						<TaskPromptComposer
 							key={composerResetKey}
 							value={prompt}

--- a/web-ui/src/hooks/use-task-editor.ts
+++ b/web-ui/src/hooks/use-task-editor.ts
@@ -1,3 +1,4 @@
+import { deriveTaskTitleFromPrompt } from "@runtime-task-title";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -35,8 +36,6 @@ interface CreateTaskOptions {
 
 export interface UseTaskEditorResult {
 	isInlineTaskCreateOpen: boolean;
-	newTaskTitle: string;
-	setNewTaskTitle: Dispatch<SetStateAction<string>>;
 	newTaskPrompt: string;
 	setNewTaskPrompt: Dispatch<SetStateAction<string>>;
 	newTaskImages: TaskImage[];
@@ -55,8 +54,6 @@ export interface UseTaskEditorResult {
 	newTaskClineSettings: RuntimeTaskClineSettings | undefined;
 	setNewTaskClineSettings: Dispatch<SetStateAction<RuntimeTaskClineSettings | undefined>>;
 	editingTaskId: string | null;
-	editTaskTitle: string;
-	setEditTaskTitle: Dispatch<SetStateAction<string>>;
 	editTaskPrompt: string;
 	setEditTaskPrompt: Dispatch<SetStateAction<string>>;
 	editTaskImages: TaskImage[];
@@ -97,7 +94,6 @@ export function useTaskEditor({
 	queueTaskStartAfterEdit,
 }: UseTaskEditorInput): UseTaskEditorResult {
 	const [isInlineTaskCreateOpen, setIsInlineTaskCreateOpen] = useState(false);
-	const [newTaskTitle, setNewTaskTitle] = useState("");
 	const [newTaskPrompt, setNewTaskPrompt] = useState("");
 	const [newTaskImages, setNewTaskImages] = useState<TaskImage[]>([]);
 	const [newTaskStartInPlanMode, setNewTaskStartInPlanMode] = useBooleanLocalStorageValue(
@@ -117,7 +113,6 @@ export function useTaskEditor({
 	const [newTaskBranchRef, setNewTaskBranchRef] = useState("");
 	const [lastCreatedTaskBranchByProjectId, setLastCreatedTaskBranchByProjectId] = useState<Record<string, string>>({});
 	const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
-	const [editTaskTitle, setEditTaskTitle] = useState("");
 	const [editTaskPrompt, setEditTaskPrompt] = useState("");
 	const [editTaskImages, setEditTaskImages] = useState<TaskImage[]>([]);
 	const [editTaskStartInPlanMode, setEditTaskStartInPlanMode] = useState(false);
@@ -197,7 +192,7 @@ export function useTaskEditor({
 		const selection = findCardSelection(board, editingTaskId);
 		if (!selection || selection.column.id !== "backlog") {
 			setEditingTaskId(null);
-			setEditTaskTitle("");
+
 			setEditTaskPrompt("");
 			setEditTaskStartInPlanMode(false);
 			setEditTaskAutoReviewEnabled(false);
@@ -211,7 +206,7 @@ export function useTaskEditor({
 		setEditingTaskId(null);
 		setEditTaskPrompt("");
 		setEditTaskImages([]);
-		setNewTaskTitle("");
+
 		setNewTaskAgentId(undefined);
 		setNewTaskClineSettings(undefined);
 		setIsInlineTaskCreateOpen(true);
@@ -219,7 +214,7 @@ export function useTaskEditor({
 
 	const handleCancelCreateTask = useCallback(() => {
 		setIsInlineTaskCreateOpen(false);
-		setNewTaskTitle("");
+
 		setNewTaskPrompt("");
 		setNewTaskImages([]);
 		setNewTaskBranchRef(resolvedDefaultTaskBranchRef);
@@ -233,12 +228,12 @@ export function useTaskEditor({
 				setSelectedTaskId(null);
 			}
 			setIsInlineTaskCreateOpen(false);
-			setNewTaskTitle("");
+
 			setNewTaskPrompt("");
 			setNewTaskImages([]);
 			const taskPrompt = task.prompt.trim();
 			setEditingTaskId(task.id);
-			setEditTaskTitle(task.title);
+
 			setEditTaskPrompt(taskPrompt);
 			setEditTaskImages(task.images ? task.images.map((image) => ({ ...image })) : []);
 			setEditTaskStartInPlanMode(task.startInPlanMode);
@@ -254,7 +249,7 @@ export function useTaskEditor({
 
 	const handleCancelEditTask = useCallback(() => {
 		setEditingTaskId(null);
-		setEditTaskTitle("");
+
 		setEditTaskPrompt("");
 		setEditTaskStartInPlanMode(false);
 		setEditTaskAutoReviewEnabled(false);
@@ -279,7 +274,8 @@ export function useTaskEditor({
 		const savedTaskId = editingTaskId;
 
 		setBoard((currentBoard) => {
-			const title = editTaskTitle.trim();
+			const currentCard = currentBoard.columns.flatMap((c) => c.cards).find((c) => c.id === savedTaskId);
+			const title = currentCard?.title ?? "";
 			const updated = updateTask(currentBoard, savedTaskId, {
 				title,
 				prompt,
@@ -294,7 +290,7 @@ export function useTaskEditor({
 			return updated.updated ? updated.board : currentBoard;
 		});
 		setEditingTaskId(null);
-		setEditTaskTitle("");
+
 		setEditTaskPrompt("");
 		setEditTaskStartInPlanMode(false);
 		setEditTaskAutoReviewEnabled(false);
@@ -313,7 +309,6 @@ export function useTaskEditor({
 		editTaskPrompt,
 		editTaskImages,
 		editTaskStartInPlanMode,
-		editTaskTitle,
 		editingTaskId,
 		resolvedDefaultTaskBranchRef,
 		setBoard,
@@ -347,7 +342,7 @@ export function useTaskEditor({
 				return null;
 			}
 			const baseRef = newTaskBranchRef || resolvedDefaultTaskBranchRef;
-			const title = newTaskTitle.trim();
+			const title = deriveTaskTitleFromPrompt(prompt);
 			const created = addTaskToColumnWithResult(board, "backlog", {
 				title,
 				prompt,
@@ -372,7 +367,7 @@ export function useTaskEditor({
 					[currentProjectId]: baseRef,
 				}));
 			}
-			setNewTaskTitle("");
+
 			setNewTaskPrompt("");
 			setNewTaskImages([]);
 			setNewTaskBranchRef(baseRef);
@@ -393,7 +388,6 @@ export function useTaskEditor({
 			newTaskClineSettings,
 			newTaskImages,
 			newTaskPrompt,
-			newTaskTitle,
 			newTaskStartInPlanMode,
 			resolvedDefaultTaskBranchRef,
 			selectedAgentId,
@@ -444,7 +438,7 @@ export function useTaskEditor({
 					[currentProjectId]: baseRef,
 				}));
 			}
-			setNewTaskTitle("");
+
 			setNewTaskPrompt("");
 			setNewTaskImages([]);
 			setNewTaskBranchRef(baseRef);
@@ -476,9 +470,9 @@ export function useTaskEditor({
 	const resetTaskEditorState = useCallback(() => {
 		setIsInlineTaskCreateOpen(false);
 		setEditingTaskId(null);
-		setNewTaskTitle("");
+
 		setNewTaskPrompt("");
-		setEditTaskTitle("");
+
 		setEditTaskPrompt("");
 		setEditTaskStartInPlanMode(false);
 		setEditTaskAutoReviewEnabled(false);
@@ -494,8 +488,6 @@ export function useTaskEditor({
 
 	return {
 		isInlineTaskCreateOpen,
-		newTaskTitle,
-		setNewTaskTitle,
 		newTaskPrompt,
 		setNewTaskPrompt,
 		newTaskImages,
@@ -514,8 +506,6 @@ export function useTaskEditor({
 		newTaskClineSettings,
 		setNewTaskClineSettings,
 		editingTaskId,
-		editTaskTitle,
-		setEditTaskTitle,
 		editTaskPrompt,
 		setEditTaskPrompt,
 		editTaskImages,

--- a/web-ui/src/utils/task-prompt.test.ts
+++ b/web-ui/src/utils/task-prompt.test.ts
@@ -28,6 +28,10 @@ describe("getTaskPromptDescription", () => {
 	it("returns empty when prompt equals title", () => {
 		expect(getTaskPromptDescription("Fix bugs", "Fix bugs")).toBe("");
 	});
+
+	it("strips XML wrapper tags from the prompt before comparing with the title", () => {
+		expect(getTaskPromptDescription('<user_input mode="act">Fix the bug</user_input>', "Fix the bug")).toBe("");
+	});
 });
 
 describe("clampTextWithInlineSuffix", () => {

--- a/web-ui/src/utils/task-prompt.ts
+++ b/web-ui/src/utils/task-prompt.ts
@@ -16,8 +16,15 @@ export function normalizePromptForDisplay(prompt: string): string {
 	return prompt.replaceAll(/\s+/g, " ").trim();
 }
 
+function stripOuterXmlTag(text: string): string {
+	return text
+		.replace(/^<[^>]+>/u, "")
+		.replace(/<\/[^>]+>$/u, "")
+		.trim();
+}
+
 export function getTaskPromptDescription(prompt: string, title: string): string {
-	const normalizedPrompt = normalizePromptForDisplay(prompt);
+	const normalizedPrompt = stripOuterXmlTag(normalizePromptForDisplay(prompt));
 	const normalizedTitle = normalizePromptForDisplay(title);
 	if (!normalizedPrompt) {
 		return "";


### PR DESCRIPTION
## What

Two small UX fixes to the task title flow.

### 1. Remove live title preview during task creation

The "New task" dialog previously showed a Title input whose placeholder updated live as you typed the prompt. This caused the distracting effect of watching two things update simultaneously while typing.

**Now:** The title input is gone from the create dialog entirely. The title is derived from the prompt silently at save time. You can still rename any card title later via the in-place click-to-edit on the board card.

### 2. Fix click-through on the title input reopening the card

While editing a title inline on a board card, clicking inside the already-focused input to reposition the cursor was bubbling up to the card root onClick, which re-opened the card detail view.

**Root cause:** The card root onClick handler had no guard for interactive descendants, even though onMouseDownCapture already had the correct closest() guard.

**Fix:** Added the same closest("button, a, input, textarea, ...") check to onClick.

## Files changed

- `web-ui/src/App.tsx` - remove title state destructuring and prop pass-throughs
- `web-ui/src/components/task-create-dialog.tsx` - remove Title input block
- `web-ui/src/hooks/use-task-editor.ts` - remove title state; derive from prompt at save time
- `web-ui/src/components/board-card.tsx` - add closest() guard to onClick

## Screenshots

Before
<img width="740" height="585" alt="Screenshot 2026-04-15 at 5 00 28 PM" src="https://github.com/user-attachments/assets/79be61c1-3766-4313-b3e6-fd77679bbb90" />

After

<img width="740" height="585" alt="Screenshot 2026-04-15 at 5 00 28 PM" src="https://github.com/user-attachments/assets/79be61c1-3766-4313-b3e6-fd77679bbb90" />
<img width="728" height="543" alt="Screenshot 2026-04-15 at 5 00 50 PM" src="https://github.com/user-attachments/assets/5514f7e8-4d4f-4416-9752-c5e203a82c06" />
<img width="592" height="167" alt="Screenshot 2026-04-15 at 5 00 58 PM" src="https://github.com/user-attachments/assets/bf7a2d6f-ad74-4bc1-baa2-bd08c76137ae" />
