### PR TITLE
fix(pre-commit): use `git add -f` so stale info/exclude can't block commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,9 +16,11 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+# Use -f so an over-broad .git/info/exclude entry can't block the re-add;
+# these files were already staged, so forcing is safe.
 for file in $STAGED_FILES; do
 	if [ -f "$file" ]; then
-		git add "$file"
+		git add -f "$file"
 	fi
 done
 


### PR DESCRIPTION
Closes #351.

## Change

```diff
 for file in $STAGED_FILES; do
 	if [ -f "$file" ]; then
-		git add "$file"
+		git add -f "$file"
 	fi
 done
```

One line in `.husky/pre-commit`.

## Why this is a real bug

`git add <path>` refuses to add a file whose parent directory is matched by `.git/info/exclude` (or `.gitignore`), **even if the file is already tracked**. Reproduced in a scratch repo:

```console
$ # repo has packages/foo.ts tracked, /packages in .git/info/exclude
$ git add packages/foo.ts
The following paths are ignored by one of your .gitignore files:
packages
hint: Use -f if you really want to add them.
# exit 128
```

That's exactly the hook's failure mode. The re-stage loop runs *after* `biome check --staged` has applied fixes in-place and is how the hook pulls those fixes back into the index. If the developer has a stale Kanban-managed `/<dir>` line in `.git/info/exclude` (written by an older task-worktree run before that directory gained tracked content), every `git add "$file"` in the loop hits `fatal: ignored`, husky exits 1, and the developer sees `pre-commit script failed (code 1)` with no useful signal — even though biome, typecheck, and tests all passed.

## Why `-f` is safe here

- The loop only re-adds paths that were already `git add`-ed at the start of the hook, i.e. files the developer explicitly chose to stage.
- `-f` only overrides ignore rules; it does not touch permissions, symlinks, large-file/LFS hooks, or any other git policy.
- It matches user intent: a commit the developer authored shouldn't be silently vetoed by a stale client-side ignore rule.

## Scope

Just the hook. No source or test changes — `syncManagedIgnoredPathExcludes` in `src/workspace/task-worktree.ts` already regenerates the managed exclude block correctly from fresh `git ls-files --others --ignored` output (which, by definition, can never include paths that shadow tracked content), so adding "defensive" filtering there would be dead code guarding against impossible input.

## Verification

- `npm run typecheck` ✅
- `npm run test:precommit` ✅ 504 / 504
- `npx biome check` ✅
- **End-to-end**: re-injected `/packages` into a local `.git/info/exclude`, then `git commit` with the full husky hook enabled — hook passed, commit landed. Without the `-f`, the same commit fails as in the scratch-repo repro above.
