### PR TITLE
feat: add ⌘E / Ctrl+E keyboard shortcut to toggle project sidebar

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -617,6 +617,11 @@ export default function App(): ReactElement {
 		setSelectedTaskId,
 	});
 
+	const sidebarLayout = useProjectNavigationLayout();
+	const handleToggleSidebar = useCallback(() => {
+		sidebarLayout.setSidebarCollapsed(!sidebarLayout.isCollapsed);
+	}, [sidebarLayout]);
+
 	useAppHotkeys({
 		selectedCard,
 		isDetailTerminalOpen,
@@ -631,6 +636,7 @@ export default function App(): ReactElement {
 		handleOpenSettings,
 		handleToggleGitHistory,
 		handleCloseGitHistory,
+		handleToggleSidebar,
 		onStartAllTasks: handleStartAllBacklogTasksFromBoard,
 	});
 
@@ -689,11 +695,6 @@ export default function App(): ReactElement {
 		}
 		return undefined;
 	}, [selectedCard]);
-
-	const sidebarLayout = useProjectNavigationLayout();
-	const handleToggleSidebar = useCallback(() => {
-		sidebarLayout.setSidebarCollapsed(!sidebarLayout.isCollapsed);
-	}, [sidebarLayout]);
 
 	const navbarWorkspacePath = hasNoProjects ? undefined : activeWorkspacePath;
 	const navbarWorkspaceHint = hasNoProjects ? undefined : activeWorkspaceHint;
