### PR TITLE
Pull Cline recommended models from the API

### DIFF
--- a/src/cline-sdk/cline-provider-models.ts
+++ b/src/cline-sdk/cline-provider-models.ts
@@ -1,0 +1,157 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { getSdkProviderSettingsDirectory } from "./sdk-provider-boundary";
+
+const CLINE_PROVIDER_MODELS_CACHE_FILE = "cline-provider-models.json";
+const CLINE_PROVIDER_MODELS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const clineModelSchema = z.object({
+	id: z.string().trim().min(1),
+	name: z.string().optional(),
+	architecture: z
+		.object({
+			modality: z.union([z.string(), z.array(z.string())]).optional(),
+			input_modalities: z.array(z.string()).optional(),
+			output_modalities: z.array(z.string()).optional(),
+		})
+		.nullish(),
+	supported_parameters: z.array(z.string()).nullish(),
+});
+
+const clineProviderModelsResponseSchema = z.object({
+	data: z.array(clineModelSchema).default([]),
+});
+
+export interface ClineProviderModelData {
+	id: string;
+	name: string;
+	supportsVision?: boolean;
+	supportsAttachments?: boolean;
+	supportsReasoningEffort?: boolean;
+}
+
+type RawClineProviderModelsData = z.infer<typeof clineProviderModelsResponseSchema>;
+
+let inMemoryCache: { apiBaseUrl: string; models: ClineProviderModelData[]; timestamp: number } | null = null;
+let pendingRefresh: Promise<ClineProviderModelData[]> | null = null;
+
+function resolveCacheFilePath(): string {
+	return join(getSdkProviderSettingsDirectory(), CLINE_PROVIDER_MODELS_CACHE_FILE);
+}
+
+function normalizeModalities(model: z.infer<typeof clineModelSchema>): string[] {
+	const modality = model.architecture?.modality;
+	const rawValues = [
+		...(typeof modality === "string" ? [modality] : Array.isArray(modality) ? modality : []),
+		...(model.architecture?.input_modalities ?? []),
+		...(model.architecture?.output_modalities ?? []),
+	];
+	return [...new Set(rawValues.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0))];
+}
+
+function normalizeClineProviderModels(input: RawClineProviderModelsData): ClineProviderModelData[] {
+	const modelsById = new Map<string, ClineProviderModelData>();
+	for (const model of input.data) {
+		const id = model.id.trim();
+		if (!id) {
+			continue;
+		}
+		const modalities = normalizeModalities(model);
+		const supportsVision = modalities.some((value) => value.includes("image"));
+		const supportsReasoningEffort = (model.supported_parameters ?? []).some(
+			(value) => value === "include_reasoning" || value === "reasoning",
+		);
+		modelsById.set(id, {
+			id,
+			name: model.name?.trim() || id,
+			supportsVision: supportsVision || undefined,
+			supportsAttachments: supportsVision || undefined,
+			supportsReasoningEffort: supportsReasoningEffort || undefined,
+		});
+	}
+	return [...modelsById.values()];
+}
+
+async function readCachedClineProviderModels(): Promise<ClineProviderModelData[] | null> {
+	try {
+		const raw = await readFile(resolveCacheFilePath(), "utf8");
+		const parsed = clineProviderModelsResponseSchema.safeParse(JSON.parse(raw));
+		if (!parsed.success) {
+			return null;
+		}
+		const models = normalizeClineProviderModels(parsed.data);
+		return models.length > 0 ? models : null;
+	} catch {
+		return null;
+	}
+}
+
+async function writeCachedClineProviderModels(data: RawClineProviderModelsData): Promise<void> {
+	await mkdir(getSdkProviderSettingsDirectory(), { recursive: true });
+	await writeFile(resolveCacheFilePath(), `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function fetchAndCacheClineProviderModels(apiBaseUrl: string): Promise<ClineProviderModelData[]> {
+	try {
+		const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/ai/cline/models`);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+
+		const parsed = clineProviderModelsResponseSchema.safeParse(await response.json());
+		if (!parsed.success) {
+			throw new Error("Invalid response body");
+		}
+
+		const models = normalizeClineProviderModels(parsed.data);
+		if (models.length > 0) {
+			await writeCachedClineProviderModels(parsed.data);
+			return models;
+		}
+	} catch {
+		const cachedModels = await readCachedClineProviderModels();
+		if (cachedModels && cachedModels.length > 0) {
+			return cachedModels;
+		}
+	}
+
+	return [];
+}
+
+export async function fetchClineProviderModels(apiBaseUrl: string): Promise<ClineProviderModelData[]> {
+	if (
+		inMemoryCache &&
+		inMemoryCache.apiBaseUrl === apiBaseUrl &&
+		Date.now() - inMemoryCache.timestamp <= CLINE_PROVIDER_MODELS_CACHE_TTL_MS
+	) {
+		return inMemoryCache.models;
+	}
+
+	if (pendingRefresh) {
+		return pendingRefresh;
+	}
+
+	pendingRefresh = (async () => {
+		try {
+			const models = await fetchAndCacheClineProviderModels(apiBaseUrl);
+			if (models.length > 0) {
+				inMemoryCache = {
+					apiBaseUrl,
+					models,
+					timestamp: Date.now(),
+				};
+			}
+			return models;
+		} finally {
+			pendingRefresh = null;
+		}
+	})();
+
+	return pendingRefresh;
+}
+
+export function resetClineProviderModelsCacheForTests(): void {
+	inMemoryCache = null;
+	pendingRefresh = null;
+}

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -22,7 +22,7 @@ import type {
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
 import { fetchClineProviderModels } from "./cline-provider-models";
-import { fetchClineRecommendedModelsData, type ClineRecommendedModelsData } from "./cline-recommended-models";
+import { fetchClineRecommendedModels, type ClineRecommendedModelsData } from "./cline-recommended-models";
 import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
@@ -237,6 +237,21 @@ function resolveClineApiBaseUrl(): string {
 
 function createModelRankMap(models: readonly { id: string }[]): Map<string, number> {
 	return new Map(models.map((model, index) => [model.id, index] as const));
+}
+
+function createFeaturedModelFallbacks(
+	featuredModels: ClineRecommendedModelsData,
+	existingModels: readonly { id: string }[],
+): RuntimeClineProviderModel[] {
+	const existingModelIds = new Set(existingModels.map((model) => model.id));
+	const featuredEntries = [...featuredModels.recommended, ...featuredModels.free];
+
+	return featuredEntries
+		.filter((model) => !existingModelIds.has(model.id))
+		.map((model) => ({
+			id: model.id,
+			name: model.name?.trim() || model.id,
+		}));
 }
 
 function createEmptyProviderSettingsSummary(): RuntimeClineProviderSettings {
@@ -799,10 +814,11 @@ export function createClineProviderService() {
 		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
 			const normalizedProviderId = providerId.trim().toLowerCase();
 			const clineApiBaseUrl = resolveClineApiBaseUrl();
-			const featuredModels: ClineRecommendedModelsData =
+			const featuredModelsResult =
 				normalizedProviderId === "cline"
-					? await fetchClineRecommendedModelsData(clineApiBaseUrl)
-					: { recommended: [], free: [] };
+					? await fetchClineRecommendedModels(clineApiBaseUrl)
+					: { data: { recommended: [], free: [] }, source: "fallback" as const };
+			const featuredModels: ClineRecommendedModelsData = featuredModelsResult.data;
 			const recommendedModelRanks = createModelRankMap(featuredModels.recommended);
 			const freeModelRanks = createModelRankMap(featuredModels.free);
 			const configuredModel = getSdkProviderSettings(normalizedProviderId)?.model?.trim() ?? "";
@@ -818,7 +834,12 @@ export function createClineProviderService() {
 								.catch(() => listSdkProviderModels(normalizedProviderId).catch(() => []))
 						: await listSdkProviderModels(normalizedProviderId).catch(() => [])
 					: [];
+			const featuredModelFallbacks =
+				normalizedProviderId === "cline" && featuredModelsResult.source !== "fallback"
+					? createFeaturedModelFallbacks(featuredModels, rawProviderModels)
+					: [];
 			const providerModels = rawProviderModels
+				.concat(featuredModelFallbacks)
 				.map((model) =>
 					toRuntimeProviderModel({
 						...model,

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -254,6 +254,16 @@ function createFeaturedModelFallbacks(
 		}));
 }
 
+function dedupeProviderModelsById<T extends { id: string }>(models: readonly T[]): T[] {
+	const dedupedModels = new Map<string, T>();
+	for (const model of models) {
+		if (!dedupedModels.has(model.id)) {
+			dedupedModels.set(model.id, model);
+		}
+	}
+	return [...dedupedModels.values()];
+}
+
 function createEmptyProviderSettingsSummary(): RuntimeClineProviderSettings {
 	return {
 		providerId: null,
@@ -838,8 +848,8 @@ export function createClineProviderService() {
 				normalizedProviderId === "cline" && featuredModelsResult.source !== "fallback"
 					? createFeaturedModelFallbacks(featuredModels, rawProviderModels)
 					: [];
-			const providerModels = rawProviderModels
-				.concat(featuredModelFallbacks)
+			const resolvedProviderModels = dedupeProviderModelsById(rawProviderModels.concat(featuredModelFallbacks));
+			const providerModels = resolvedProviderModels
 				.map((model) =>
 					toRuntimeProviderModel({
 						...model,
@@ -848,7 +858,7 @@ export function createClineProviderService() {
 					}),
 				)
 				.concat(
-					configuredModel.length > 0 && !rawProviderModels.some((model) => model.id === configuredModel)
+					configuredModel.length > 0 && !resolvedProviderModels.some((model) => model.id === configuredModel)
 						? [
 								toRuntimeProviderModel({
 									id: configuredModel,

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -21,7 +21,8 @@ import type {
 	RuntimeClineReasoningEffort,
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
-import { fetchClineRecommendedModelIds } from "./cline-recommended-models";
+import { fetchClineProviderModels } from "./cline-provider-models";
+import { fetchClineRecommendedModelsData, type ClineRecommendedModelsData } from "./cline-recommended-models";
 import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
@@ -226,7 +227,16 @@ function toRuntimeProviderModel(model: RuntimeClineProviderModel): RuntimeClineP
 		supportsAttachments: model.supportsAttachments || undefined,
 		supportsReasoningEffort: model.supportsReasoningEffort || undefined,
 		recommendedRank: typeof model.recommendedRank === "number" ? model.recommendedRank : undefined,
+		freeRank: typeof model.freeRank === "number" ? model.freeRank : undefined,
 	};
+}
+
+function resolveClineApiBaseUrl(): string {
+	return getSdkProviderSettings("cline")?.baseUrl?.trim() || DEFAULT_CLINE_API_BASE_URL;
+}
+
+function createModelRankMap(models: readonly { id: string }[]): Map<string, number> {
+	return new Map(models.map((model, index) => [model.id, index] as const));
 }
 
 function createEmptyProviderSettingsSummary(): RuntimeClineProviderSettings {
@@ -788,30 +798,47 @@ export function createClineProviderService() {
 
 		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
 			const normalizedProviderId = providerId.trim().toLowerCase();
-			const recommendedModelRanks =
+			const clineApiBaseUrl = resolveClineApiBaseUrl();
+			const featuredModels: ClineRecommendedModelsData =
 				normalizedProviderId === "cline"
-					? new Map(
-							(
-								await fetchClineRecommendedModelIds(
-									getSdkProviderSettings("cline")?.baseUrl?.trim() || DEFAULT_CLINE_API_BASE_URL,
-								)
-							).map((modelId, index) => [modelId, index] as const),
-						)
-					: new Map<string, number>();
-			const providerModels =
+					? await fetchClineRecommendedModelsData(clineApiBaseUrl)
+					: { recommended: [], free: [] };
+			const recommendedModelRanks = createModelRankMap(featuredModels.recommended);
+			const freeModelRanks = createModelRankMap(featuredModels.free);
+			const configuredModel = getSdkProviderSettings(normalizedProviderId)?.model?.trim() ?? "";
+			const rawProviderModels =
 				normalizedProviderId.length > 0
-					? await listSdkProviderModels(normalizedProviderId)
-							.then((sdkModels) =>
-								sdkModels.map((model) =>
-									toRuntimeProviderModel({
-										...model,
-										recommendedRank: recommendedModelRanks.get(model.id),
-									}),
-								),
-							)
-							.then((sdkModels) => sdkModels.sort((left, right) => left.name.localeCompare(right.name)))
-							.catch(() => [])
+					? normalizedProviderId === "cline"
+						? await fetchClineProviderModels(clineApiBaseUrl)
+								.then((models) =>
+									models.length > 0
+										? models
+										: listSdkProviderModels(normalizedProviderId).catch(() => []),
+								)
+								.catch(() => listSdkProviderModels(normalizedProviderId).catch(() => []))
+						: await listSdkProviderModels(normalizedProviderId).catch(() => [])
 					: [];
+			const providerModels = rawProviderModels
+				.map((model) =>
+					toRuntimeProviderModel({
+						...model,
+						recommendedRank: recommendedModelRanks.get(model.id),
+						freeRank: freeModelRanks.get(model.id),
+					}),
+				)
+				.concat(
+					configuredModel.length > 0 && !rawProviderModels.some((model) => model.id === configuredModel)
+						? [
+								toRuntimeProviderModel({
+									id: configuredModel,
+									name: configuredModel,
+									recommendedRank: recommendedModelRanks.get(configuredModel),
+									freeRank: freeModelRanks.get(configuredModel),
+								}),
+							]
+						: [],
+				)
+				.sort((left, right) => left.name.localeCompare(right.name));
 
 			if (providerModels.length > 0) {
 				return {
@@ -820,7 +847,6 @@ export function createClineProviderService() {
 				};
 			}
 
-			const configuredModel = getSdkProviderSettings(normalizedProviderId)?.model?.trim() ?? "";
 			if (configuredModel.length > 0) {
 				return {
 					providerId: normalizedProviderId || providerId,
@@ -829,6 +855,7 @@ export function createClineProviderService() {
 							id: configuredModel,
 							name: configuredModel,
 							recommendedRank: recommendedModelRanks.get(configuredModel),
+							freeRank: freeModelRanks.get(configuredModel),
 						}),
 					],
 				};

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -21,6 +21,7 @@ import type {
 	RuntimeClineReasoningEffort,
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
+import { fetchClineRecommendedModelIds } from "./cline-recommended-models";
 import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
@@ -224,6 +225,7 @@ function toRuntimeProviderModel(model: RuntimeClineProviderModel): RuntimeClineP
 		supportsVision: model.supportsVision || undefined,
 		supportsAttachments: model.supportsAttachments || undefined,
 		supportsReasoningEffort: model.supportsReasoningEffort || undefined,
+		recommendedRank: typeof model.recommendedRank === "number" ? model.recommendedRank : undefined,
 	};
 }
 
@@ -786,10 +788,27 @@ export function createClineProviderService() {
 
 		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
 			const normalizedProviderId = providerId.trim().toLowerCase();
+			const recommendedModelRanks =
+				normalizedProviderId === "cline"
+					? new Map(
+							(
+								await fetchClineRecommendedModelIds(
+									getSdkProviderSettings("cline")?.baseUrl?.trim() || DEFAULT_CLINE_API_BASE_URL,
+								)
+							).map((modelId, index) => [modelId, index] as const),
+						)
+					: new Map<string, number>();
 			const providerModels =
 				normalizedProviderId.length > 0
 					? await listSdkProviderModels(normalizedProviderId)
-							.then((sdkModels) => sdkModels.map((model) => toRuntimeProviderModel(model)))
+							.then((sdkModels) =>
+								sdkModels.map((model) =>
+									toRuntimeProviderModel({
+										...model,
+										recommendedRank: recommendedModelRanks.get(model.id),
+									}),
+								),
+							)
 							.then((sdkModels) => sdkModels.sort((left, right) => left.name.localeCompare(right.name)))
 							.catch(() => [])
 					: [];
@@ -805,7 +824,13 @@ export function createClineProviderService() {
 			if (configuredModel.length > 0) {
 				return {
 					providerId: normalizedProviderId || providerId,
-					models: [{ id: configuredModel, name: configuredModel }],
+					models: [
+						toRuntimeProviderModel({
+							id: configuredModel,
+							name: configuredModel,
+							recommendedRank: recommendedModelRanks.get(configuredModel),
+						}),
+					],
 				};
 			}
 

--- a/src/cline-sdk/cline-recommended-models.ts
+++ b/src/cline-sdk/cline-recommended-models.ts
@@ -20,6 +20,11 @@ const recommendedModelsSchema = z.object({
 
 export type ClineFeaturedModel = z.infer<typeof recommendedModelSchema>;
 export type ClineRecommendedModelsData = z.infer<typeof recommendedModelsSchema>;
+export type ClineRecommendedModelsDataSource = "remote" | "cache" | "fallback";
+export interface ClineRecommendedModelsFetchResult {
+	data: ClineRecommendedModelsData;
+	source: ClineRecommendedModelsDataSource;
+}
 
 const CLINE_RECOMMENDED_MODEL_IDS_FALLBACK = [
 	"google/gemini-3.1-pro-preview",
@@ -29,8 +34,8 @@ const CLINE_RECOMMENDED_MODEL_IDS_FALLBACK = [
 ] as const;
 const CLINE_FREE_MODEL_IDS_FALLBACK = ["kwaipilot/kat-coder-pro", "arcee-ai/trinity-large-preview:free"] as const;
 
-let inMemoryCache: { apiBaseUrl: string; data: ClineRecommendedModelsData; timestamp: number } | null = null;
-let pendingRefresh: Promise<ClineRecommendedModelsData> | null = null;
+let inMemoryCache: { apiBaseUrl: string; result: ClineRecommendedModelsFetchResult; timestamp: number } | null = null;
+let pendingRefresh: Promise<ClineRecommendedModelsFetchResult> | null = null;
 
 function normalizeFeaturedModels(models: readonly ClineFeaturedModel[]): ClineFeaturedModel[] {
 	const featuredModelsById = new Map<string, ClineFeaturedModel>();
@@ -86,7 +91,7 @@ async function writeCachedRecommendedModels(data: ClineRecommendedModelsData): P
 	await writeFile(resolveCacheFilePath(), `${JSON.stringify(data, null, 2)}\n`, "utf8");
 }
 
-async function fetchAndCacheRecommendedModels(apiBaseUrl: string): Promise<ClineRecommendedModelsData> {
+async function fetchAndCacheRecommendedModels(apiBaseUrl: string): Promise<ClineRecommendedModelsFetchResult> {
 	try {
 		const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/ai/cline/recommended-models`);
 		if (!response.ok) {
@@ -101,25 +106,34 @@ async function fetchAndCacheRecommendedModels(apiBaseUrl: string): Promise<Cline
 		const data = normalizeRecommendedModels(parsed.data);
 		if (data.recommended.length > 0 || data.free.length > 0) {
 			await writeCachedRecommendedModels(data);
-			return data;
+			return {
+				data,
+				source: "remote",
+			};
 		}
 	} catch {
 		const cachedData = await readCachedRecommendedModels();
 		if (cachedData && (cachedData.recommended.length > 0 || cachedData.free.length > 0)) {
-			return cachedData;
+			return {
+				data: cachedData,
+				source: "cache",
+			};
 		}
 	}
 
-	return getFallbackRecommendedModels();
+	return {
+		data: getFallbackRecommendedModels(),
+		source: "fallback",
+	};
 }
 
-export async function fetchClineRecommendedModelsData(apiBaseUrl: string): Promise<ClineRecommendedModelsData> {
+export async function fetchClineRecommendedModels(apiBaseUrl: string): Promise<ClineRecommendedModelsFetchResult> {
 	if (
 		inMemoryCache &&
 		inMemoryCache.apiBaseUrl === apiBaseUrl &&
 		Date.now() - inMemoryCache.timestamp <= CLINE_RECOMMENDED_MODELS_CACHE_TTL_MS
 	) {
-		return inMemoryCache.data;
+		return inMemoryCache.result;
 	}
 
 	if (pendingRefresh) {
@@ -128,21 +142,25 @@ export async function fetchClineRecommendedModelsData(apiBaseUrl: string): Promi
 
 	pendingRefresh = (async () => {
 		try {
-			const data = await fetchAndCacheRecommendedModels(apiBaseUrl);
-			if (data.recommended.length > 0 || data.free.length > 0) {
+			const result = await fetchAndCacheRecommendedModels(apiBaseUrl);
+			if (result.data.recommended.length > 0 || result.data.free.length > 0) {
 				inMemoryCache = {
 					apiBaseUrl,
-					data,
+					result,
 					timestamp: Date.now(),
 				};
 			}
-			return data;
+			return result;
 		} finally {
 			pendingRefresh = null;
 		}
 	})();
 
 	return pendingRefresh;
+}
+
+export async function fetchClineRecommendedModelsData(apiBaseUrl: string): Promise<ClineRecommendedModelsData> {
+	return (await fetchClineRecommendedModels(apiBaseUrl)).data;
 }
 
 export async function fetchClineRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {

--- a/src/cline-sdk/cline-recommended-models.ts
+++ b/src/cline-sdk/cline-recommended-models.ts
@@ -18,7 +18,8 @@ const recommendedModelsSchema = z.object({
 	free: z.array(recommendedModelSchema).default([]),
 });
 
-type RecommendedModelsData = z.infer<typeof recommendedModelsSchema>;
+export type ClineFeaturedModel = z.infer<typeof recommendedModelSchema>;
+export type ClineRecommendedModelsData = z.infer<typeof recommendedModelsSchema>;
 
 const CLINE_RECOMMENDED_MODEL_IDS_FALLBACK = [
 	"google/gemini-3.1-pro-preview",
@@ -26,42 +27,66 @@ const CLINE_RECOMMENDED_MODEL_IDS_FALLBACK = [
 	"anthropic/claude-opus-4.6",
 	"openai/gpt-5.3-codex",
 ] as const;
+const CLINE_FREE_MODEL_IDS_FALLBACK = ["kwaipilot/kat-coder-pro", "arcee-ai/trinity-large-preview:free"] as const;
 
-let inMemoryCache: { apiBaseUrl: string; ids: string[]; timestamp: number } | null = null;
-let pendingRefresh: Promise<string[]> | null = null;
+let inMemoryCache: { apiBaseUrl: string; data: ClineRecommendedModelsData; timestamp: number } | null = null;
+let pendingRefresh: Promise<ClineRecommendedModelsData> | null = null;
 
-function normalizeRecommendedModelIds(input: RecommendedModelsData): string[] {
-	return [...new Set(input.recommended.map((model) => model.id.trim()).filter((id) => id.length > 0))];
+function normalizeFeaturedModels(models: readonly ClineFeaturedModel[]): ClineFeaturedModel[] {
+	const featuredModelsById = new Map<string, ClineFeaturedModel>();
+	for (const model of models) {
+		const id = model.id.trim();
+		if (!id || featuredModelsById.has(id)) {
+			continue;
+		}
+		featuredModelsById.set(id, {
+			id,
+			name: model.name?.trim() || undefined,
+			description: model.description?.trim() || undefined,
+			tags: model.tags?.map((tag) => tag.trim()).filter((tag) => tag.length > 0) ?? undefined,
+		});
+	}
+	return [...featuredModelsById.values()];
+}
+
+function normalizeRecommendedModels(input: ClineRecommendedModelsData): ClineRecommendedModelsData {
+	return {
+		recommended: normalizeFeaturedModels(input.recommended),
+		free: normalizeFeaturedModels(input.free),
+	};
 }
 
 function resolveCacheFilePath(): string {
 	return join(getSdkProviderSettingsDirectory(), CLINE_RECOMMENDED_MODELS_CACHE_FILE);
 }
 
-function getFallbackRecommendedModelIds(): string[] {
-	return [...CLINE_RECOMMENDED_MODEL_IDS_FALLBACK];
+function getFallbackRecommendedModels(): ClineRecommendedModelsData {
+	return {
+		recommended: CLINE_RECOMMENDED_MODEL_IDS_FALLBACK.map((id) => ({ id })),
+		free: CLINE_FREE_MODEL_IDS_FALLBACK.map((id) => ({ id })),
+	};
 }
 
-async function readCachedRecommendedModelIds(): Promise<string[] | null> {
+async function readCachedRecommendedModels(): Promise<ClineRecommendedModelsData | null> {
 	try {
 		const raw = await readFile(resolveCacheFilePath(), "utf8");
 		const parsed = recommendedModelsSchema.safeParse(JSON.parse(raw));
 		if (!parsed.success) {
 			return null;
 		}
-		const ids = normalizeRecommendedModelIds(parsed.data);
-		return ids.length > 0 ? ids : null;
+		const data = normalizeRecommendedModels(parsed.data);
+		return data.recommended.length > 0 || data.free.length > 0 ? data : null;
 	} catch {
 		return null;
 	}
 }
 
-async function writeCachedRecommendedModels(data: RecommendedModelsData): Promise<void> {
+async function writeCachedRecommendedModels(data: ClineRecommendedModelsData): Promise<void> {
 	await mkdir(getSdkProviderSettingsDirectory(), { recursive: true });
 	await writeFile(resolveCacheFilePath(), `${JSON.stringify(data, null, 2)}\n`, "utf8");
 }
 
-async function fetchAndCacheRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {
+async function fetchAndCacheRecommendedModels(apiBaseUrl: string): Promise<ClineRecommendedModelsData> {
 	try {
 		const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/ai/cline/recommended-models`);
 		if (!response.ok) {
@@ -73,28 +98,28 @@ async function fetchAndCacheRecommendedModelIds(apiBaseUrl: string): Promise<str
 			throw new Error("Invalid response body");
 		}
 
-		const ids = normalizeRecommendedModelIds(parsed.data);
-		if (ids.length > 0) {
-			await writeCachedRecommendedModels(parsed.data);
-			return ids;
+		const data = normalizeRecommendedModels(parsed.data);
+		if (data.recommended.length > 0 || data.free.length > 0) {
+			await writeCachedRecommendedModels(data);
+			return data;
 		}
 	} catch {
-		const cachedIds = await readCachedRecommendedModelIds();
-		if (cachedIds && cachedIds.length > 0) {
-			return cachedIds;
+		const cachedData = await readCachedRecommendedModels();
+		if (cachedData && (cachedData.recommended.length > 0 || cachedData.free.length > 0)) {
+			return cachedData;
 		}
 	}
 
-	return getFallbackRecommendedModelIds();
+	return getFallbackRecommendedModels();
 }
 
-export async function fetchClineRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {
+export async function fetchClineRecommendedModelsData(apiBaseUrl: string): Promise<ClineRecommendedModelsData> {
 	if (
 		inMemoryCache &&
 		inMemoryCache.apiBaseUrl === apiBaseUrl &&
 		Date.now() - inMemoryCache.timestamp <= CLINE_RECOMMENDED_MODELS_CACHE_TTL_MS
 	) {
-		return inMemoryCache.ids;
+		return inMemoryCache.data;
 	}
 
 	if (pendingRefresh) {
@@ -103,21 +128,25 @@ export async function fetchClineRecommendedModelIds(apiBaseUrl: string): Promise
 
 	pendingRefresh = (async () => {
 		try {
-			const ids = await fetchAndCacheRecommendedModelIds(apiBaseUrl);
-			if (ids.length > 0) {
+			const data = await fetchAndCacheRecommendedModels(apiBaseUrl);
+			if (data.recommended.length > 0 || data.free.length > 0) {
 				inMemoryCache = {
 					apiBaseUrl,
-					ids,
+					data,
 					timestamp: Date.now(),
 				};
 			}
-			return ids;
+			return data;
 		} finally {
 			pendingRefresh = null;
 		}
 	})();
 
 	return pendingRefresh;
+}
+
+export async function fetchClineRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {
+	return (await fetchClineRecommendedModelsData(apiBaseUrl)).recommended.map((model) => model.id);
 }
 
 export function resetClineRecommendedModelsCacheForTests(): void {

--- a/src/cline-sdk/cline-recommended-models.ts
+++ b/src/cline-sdk/cline-recommended-models.ts
@@ -1,0 +1,126 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { getSdkProviderSettingsDirectory } from "./sdk-provider-boundary";
+
+const CLINE_RECOMMENDED_MODELS_CACHE_FILE = "cline-recommended-models.json";
+const CLINE_RECOMMENDED_MODELS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const recommendedModelSchema = z.object({
+	id: z.string().trim().min(1),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	tags: z.array(z.string()).optional(),
+});
+
+const recommendedModelsSchema = z.object({
+	recommended: z.array(recommendedModelSchema).default([]),
+	free: z.array(recommendedModelSchema).default([]),
+});
+
+type RecommendedModelsData = z.infer<typeof recommendedModelsSchema>;
+
+const CLINE_RECOMMENDED_MODEL_IDS_FALLBACK = [
+	"google/gemini-3.1-pro-preview",
+	"anthropic/claude-sonnet-4.6",
+	"anthropic/claude-opus-4.6",
+	"openai/gpt-5.3-codex",
+] as const;
+
+let inMemoryCache: { apiBaseUrl: string; ids: string[]; timestamp: number } | null = null;
+let pendingRefresh: Promise<string[]> | null = null;
+
+function normalizeRecommendedModelIds(input: RecommendedModelsData): string[] {
+	return [...new Set(input.recommended.map((model) => model.id.trim()).filter((id) => id.length > 0))];
+}
+
+function resolveCacheFilePath(): string {
+	return join(getSdkProviderSettingsDirectory(), CLINE_RECOMMENDED_MODELS_CACHE_FILE);
+}
+
+function getFallbackRecommendedModelIds(): string[] {
+	return [...CLINE_RECOMMENDED_MODEL_IDS_FALLBACK];
+}
+
+async function readCachedRecommendedModelIds(): Promise<string[] | null> {
+	try {
+		const raw = await readFile(resolveCacheFilePath(), "utf8");
+		const parsed = recommendedModelsSchema.safeParse(JSON.parse(raw));
+		if (!parsed.success) {
+			return null;
+		}
+		const ids = normalizeRecommendedModelIds(parsed.data);
+		return ids.length > 0 ? ids : null;
+	} catch {
+		return null;
+	}
+}
+
+async function writeCachedRecommendedModels(data: RecommendedModelsData): Promise<void> {
+	await mkdir(getSdkProviderSettingsDirectory(), { recursive: true });
+	await writeFile(resolveCacheFilePath(), `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function fetchAndCacheRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {
+	try {
+		const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/ai/cline/recommended-models`);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+
+		const parsed = recommendedModelsSchema.safeParse(await response.json());
+		if (!parsed.success) {
+			throw new Error("Invalid response body");
+		}
+
+		const ids = normalizeRecommendedModelIds(parsed.data);
+		if (ids.length > 0) {
+			await writeCachedRecommendedModels(parsed.data);
+			return ids;
+		}
+	} catch {
+		const cachedIds = await readCachedRecommendedModelIds();
+		if (cachedIds && cachedIds.length > 0) {
+			return cachedIds;
+		}
+	}
+
+	return getFallbackRecommendedModelIds();
+}
+
+export async function fetchClineRecommendedModelIds(apiBaseUrl: string): Promise<string[]> {
+	if (
+		inMemoryCache &&
+		inMemoryCache.apiBaseUrl === apiBaseUrl &&
+		Date.now() - inMemoryCache.timestamp <= CLINE_RECOMMENDED_MODELS_CACHE_TTL_MS
+	) {
+		return inMemoryCache.ids;
+	}
+
+	if (pendingRefresh) {
+		return pendingRefresh;
+	}
+
+	pendingRefresh = (async () => {
+		try {
+			const ids = await fetchAndCacheRecommendedModelIds(apiBaseUrl);
+			if (ids.length > 0) {
+				inMemoryCache = {
+					apiBaseUrl,
+					ids,
+					timestamp: Date.now(),
+				};
+			}
+			return ids;
+		} finally {
+			pendingRefresh = null;
+		}
+	})();
+
+	return pendingRefresh;
+}
+
+export function resetClineRecommendedModelsCacheForTests(): void {
+	inMemoryCache = null;
+	pendingRefresh = null;
+}

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -322,8 +322,12 @@ export async function listSdkProviderModels(providerId: string): Promise<SdkProv
 
 const providerManager = new ProviderSettingsManager();
 
+export function getSdkProviderSettingsDirectory(): string {
+	return dirname(providerManager.getFilePath());
+}
+
 function resolveModelsPath(): string {
-	return join(dirname(providerManager.getFilePath()), "models.json");
+	return join(getSdkProviderSettingsDirectory(), "models.json");
 }
 
 async function readModelsRegistry(): Promise<LocalModelsFile> {

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -693,6 +693,7 @@ export const runtimeClineProviderModelSchema = z.object({
 	supportsAttachments: z.boolean().optional(),
 	supportsReasoningEffort: z.boolean().optional(),
 	recommendedRank: z.number().int().nonnegative().optional(),
+	freeRank: z.number().int().nonnegative().optional(),
 });
 export type RuntimeClineProviderModel = z.infer<typeof runtimeClineProviderModelSchema>;
 

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -692,6 +692,7 @@ export const runtimeClineProviderModelSchema = z.object({
 	supportsVision: z.boolean().optional(),
 	supportsAttachments: z.boolean().optional(),
 	supportsReasoningEffort: z.boolean().optional(),
+	recommendedRank: z.number().int().nonnegative().optional(),
 });
 export type RuntimeClineProviderModel = z.infer<typeof runtimeClineProviderModelSchema>;
 

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -233,7 +233,7 @@ describe("getProviderModels", () => {
 		await rm(CLINE_RECOMMENDED_MODELS_CACHE_PATH, { force: true });
 	});
 
-	it("uses the cline endpoints for live models plus recommended and free rankings", async () => {
+	it("merges missing featured models back into the cline model list", async () => {
 		setSelectedProviderSettings({
 			provider: "cline",
 			baseUrl: "https://api.cline.bot",
@@ -246,7 +246,6 @@ describe("getProviderModels", () => {
 						data: [
 							{ id: "anthropic/claude-opus-4.7", name: "Claude Opus 4.7", supported_parameters: ["reasoning"] },
 							{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
-							{ id: "bytedance/seed-2-0-pro", name: "Seed 2.0 Pro" },
 						],
 					}),
 				};
@@ -269,6 +268,11 @@ describe("getProviderModels", () => {
 		expect(localProviderMocks.getLocalProviderModels).not.toHaveBeenCalled();
 		expect(result.models).toEqual([
 			{
+				id: "bytedance/seed-2-0-pro",
+				name: "bytedance/seed-2-0-pro",
+				freeRank: 0,
+			},
+			{
 				id: "anthropic/claude-opus-4.7",
 				name: "Claude Opus 4.7",
 				supportsReasoningEffort: true,
@@ -278,11 +282,6 @@ describe("getProviderModels", () => {
 				id: "anthropic/claude-sonnet-4.6",
 				name: "Claude Sonnet 4.6",
 				recommendedRank: 0,
-			},
-			{
-				id: "bytedance/seed-2-0-pro",
-				name: "Seed 2.0 Pro",
-				freeRank: 0,
 			},
 		]);
 	});

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -1,3 +1,5 @@
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const clineAccountMocks = vi.hoisted(() => ({
@@ -97,6 +99,9 @@ vi.mock("../../../src/server/browser.js", () => ({
 }));
 
 import { createClineProviderService } from "../../../src/cline-sdk/cline-provider-service";
+import { resetClineRecommendedModelsCacheForTests } from "../../../src/cline-sdk/cline-recommended-models";
+
+const CLINE_RECOMMENDED_MODELS_CACHE_PATH = join("/tmp", "cline-recommended-models.json");
 
 function setSelectedProviderSettings(
 	settings: {
@@ -213,6 +218,95 @@ describe("getClineAccountBalance", () => {
 		expect(result.balance).toBeNull();
 		expect(result.activeAccountLabel).toBeNull();
 		expect(result.activeOrganizationId).toBeNull();
+	});
+});
+
+describe("getProviderModels", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		resetClineRecommendedModelsCacheForTests();
+		vi.unstubAllGlobals();
+		await rm(CLINE_RECOMMENDED_MODELS_CACHE_PATH, { force: true });
+	});
+
+	it("annotates cline models using the recommended models endpoint", async () => {
+		setSelectedProviderSettings({
+			provider: "cline",
+			baseUrl: "https://api.cline.bot",
+		});
+		localProviderMocks.getLocalProviderModels.mockResolvedValue({
+			providerId: "cline",
+			models: [
+				{ id: "openai/gpt-5.4", name: "GPT-5.4" },
+				{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
+				{ id: "openai/gpt-5.2", name: "GPT-5.2" },
+			],
+		});
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				recommended: [{ id: "anthropic/claude-sonnet-4.6" }, { id: "openai/gpt-5.4" }],
+				free: [],
+			}),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const service = createClineProviderService();
+		const result = await service.getProviderModels("cline");
+
+		expect(fetchMock).toHaveBeenCalledWith("https://api.cline.bot/api/v1/ai/cline/recommended-models");
+		expect(result.models).toEqual([
+			{
+				id: "anthropic/claude-sonnet-4.6",
+				name: "Claude Sonnet 4.6",
+				recommendedRank: 0,
+			},
+			{
+				id: "openai/gpt-5.2",
+				name: "GPT-5.2",
+			},
+			{
+				id: "openai/gpt-5.4",
+				name: "GPT-5.4",
+				recommendedRank: 1,
+			},
+		]);
+	});
+
+	it("falls back to the bundled recommended model IDs when the endpoint fails", async () => {
+		setSelectedProviderSettings({
+			provider: "cline",
+			baseUrl: "https://api.cline.bot",
+		});
+		localProviderMocks.getLocalProviderModels.mockResolvedValue({
+			providerId: "cline",
+			models: [
+				{ id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
+				{ id: "openai/gpt-5.3-codex", name: "GPT-5.3 Codex" },
+				{ id: "openai/gpt-5.2", name: "GPT-5.2" },
+			],
+		});
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network unavailable")));
+
+		const service = createClineProviderService();
+		const result = await service.getProviderModels("cline");
+
+		expect(result.models).toEqual([
+			{
+				id: "google/gemini-3.1-pro-preview",
+				name: "Gemini 3.1 Pro Preview",
+				recommendedRank: 0,
+			},
+			{
+				id: "openai/gpt-5.2",
+				name: "GPT-5.2",
+			},
+			{
+				id: "openai/gpt-5.3-codex",
+				name: "GPT-5.3 Codex",
+				recommendedRank: 3,
+			},
+		]);
 	});
 });
 

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -286,6 +286,43 @@ describe("getProviderModels", () => {
 		]);
 	});
 
+	it("does not duplicate a configured model when featured backfill already added it", async () => {
+		setSelectedProviderSettings({
+			provider: "cline",
+			baseUrl: "https://api.cline.bot",
+			model: "bytedance/seed-2-0-pro",
+		});
+		const fetchMock = vi.fn(async (input: string) => {
+			if (input.endsWith("/api/v1/ai/cline/models")) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: [{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+					}),
+				};
+			}
+			return {
+				ok: true,
+				json: async () => ({
+					recommended: [{ id: "anthropic/claude-sonnet-4.6" }],
+					free: [{ id: "bytedance/seed-2-0-pro", name: "seed-2-0-pro" }],
+				}),
+			};
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const service = createClineProviderService();
+		const result = await service.getProviderModels("cline");
+
+		expect(result.models.filter((model) => model.id === "bytedance/seed-2-0-pro")).toEqual([
+			{
+				id: "bytedance/seed-2-0-pro",
+				name: "seed-2-0-pro",
+				freeRank: 0,
+			},
+		]);
+	});
+
 	it("falls back to the bundled recommended model IDs when the endpoint fails", async () => {
 		setSelectedProviderSettings({
 			provider: "cline",

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -99,8 +99,10 @@ vi.mock("../../../src/server/browser.js", () => ({
 }));
 
 import { createClineProviderService } from "../../../src/cline-sdk/cline-provider-service";
+import { resetClineProviderModelsCacheForTests } from "../../../src/cline-sdk/cline-provider-models";
 import { resetClineRecommendedModelsCacheForTests } from "../../../src/cline-sdk/cline-recommended-models";
 
+const CLINE_PROVIDER_MODELS_CACHE_PATH = join("/tmp", "cline-provider-models.json");
 const CLINE_RECOMMENDED_MODELS_CACHE_PATH = join("/tmp", "cline-recommended-models.json");
 
 function setSelectedProviderSettings(
@@ -224,30 +226,38 @@ describe("getClineAccountBalance", () => {
 describe("getProviderModels", () => {
 	beforeEach(async () => {
 		vi.clearAllMocks();
+		resetClineProviderModelsCacheForTests();
 		resetClineRecommendedModelsCacheForTests();
 		vi.unstubAllGlobals();
+		await rm(CLINE_PROVIDER_MODELS_CACHE_PATH, { force: true });
 		await rm(CLINE_RECOMMENDED_MODELS_CACHE_PATH, { force: true });
 	});
 
-	it("annotates cline models using the recommended models endpoint", async () => {
+	it("uses the cline endpoints for live models plus recommended and free rankings", async () => {
 		setSelectedProviderSettings({
 			provider: "cline",
 			baseUrl: "https://api.cline.bot",
 		});
-		localProviderMocks.getLocalProviderModels.mockResolvedValue({
-			providerId: "cline",
-			models: [
-				{ id: "openai/gpt-5.4", name: "GPT-5.4" },
-				{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
-				{ id: "openai/gpt-5.2", name: "GPT-5.2" },
-			],
-		});
-		const fetchMock = vi.fn().mockResolvedValue({
-			ok: true,
-			json: async () => ({
-				recommended: [{ id: "anthropic/claude-sonnet-4.6" }, { id: "openai/gpt-5.4" }],
-				free: [],
-			}),
+		const fetchMock = vi.fn(async (input: string) => {
+			if (input.endsWith("/api/v1/ai/cline/models")) {
+				return {
+					ok: true,
+					json: async () => ({
+						data: [
+							{ id: "anthropic/claude-opus-4.7", name: "Claude Opus 4.7", supported_parameters: ["reasoning"] },
+							{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
+							{ id: "bytedance/seed-2-0-pro", name: "Seed 2.0 Pro" },
+						],
+					}),
+				};
+			}
+			return {
+				ok: true,
+				json: async () => ({
+					recommended: [{ id: "anthropic/claude-sonnet-4.6" }, { id: "anthropic/claude-opus-4.7" }],
+					free: [{ id: "bytedance/seed-2-0-pro" }],
+				}),
+			};
 		});
 		vi.stubGlobal("fetch", fetchMock);
 
@@ -255,20 +265,24 @@ describe("getProviderModels", () => {
 		const result = await service.getProviderModels("cline");
 
 		expect(fetchMock).toHaveBeenCalledWith("https://api.cline.bot/api/v1/ai/cline/recommended-models");
+		expect(fetchMock).toHaveBeenCalledWith("https://api.cline.bot/api/v1/ai/cline/models");
+		expect(localProviderMocks.getLocalProviderModels).not.toHaveBeenCalled();
 		expect(result.models).toEqual([
+			{
+				id: "anthropic/claude-opus-4.7",
+				name: "Claude Opus 4.7",
+				supportsReasoningEffort: true,
+				recommendedRank: 1,
+			},
 			{
 				id: "anthropic/claude-sonnet-4.6",
 				name: "Claude Sonnet 4.6",
 				recommendedRank: 0,
 			},
 			{
-				id: "openai/gpt-5.2",
-				name: "GPT-5.2",
-			},
-			{
-				id: "openai/gpt-5.4",
-				name: "GPT-5.4",
-				recommendedRank: 1,
+				id: "bytedance/seed-2-0-pro",
+				name: "Seed 2.0 Pro",
+				freeRank: 0,
 			},
 		]);
 	});

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -1842,16 +1842,18 @@ describe("createRuntimeApi startTaskSession", () => {
 				baseUrl: "https://openrouter.ai/api/v1",
 			}),
 		);
-		expect(response).toEqual({
-			providerId: "openrouter",
-			models: [
-				{
-					id: "openrouter/free",
-					name: "OpenRouter Free",
-					supportsReasoningEffort: true,
-				},
-			],
-		});
+		expect(response.providerId).toBe("openrouter");
+		expect(response.models).toEqual([
+			expect.objectContaining({
+				id: "openrouter/free",
+				name: "OpenRouter Free",
+				supportsReasoningEffort: true,
+			}),
+			expect.objectContaining({
+				id: "openrouter/auto",
+				name: "openrouter/auto",
+			}),
+		]);
 	});
 
 	it("falls back to the queried provider's saved model when provider model loading fails", async () => {

--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
@@ -445,6 +445,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 						onCancel={handleCancelTurn}
 						modelOptions={modelOptions}
 						recommendedModelIds={modelPickerOptions.recommendedModelIds}
+						freeModelIds={modelPickerOptions.freeModelIds}
 						pinSelectedModelToTop={modelPickerOptions.shouldPinSelectedModelToTop}
 						selectedModelId={clineSettings.modelId}
 						selectedModelButtonText={selectedModelButtonText}

--- a/web-ui/src/components/detail-panels/cline-chat-composer.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-composer.tsx
@@ -56,6 +56,7 @@ export function ClineChatComposer({
 	onCancel,
 	modelOptions,
 	recommendedModelIds = [],
+	freeModelIds = [],
 	pinSelectedModelToTop = true,
 	selectedModelId,
 	selectedModelButtonText,
@@ -86,6 +87,7 @@ export function ClineChatComposer({
 	onCancel: () => void;
 	modelOptions: readonly SearchSelectOption[];
 	recommendedModelIds?: readonly string[];
+	freeModelIds?: readonly string[];
 	pinSelectedModelToTop?: boolean;
 	selectedModelId: string;
 	selectedModelButtonText: string;
@@ -496,6 +498,7 @@ export function ClineChatComposer({
 					<ClineChatModelSelector
 						modelOptions={modelOptions}
 						recommendedModelIds={recommendedModelIds}
+						freeModelIds={freeModelIds}
 						pinSelectedModelToTop={pinSelectedModelToTop}
 						selectedModelId={selectedModelId}
 						selectedModelButtonText={selectedModelButtonText}

--- a/web-ui/src/components/detail-panels/cline-chat-model-selector.test.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-model-selector.test.tsx
@@ -70,8 +70,10 @@ describe("ClineChatModelSelector", () => {
 					modelOptions={[
 						{ value: "openai/gpt-5.4", label: "GPT-5.4" },
 						{ value: "anthropic/claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+						{ value: "arcee-ai/trinity-large-preview:free", label: "Trinity Large Preview" },
 					]}
 					recommendedModelIds={["openai/gpt-5.4"]}
+					freeModelIds={["arcee-ai/trinity-large-preview:free"]}
 					selectedModelId="openai/gpt-5.4"
 					selectedModelButtonText="GPT-5.4 (High)"
 					onSelectModel={() => {}}
@@ -110,6 +112,7 @@ describe("ClineChatModelSelector", () => {
 		expect(document.body.textContent).toContain("Model ID");
 		expect(document.body.textContent).toContain("Reasoning effort");
 		expect(document.body.textContent).toContain("Recommended models");
+		expect(document.body.textContent).toContain("Free models");
 		expect(document.body.textContent).toContain("Default");
 		expect(hasClass(selectedModelButton, "cursor-pointer")).toBe(true);
 		expect(hasClass(selectedReasoningButton, "bg-accent")).toBe(true);

--- a/web-ui/src/components/detail-panels/cline-chat-model-selector.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-model-selector.tsx
@@ -22,6 +22,7 @@ const MATCHED_TEXT_STYLE = {
 export function ClineChatModelSelector({
 	modelOptions,
 	recommendedModelIds = [],
+	freeModelIds = [],
 	pinSelectedModelToTop = true,
 	selectedModelId,
 	selectedModelButtonText,
@@ -39,6 +40,7 @@ export function ClineChatModelSelector({
 }: {
 	modelOptions: readonly SearchSelectOption[];
 	recommendedModelIds?: readonly string[];
+	freeModelIds?: readonly string[];
 	pinSelectedModelToTop?: boolean;
 	selectedModelId: string;
 	selectedModelButtonText: string;
@@ -65,6 +67,15 @@ export function ClineChatModelSelector({
 	const recommendedModelIdSet = useMemo(
 		() => new Set(recommendedModelIds.map((value) => value.trim()).filter((value) => value.length > 0)),
 		[recommendedModelIds],
+	);
+	const freeModelIdSet = useMemo(
+		() =>
+			new Set(
+				freeModelIds
+					.map((value) => value.trim())
+					.filter((value) => value.length > 0 && !recommendedModelIdSet.has(value)),
+			),
+		[freeModelIds, recommendedModelIdSet],
 	);
 	const reasoningEnabledModelIdSet = useMemo(
 		() => new Set(reasoningEnabledModelIds.map((value) => value.trim()).filter((value) => value.length > 0)),
@@ -107,15 +118,18 @@ export function ClineChatModelSelector({
 	);
 	const filteredModelOptions = useMemo(() => {
 		if (!query.trim()) {
-			if (recommendedModelIdSet.size === 0) {
+			if (recommendedModelIdSet.size === 0 && freeModelIdSet.size === 0) {
 				return orderedOptions;
 			}
 			const recommendedItems = orderedOptions.filter((item) => recommendedModelIdSet.has(item.value));
-			const otherItems = orderedOptions.filter((item) => !recommendedModelIdSet.has(item.value));
-			return [...recommendedItems, ...otherItems];
+			const freeItems = orderedOptions.filter((item) => freeModelIdSet.has(item.value));
+			const otherItems = orderedOptions.filter(
+				(item) => !recommendedModelIdSet.has(item.value) && !freeModelIdSet.has(item.value),
+			);
+			return [...recommendedItems, ...freeItems, ...otherItems];
 		}
 		return fuzzyMatches.map((entry) => entry.item);
-	}, [fuzzyMatches, orderedOptions, query, recommendedModelIdSet]);
+	}, [freeModelIdSet, fuzzyMatches, orderedOptions, query, recommendedModelIdSet]);
 	const filteredItemIndexByValue = useMemo(
 		() => new Map(filteredModelOptions.map((item, index) => [item.value, index] as const)),
 		[filteredModelOptions],
@@ -124,14 +138,21 @@ export function ClineChatModelSelector({
 		() => filteredModelOptions.findIndex((option) => option.value === selectedModelId),
 		[filteredModelOptions, selectedModelId],
 	);
-	const showRecommendedSection = query.trim().length === 0 && recommendedModelIdSet.size > 0;
+	const showFeaturedSections = query.trim().length === 0 && (recommendedModelIdSet.size > 0 || freeModelIdSet.size > 0);
 	const recommendedItems = useMemo(
 		() => filteredModelOptions.filter((item) => recommendedModelIdSet.has(item.value)),
 		[filteredModelOptions, recommendedModelIdSet],
 	);
+	const freeItems = useMemo(
+		() => filteredModelOptions.filter((item) => freeModelIdSet.has(item.value)),
+		[filteredModelOptions, freeModelIdSet],
+	);
 	const otherItems = useMemo(
-		() => filteredModelOptions.filter((item) => !recommendedModelIdSet.has(item.value)),
-		[filteredModelOptions, recommendedModelIdSet],
+		() =>
+			filteredModelOptions.filter(
+				(item) => !recommendedModelIdSet.has(item.value) && !freeModelIdSet.has(item.value),
+			),
+		[filteredModelOptions, freeModelIdSet, recommendedModelIdSet],
 	);
 
 	const handleOpenChange = useCallback(
@@ -355,15 +376,23 @@ export function ClineChatModelSelector({
 									<div className="px-2.5 py-1.5 text-[13px] text-text-tertiary">No matching models</div>
 								) : (
 									<>
-										{showRecommendedSection && recommendedItems.length > 0 ? (
+										{showFeaturedSections && recommendedItems.length > 0 ? (
 											<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
 												Recommended models
 											</div>
 										) : null}
-										{(showRecommendedSection ? recommendedItems : filteredModelOptions).map((option) =>
+										{(showFeaturedSections ? recommendedItems : filteredModelOptions).map((option) =>
 											renderModelOptionButton(option),
 										)}
-										{showRecommendedSection && recommendedItems.length > 0 && otherItems.length > 0 ? (
+										{showFeaturedSections && freeItems.length > 0 ? (
+											<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
+												Free models
+											</div>
+										) : null}
+										{showFeaturedSections ? freeItems.map((option) => renderModelOptionButton(option)) : null}
+										{showFeaturedSections &&
+										(recommendedItems.length > 0 || freeItems.length > 0) &&
+										otherItems.length > 0 ? (
 											<>
 												<div className="my-1 border-t border-border" />
 												<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
@@ -371,7 +400,7 @@ export function ClineChatModelSelector({
 												</div>
 											</>
 										) : null}
-										{showRecommendedSection && otherItems.length > 0
+										{showFeaturedSections && otherItems.length > 0
 											? otherItems.map((option) => renderModelOptionButton(option))
 											: null}
 									</>

--- a/web-ui/src/components/detail-panels/cline-model-picker-options.test.ts
+++ b/web-ui/src/components/detail-panels/cline-model-picker-options.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
 	buildClineAgentModelPickerOptions,
 	buildClineSelectedModelButtonText,
-	CLINE_RECOMMENDED_MODEL_IDS,
 	formatClineReasoningEffortLabel,
 	formatClineSelectedModelButtonText,
 	getClineReasoningEnabledModelIds,
@@ -11,27 +10,46 @@ import {
 } from "@/components/detail-panels/cline-model-picker-options";
 import type { RuntimeClineProviderModel } from "@/runtime/types";
 
-function createModel(id: string, name: string): RuntimeClineProviderModel {
-	return { id, name };
+function createModel(
+	id: string,
+	name: string,
+	options: Partial<Pick<RuntimeClineProviderModel, "recommendedRank" | "supportsReasoningEffort">> = {},
+): RuntimeClineProviderModel {
+	return { id, name, ...options };
 }
 
 describe("buildClineAgentModelPickerOptions", () => {
 	it("returns recommended models first for the cline provider", () => {
 		const models: RuntimeClineProviderModel[] = [
-			createModel("openai/gpt-5.4", "GPT-5.4"),
+			createModel("openai/gpt-5.4", "GPT-5.4", { recommendedRank: 3 }),
 			createModel("openai/gpt-5.2", "GPT-5.2"),
-			createModel("anthropic/claude-opus-4.6", "Claude Opus 4.6"),
-			createModel("anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6"),
-			createModel("openai/gpt-5.3-codex", "GPT-5.3 Codex"),
-			createModel("google/gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview"),
+			createModel("anthropic/claude-opus-4.6", "Claude Opus 4.6", { recommendedRank: 2 }),
+			createModel("anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6", { recommendedRank: 1 }),
+			createModel("openai/gpt-5.3-codex", "GPT-5.3 Codex", { recommendedRank: 4 }),
+			createModel("google/gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", { recommendedRank: 0 }),
 			createModel("google/gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash Lite Preview"),
 			createModel("xiaomi/mimo-v2-pro", "Mimo v2 Pro"),
 		];
 
 		const result = buildClineAgentModelPickerOptions("cline", models);
 
-		expect(result.options.map((option) => option.value)).toEqual([...CLINE_RECOMMENDED_MODEL_IDS, "openai/gpt-5.2"]);
-		expect(result.recommendedModelIds).toEqual([...CLINE_RECOMMENDED_MODEL_IDS]);
+		expect(result.options.map((option) => option.value)).toEqual([
+			"google/gemini-3.1-pro-preview",
+			"anthropic/claude-sonnet-4.6",
+			"anthropic/claude-opus-4.6",
+			"openai/gpt-5.4",
+			"openai/gpt-5.3-codex",
+			"openai/gpt-5.2",
+			"google/gemini-3.1-flash-lite-preview",
+			"xiaomi/mimo-v2-pro",
+		]);
+		expect(result.recommendedModelIds).toEqual([
+			"google/gemini-3.1-pro-preview",
+			"anthropic/claude-sonnet-4.6",
+			"anthropic/claude-opus-4.6",
+			"openai/gpt-5.4",
+			"openai/gpt-5.3-codex",
+		]);
 		expect(result.shouldPinSelectedModelToTop).toBe(false);
 	});
 

--- a/web-ui/src/components/detail-panels/cline-model-picker-options.test.ts
+++ b/web-ui/src/components/detail-panels/cline-model-picker-options.test.ts
@@ -13,7 +13,7 @@ import type { RuntimeClineProviderModel } from "@/runtime/types";
 function createModel(
 	id: string,
 	name: string,
-	options: Partial<Pick<RuntimeClineProviderModel, "recommendedRank" | "supportsReasoningEffort">> = {},
+	options: Partial<Pick<RuntimeClineProviderModel, "recommendedRank" | "freeRank" | "supportsReasoningEffort">> = {},
 ): RuntimeClineProviderModel {
 	return { id, name, ...options };
 }
@@ -26,6 +26,8 @@ describe("buildClineAgentModelPickerOptions", () => {
 			createModel("anthropic/claude-opus-4.6", "Claude Opus 4.6", { recommendedRank: 2 }),
 			createModel("anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6", { recommendedRank: 1 }),
 			createModel("openai/gpt-5.3-codex", "GPT-5.3 Codex", { recommendedRank: 4 }),
+			createModel("arcee-ai/trinity-large-preview:free", "Trinity Large Preview", { freeRank: 0 }),
+			createModel("bytedance/seed-2-0-pro", "Seed 2.0 Pro", { freeRank: 1 }),
 			createModel("google/gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", { recommendedRank: 0 }),
 			createModel("google/gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash Lite Preview"),
 			createModel("xiaomi/mimo-v2-pro", "Mimo v2 Pro"),
@@ -39,6 +41,8 @@ describe("buildClineAgentModelPickerOptions", () => {
 			"anthropic/claude-opus-4.6",
 			"openai/gpt-5.4",
 			"openai/gpt-5.3-codex",
+			"arcee-ai/trinity-large-preview:free",
+			"bytedance/seed-2-0-pro",
 			"openai/gpt-5.2",
 			"google/gemini-3.1-flash-lite-preview",
 			"xiaomi/mimo-v2-pro",
@@ -50,6 +54,7 @@ describe("buildClineAgentModelPickerOptions", () => {
 			"openai/gpt-5.4",
 			"openai/gpt-5.3-codex",
 		]);
+		expect(result.freeModelIds).toEqual(["arcee-ai/trinity-large-preview:free", "bytedance/seed-2-0-pro"]);
 		expect(result.shouldPinSelectedModelToTop).toBe(false);
 	});
 
@@ -63,6 +68,7 @@ describe("buildClineAgentModelPickerOptions", () => {
 
 		expect(result.options.map((option) => option.value)).toEqual(["model-a", "model-b"]);
 		expect(result.recommendedModelIds).toEqual([]);
+		expect(result.freeModelIds).toEqual([]);
 		expect(result.shouldPinSelectedModelToTop).toBe(true);
 	});
 });

--- a/web-ui/src/components/detail-panels/cline-model-picker-options.ts
+++ b/web-ui/src/components/detail-panels/cline-model-picker-options.ts
@@ -24,6 +24,7 @@ export const CLINE_REASONING_EFFORT_OPTIONS: SearchSelectOption[] = [
 export interface BuildClineAgentModelPickerOptionsResult {
 	options: SearchSelectOption[];
 	recommendedModelIds: string[];
+	freeModelIds: string[];
 	shouldPinSelectedModelToTop: boolean;
 }
 
@@ -39,6 +40,7 @@ export function buildClineAgentModelPickerOptions(
 		return {
 			options: defaultOptions,
 			recommendedModelIds: [],
+			freeModelIds: [],
 			shouldPinSelectedModelToTop: true,
 		};
 	}
@@ -58,11 +60,28 @@ export function buildClineAgentModelPickerOptions(
 		.filter((option): option is SearchSelectOption => option !== undefined);
 	const recommendedModelIds = recommendedOptions.map((option) => option.value);
 	const recommendedModelIdSet = new Set(recommendedModelIds);
-	const nonRecommendedOptions = defaultOptions.filter((option) => !recommendedModelIdSet.has(option.value));
+	const freeOptions = providerModels
+		.filter((model) => typeof model.freeRank === "number" && !recommendedModelIdSet.has(model.id))
+		.sort((left, right) => {
+			const leftRank = left.freeRank ?? Number.MAX_SAFE_INTEGER;
+			const rightRank = right.freeRank ?? Number.MAX_SAFE_INTEGER;
+			if (leftRank !== rightRank) {
+				return leftRank - rightRank;
+			}
+			return left.name.localeCompare(right.name);
+		})
+		.map((model) => optionsById.get(model.id))
+		.filter((option): option is SearchSelectOption => option !== undefined);
+	const freeModelIds = freeOptions.map((option) => option.value);
+	const freeModelIdSet = new Set(freeModelIds);
+	const nonFeaturedOptions = defaultOptions.filter(
+		(option) => !recommendedModelIdSet.has(option.value) && !freeModelIdSet.has(option.value),
+	);
 
 	return {
-		options: [...recommendedOptions, ...nonRecommendedOptions],
+		options: [...recommendedOptions, ...freeOptions, ...nonFeaturedOptions],
 		recommendedModelIds,
+		freeModelIds,
 		shouldPinSelectedModelToTop: false,
 	};
 }

--- a/web-ui/src/components/detail-panels/cline-model-picker-options.ts
+++ b/web-ui/src/components/detail-panels/cline-model-picker-options.ts
@@ -3,16 +3,6 @@ import type { RuntimeClineProviderModel, RuntimeClineReasoningEffort } from "@/r
 
 const CLINE_PROVIDER_ID = "cline";
 
-export const CLINE_RECOMMENDED_MODEL_IDS = [
-	"anthropic/claude-opus-4.6",
-	"anthropic/claude-sonnet-4.6",
-	"openai/gpt-5.3-codex",
-	"openai/gpt-5.4",
-	"google/gemini-3.1-pro-preview",
-	"google/gemini-3.1-flash-lite-preview",
-	"xiaomi/mimo-v2-pro",
-] as const;
-
 const CLINE_MODEL_NAME_BY_ID: Record<string, string> = {
 	"anthropic/claude-opus-4.6": "Claude Opus 4.6",
 	"anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6",
@@ -54,9 +44,18 @@ export function buildClineAgentModelPickerOptions(
 	}
 
 	const optionsById = new Map(defaultOptions.map((option) => [option.value, option] as const));
-	const recommendedOptions = CLINE_RECOMMENDED_MODEL_IDS.map((modelId) => optionsById.get(modelId)).filter(
-		(option): option is SearchSelectOption => option !== undefined,
-	);
+	const recommendedOptions = providerModels
+		.filter((model) => typeof model.recommendedRank === "number")
+		.sort((left, right) => {
+			const leftRank = left.recommendedRank ?? Number.MAX_SAFE_INTEGER;
+			const rightRank = right.recommendedRank ?? Number.MAX_SAFE_INTEGER;
+			if (leftRank !== rightRank) {
+				return leftRank - rightRank;
+			}
+			return left.name.localeCompare(right.name);
+		})
+		.map((model) => optionsById.get(model.id))
+		.filter((option): option is SearchSelectOption => option !== undefined);
 	const recommendedModelIds = recommendedOptions.map((option) => option.value);
 	const recommendedModelIdSet = new Set(recommendedModelIds);
 	const nonRecommendedOptions = defaultOptions.filter((option) => !recommendedModelIdSet.has(option.value));

--- a/web-ui/src/components/search-select-dropdown.tsx
+++ b/web-ui/src/components/search-select-dropdown.tsx
@@ -37,7 +37,9 @@ export function SearchSelectDropdown({
 	showSelectedIndicator = false,
 	pinSelectedToTop = true,
 	recommendedOptionValues = [],
+	freeOptionValues = [],
 	recommendedHeading = "Recommended models",
+	freeHeading = "Free models",
 	matchTargetWidth = true,
 	collisionPadding = 8,
 	dropdownStyle,
@@ -63,7 +65,9 @@ export function SearchSelectDropdown({
 	showSelectedIndicator?: boolean;
 	pinSelectedToTop?: boolean;
 	recommendedOptionValues?: readonly string[];
+	freeOptionValues?: readonly string[];
 	recommendedHeading?: string;
+	freeHeading?: string;
 	matchTargetWidth?: boolean;
 	collisionPadding?: number;
 	dropdownStyle?: CSSProperties;
@@ -104,6 +108,15 @@ export function SearchSelectDropdown({
 		() => new Set(recommendedOptionValues.map((value) => value.trim()).filter((value) => value.length > 0)),
 		[recommendedOptionValues],
 	);
+	const freeOptionValueSet = useMemo(
+		() =>
+			new Set(
+				freeOptionValues
+					.map((value) => value.trim())
+					.filter((value) => value.length > 0 && !recommendedOptionValueSet.has(value)),
+			),
+		[freeOptionValues, recommendedOptionValueSet],
+	);
 	const fuzzyMatches = useMemo(() => {
 		if (!query.trim()) {
 			return [] as ReturnType<Fzf<SearchSelectOption[]>["find"]>;
@@ -119,24 +132,34 @@ export function SearchSelectDropdown({
 	);
 	const filteredItems = useMemo(() => {
 		if (!query.trim()) {
-			if (recommendedOptionValueSet.size === 0) {
+			if (recommendedOptionValueSet.size === 0 && freeOptionValueSet.size === 0) {
 				return orderedOptions;
 			}
 			const recommendedItems = orderedOptions.filter((item) => recommendedOptionValueSet.has(item.value));
-			const otherItems = orderedOptions.filter((item) => !recommendedOptionValueSet.has(item.value));
-			return [...recommendedItems, ...otherItems];
+			const freeItems = orderedOptions.filter((item) => freeOptionValueSet.has(item.value));
+			const otherItems = orderedOptions.filter(
+				(item) => !recommendedOptionValueSet.has(item.value) && !freeOptionValueSet.has(item.value),
+			);
+			return [...recommendedItems, ...freeItems, ...otherItems];
 		}
 		return fuzzyMatches.map((entry) => entry.item);
-	}, [fuzzyMatches, orderedOptions, query, recommendedOptionValueSet]);
+	}, [freeOptionValueSet, fuzzyMatches, orderedOptions, query, recommendedOptionValueSet]);
 	const isSearching = query.trim().length > 0;
-	const showRecommendedSection = !isSearching && recommendedOptionValueSet.size > 0;
+	const showFeaturedSections = !isSearching && (recommendedOptionValueSet.size > 0 || freeOptionValueSet.size > 0);
 	const recommendedItems = useMemo(
 		() => filteredItems.filter((item) => recommendedOptionValueSet.has(item.value)),
 		[filteredItems, recommendedOptionValueSet],
 	);
+	const freeItems = useMemo(
+		() => filteredItems.filter((item) => freeOptionValueSet.has(item.value)),
+		[filteredItems, freeOptionValueSet],
+	);
 	const otherItems = useMemo(
-		() => filteredItems.filter((item) => !recommendedOptionValueSet.has(item.value)),
-		[filteredItems, recommendedOptionValueSet],
+		() =>
+			filteredItems.filter(
+				(item) => !recommendedOptionValueSet.has(item.value) && !freeOptionValueSet.has(item.value),
+			),
+		[filteredItems, freeOptionValueSet, recommendedOptionValueSet],
 	);
 	const filteredItemIndexByValue = useMemo(
 		() => new Map(filteredItems.map((item, index) => [item.value, index] as const)),
@@ -327,14 +350,18 @@ export function SearchSelectDropdown({
 							<div className="px-2.5 py-1.5 text-[13px] text-text-tertiary">{noResultsText}</div>
 						) : (
 							<>
-								{showRecommendedSection && recommendedItems.length > 0 ? (
+								{showFeaturedSections && recommendedItems.length > 0 ? (
 									<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
 										{recommendedHeading}
 									</div>
 								) : null}
-								{(showRecommendedSection ? recommendedItems : filteredItems).map((option) =>
-									renderOptionButton(option),
-								)}
+								{(showFeaturedSections ? recommendedItems : filteredItems).map((option) => renderOptionButton(option))}
+								{showFeaturedSections && freeItems.length > 0 ? (
+									<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
+										{freeHeading}
+									</div>
+								) : null}
+								{showFeaturedSections ? freeItems.map((option) => renderOptionButton(option)) : null}
 								{footerAction ? (
 									<div className="border-t border-border p-1">
 										<button
@@ -349,7 +376,7 @@ export function SearchSelectDropdown({
 										</button>
 									</div>
 								) : null}
-								{showRecommendedSection && recommendedItems.length > 0 && otherItems.length > 0 ? (
+								{showFeaturedSections && (recommendedItems.length > 0 || freeItems.length > 0) && otherItems.length > 0 ? (
 									<>
 										<div className="my-1 border-t border-border" />
 										<div className="px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.02em] text-text-tertiary">
@@ -357,7 +384,7 @@ export function SearchSelectDropdown({
 										</div>
 									</>
 								) : null}
-								{showRecommendedSection && otherItems.length > 0
+								{showFeaturedSections && otherItems.length > 0
 									? otherItems.map((option) => renderOptionButton(option))
 									: null}
 							</>

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -575,6 +575,7 @@ export function ClineSetupSection({
 							showSelectedIndicator
 							pinSelectedToTop={modelPickerOptions.shouldPinSelectedModelToTop}
 							recommendedOptionValues={modelPickerOptions.recommendedModelIds}
+							freeOptionValues={modelPickerOptions.freeModelIds}
 							recommendedHeading="Recommended models"
 						/>
 					</div>

--- a/web-ui/src/components/task-agent-model-picker.tsx
+++ b/web-ui/src/components/task-agent-model-picker.tsx
@@ -324,6 +324,7 @@ export function TaskAgentModelPicker({
 			return {
 				options: defaultOption ? [defaultOption, ...explicitOptions] : explicitOptions,
 				recommendedModelIds: [] as string[],
+				freeModelIds: [] as string[],
 				shouldPinSelectedModelToTop: true,
 			};
 		}
@@ -339,6 +340,7 @@ export function TaskAgentModelPicker({
 		return {
 			options: defaultOption ? [defaultOption, ...orderedExplicit, ...remainingExplicit] : orderedExplicit,
 			recommendedModelIds: orderedOptions.recommendedModelIds,
+			freeModelIds: orderedOptions.freeModelIds,
 			shouldPinSelectedModelToTop: orderedOptions.shouldPinSelectedModelToTop,
 		};
 	}, [clineModelOptions, effectiveProviderId, providerModels]);
@@ -546,6 +548,7 @@ export function TaskAgentModelPicker({
 										<ClineChatModelSelector
 											modelOptions={modelPickerOptions.options}
 											recommendedModelIds={modelPickerOptions.recommendedModelIds}
+											freeModelIds={modelPickerOptions.freeModelIds}
 											pinSelectedModelToTop={modelPickerOptions.shouldPinSelectedModelToTop}
 											selectedModelId={clineModelId ?? ""}
 											selectedModelButtonText={selectedModelButtonText}


### PR DESCRIPTION
## Summary
- fetch Cline recommended models from the same  endpoint used by Cline
- cache the recommended model response on disk with an in-memory TTL and fall back to bundled IDs when the endpoint is unavailable
- annotate returned Cline provider models with recommendation rank so the Kanban picker can order them without a hard-coded UI list

## Testing
- npm run test -- test/runtime/cline-sdk/account-balance.test.ts
- npm --prefix web-ui run test -- src/components/detail-panels/cline-model-picker-options.test.ts
- npm run typecheck
- npm --prefix web-ui run typecheck