### PR TITLE
fix(web-ui): show "Kanban" (not "cline") in document title fallback

### DIFF
--- a/web-ui/src/hooks/use-review-ready-notifications.ts
+++ b/web-ui/src/hooks/use-review-ready-notifications.ts
@@ -231,7 +231,7 @@ export function useReviewReadyNotifications({
 		setPendingReviewReadyNotificationCount(0);
 	}, [activeWorkspaceId]);
 
-	const baseTitle = workspaceTitle || "cline";
+	const baseTitle = workspaceTitle || "Kanban";
 	const documentTitle =
 		pendingReviewReadyNotificationCount > 0 ? `(${pendingReviewReadyNotificationCount}) ${baseTitle}` : baseTitle;
 	useDocumentTitle(documentTitle);


### PR DESCRIPTION
When an active workspace has no title, `useReviewReadyNotifications` falls back to a hard-coded product name for the browser `<title>`. That fallback was still `"cline"` — a leftover from the Cline → Kanban product rename — which makes the tab read `cline` on first paint and any time the active workspace has no title.

## Diff

```diff
-	const baseTitle = workspaceTitle || "cline";
+	const baseTitle = workspaceTitle || "Kanban";
```

One line in `web-ui/src/hooks/use-review-ready-notifications.ts`.

## Not a regression of Cline agent naming

The `"cline"` **agent id** (used in `selectedAgentId`, `CLINE_PROVIDER_ID`, `cline-agent-chat-panel.tsx`, `cline-model-picker-options.ts`, etc.) stays exactly the same. Cline-the-agent and Kanban-the-product are distinct concepts; only the user-visible product name in the browser tab is touched.

## Why a standalone PR

Surfaced while reviewing the Electron desktop PR stack — one of the stacked branches had included this fix as part of its changes, but it's a pre-existing main-branch bug unrelated to desktop, so it belongs here as its own tiny PR instead of bundled into desktop scope.

## Verification

- `web-ui` typecheck ✅
- Manual: `npm run dev:full`, check tab title renders `Kanban` when no workspace is selected.