@@ -838,6 +839,7 @@ export default function App(): ReactElement {
 				<div className="flex flex-col flex-1 min-w-0 overflow-hidden">
 					<TopBar
 						onToggleSidebar={!selectedCard ? handleToggleSidebar : undefined}
+						isLeftPanelCollapsed={sidebarLayout.isCollapsed}
 						onBack={selectedCard ? handleBack : undefined}
 						workspacePath={navbarWorkspacePath}
 						isWorkspacePathLoading={shouldShowProjectLoadingState}

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -595,6 +595,7 @@ const ESSENTIAL_SHORTCUTS = [
 	{ keys: ["Click", MOD], label: "Hold to link tasks" },
 	{ keys: [MOD, "G"], label: "Toggle git view" },
 	{ keys: [MOD, "J"], label: "Toggle terminal" },
+	{ keys: [MOD, "E"], label: "Toggle sidebar" },
 ];
 
 const MORE_SHORTCUTS = [

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -421,7 +421,7 @@ export function TopBar({
 							className={cn("shrink-0", MOBILE_TOUCH_TARGET)}
 						/>
 					) : !isMobile && onToggleSidebar && isLeftPanelCollapsed ? (
-						<Tooltip side="bottom" content={`Toggle sidebar (${isMacPlatform ? "⌘" : "Ctrl"}E)`}>
+						<Tooltip side="bottom" content={`Toggle sidebar (${isMacPlatform ? "⌘E" : "Ctrl+E"})`}>
 							<Button
 								variant="ghost"
 								size="sm"

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -24,6 +24,7 @@ import {
 	type RuntimeShortcutPickerIconId,
 } from "@/components/shared/runtime-shortcut-icons";
 import { Button } from "@/components/ui/button";
+import { ClineIcon } from "@/components/ui/cline-icon";
 import { cn } from "@/components/ui/cn";
 import { Dialog, DialogBody, DialogFooter, DialogHeader } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
@@ -280,6 +281,7 @@ function TopBarGitStatusSection({
 
 export function TopBar({
 	onToggleSidebar,
+	isLeftPanelCollapsed,
 	onBack,
 	workspacePath,
 	isWorkspacePathLoading = false,
@@ -315,6 +317,7 @@ export function TopBar({
 	hideProjectDependentActions = false,
 }: {
 	onToggleSidebar?: () => void;
+	isLeftPanelCollapsed?: boolean;
 	onBack?: () => void;
 	workspacePath?: string;
 	isWorkspacePathLoading?: boolean;
@@ -417,6 +420,17 @@ export function TopBar({
 							aria-label="Toggle sidebar"
 							className={cn("shrink-0", MOBILE_TOUCH_TARGET)}
 						/>
+					) : !isMobile && onToggleSidebar && isLeftPanelCollapsed ? (
+						<Tooltip side="bottom" content={`Toggle sidebar (${isMacPlatform ? "⌘" : "Ctrl"}E)`}>
+							<Button
+								variant="ghost"
+								size="sm"
+								icon={<ClineIcon size={16} />}
+								onClick={onToggleSidebar}
+								aria-label="Toggle sidebar"
+								className="shrink-0"
+							/>
+						</Tooltip>
 					) : null}
 					{onBack ? (
 						<div className="flex items-center shrink-0 overflow-visible">

--- a/web-ui/src/hooks/use-app-hotkeys.test.tsx
+++ b/web-ui/src/hooks/use-app-hotkeys.test.tsx
@@ -64,6 +64,7 @@ describe("useAppHotkeys", () => {
 					handleOpenSettings={handleOpenSettings}
 					handleToggleGitHistory={handleToggleGitHistory}
 					handleCloseGitHistory={() => {}}
+					handleToggleSidebar={() => {}}
 					onStartAllTasks={() => {}}
 				/>,
 			);
@@ -108,6 +109,7 @@ describe("useAppHotkeys", () => {
 					handleOpenSettings={() => {}}
 					handleToggleGitHistory={() => {}}
 					handleCloseGitHistory={handleCloseGitHistory}
+					handleToggleSidebar={() => {}}
 					onStartAllTasks={() => {}}
 				/>,
 			);
@@ -145,6 +147,7 @@ describe("useAppHotkeys", () => {
 					handleOpenSettings={() => {}}
 					handleToggleGitHistory={() => {}}
 					handleCloseGitHistory={() => {}}
+					handleToggleSidebar={() => {}}
 					onStartAllTasks={onStartAllTasks}
 				/>,
 			);
@@ -182,6 +185,7 @@ describe("useAppHotkeys", () => {
 					handleOpenSettings={() => {}}
 					handleToggleGitHistory={() => {}}
 					handleCloseGitHistory={() => {}}
+					handleToggleSidebar={() => {}}
 					onStartAllTasks={() => {}}
 				/>,
 			);

--- a/web-ui/src/hooks/use-app-hotkeys.ts
+++ b/web-ui/src/hooks/use-app-hotkeys.ts
@@ -20,6 +20,7 @@ interface UseAppHotkeysInput {
 	handleOpenSettings: () => void;
 	handleToggleGitHistory: () => void;
 	handleCloseGitHistory: () => void;
+	handleToggleSidebar: () => void;
 	onStartAllTasks: () => void;
 }
 
@@ -37,6 +38,7 @@ export function useAppHotkeys({
 	handleOpenSettings,
 	handleToggleGitHistory,
 	handleCloseGitHistory,
+	handleToggleSidebar,
 	onStartAllTasks,
 }: UseAppHotkeysInput): void {
 	useHotkeys(
@@ -104,6 +106,19 @@ export function useAppHotkeys({
 		},
 		{ preventDefault: true },
 		[canUseCreateTaskShortcut, handleOpenCreateTask],
+	);
+
+	useHotkeys(
+		"mod+e",
+		() => {
+			handleToggleSidebar();
+		},
+		{
+			enableOnFormTags: true,
+			enableOnContentEditable: true,
+			preventDefault: true,
+		},
+		[handleToggleSidebar],
 	);
 
 	useHotkeys(


### PR DESCRIPTION
## Summary

- Registers `mod+e` (⌘E on macOS, Ctrl+E on Linux/Windows) as a global hotkey for collapsing and expanding the project navigation panel — works even when focus is inside form tags or contenteditable elements.
- On desktop, a ghost `ClineIcon` button appears in the top-left corner **only when the sidebar is collapsed**, providing a visual affordance to reopen it; the tooltip surfaces the platform-correct shortcut hint.
- Adds `⌘E / Ctrl+E → Toggle sidebar` to the ESSENTIAL_SHORTCUTS list shown in the keyboard-shortcuts reference panel.


<img width="640" height="448" alt="cms-e" src="https://github.com/user-attachments/assets/7aaed2dd-14d7-4ad0-a7f7-1672349df8de" />


## Why `mod+e`?

The mnemonic is deliberate: **`e` = Explorer**. VS Code uses `⌘⇧E` to focus the Explorer sidebar, and most modern IDEs map their project-tree panels under an "E" binding. Users coming from those tools get zero learning curve — it's the closest single-key analogue that doesn't conflict with an existing Kanban shortcut.

## Files changed

| File | What changed |
|---|---|
| `use-app-hotkeys.ts` | Registers `mod+e` via `react-hotkeys-hook`, calls `handleToggleSidebar` |
| `use-app-hotkeys.test.tsx` | Threads `handleToggleSidebar` stub through all four existing test render sites |
| `App.tsx` | Moves `useProjectNavigationLayout` + `handleToggleSidebar` above `useAppHotkeys` call (required ordering); passes new props into `<TopBar>` |
| `top-bar.tsx` | Adds collapsed-only ghost button with tooltip showing platform shortcut hint |
| `project-navigation-panel.tsx` | Adds `{ keys: [MOD, "E"], label: "Toggle sidebar" }` to shortcuts reference |

## Test plan

- [ ] Press ⌘E (macOS) / Ctrl+E (Linux/Windows) — sidebar collapses and expands
- [ ] Shortcut works while cursor is inside a text input or contenteditable area
- [ ] When sidebar is collapsed a `ClineIcon` button appears in the top-left of the top bar; click reopens the sidebar
- [ ] Tooltip on that button reads `Toggle sidebar (⌘E)` / `Toggle sidebar (Ctrl+E)` per platform
- [ ] Keyboard shortcuts panel lists `⌘E` / `Ctrl+E` under Essential shortcuts
- [ ] Existing hotkey tests (`use-app-hotkeys.test.tsx`) pass: `npm run test:fast`
- [ ] No regressions on mobile (hamburger button still shown; collapsed-icon button is desktop-only)