### PR TITLE
fix(build): opt-in runtime-dep staging into dist/node_modules/

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,18 @@
 import * as esbuild from "esbuild";
+import { execSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 
-/** Modules that must stay external (native addons, large runtime deps). */
+/**
+ * Modules that must stay external (native addons, large runtime deps that
+ * don't bundle cleanly, or deps using dynamic require patterns).
+ *
+ * These are resolved at runtime via Node's node_modules lookup. For most
+ * contexts (`npm i -g kanban`, monorepo dev) the enclosing node_modules/
+ * satisfies resolution. For contexts that don't have one — notably the
+ * Electron desktop app at `Resources/cli/` — this script can also stage the
+ * externals into `dist/node_modules/` to produce a self-contained deployable
+ * (opt-in via --stage, see the section at the bottom of this file).
+ */
 const external = [
 	"node-pty",
 	"@sentry/node",
@@ -66,3 +78,74 @@ await Promise.all([
 ]);
 
 console.log("esbuild: bundled dist/cli.js and dist/index.js");
+
+// ---------------------------------------------------------------------------
+// Optional: stage external runtime deps into dist/node_modules/
+// ---------------------------------------------------------------------------
+//
+// cli.js has literal `import "zod"` / `require("ws")` statements for every
+// name in `external`. Node resolves those via node_modules lookup starting
+// from cli.js's location. In two contexts resolution is already handled:
+//
+//   1. `npm i -g kanban` — npm installs the package's production deps into
+//      lib/node_modules/kanban/node_modules/, which satisfies resolution for
+//      dist/cli.js one level up.
+//   2. Monorepo dev (`npm run dev`) — root node_modules/ satisfies it.
+//
+// A third context, the Electron desktop app, ships `dist/` to a location
+// (`Resources/cli/`) with no enclosing node_modules/. For that case this
+// script can ALSO install the externals into `dist/node_modules/` to produce
+// a self-contained deployable — opt in with --stage or KANBAN_STAGE_RUNTIME_DEPS=1.
+//
+// Staging is off by default because it pulls ~127 MB of transitive deps and
+// would bloat every published npm tarball (the default `"files": ["dist"]`
+// in package.json includes nested node_modules).
+
+const stageRuntimeDeps =
+	process.argv.includes("--stage") ||
+	process.env.KANBAN_STAGE_RUNTIME_DEPS === "1";
+
+if (!stageRuntimeDeps) {
+	console.log(
+		"skipping dist/node_modules staging (pass --stage or set KANBAN_STAGE_RUNTIME_DEPS=1 to enable)",
+	);
+	process.exit(0);
+}
+
+const rootPkg = JSON.parse(readFileSync("package.json", "utf-8"));
+const rootDeps = { ...rootPkg.dependencies, ...rootPkg.devDependencies };
+const runtimeDeps = Object.fromEntries(
+	external
+		.map((name) => [name, rootDeps[name]])
+		.filter(([, v]) => typeof v === "string"),
+);
+
+const missing = external.filter((name) => !(name in runtimeDeps));
+if (missing.length > 0) {
+	throw new Error(
+		`build.mjs: externals missing from root package.json: ${missing.join(", ")}`,
+	);
+}
+
+mkdirSync("dist", { recursive: true });
+writeFileSync(
+	"dist/package.json",
+	`${JSON.stringify(
+		{
+			name: "kanban-cli-runtime-deps",
+			version: "0.0.0",
+			private: true,
+			type: "module",
+			dependencies: runtimeDeps,
+		},
+		null,
+		2,
+	)}\n`,
+);
+
+console.log("staging runtime deps into dist/node_modules/ ...");
+execSync("npm install --omit=dev --no-audit --no-fund --ignore-scripts", {
+	cwd: "dist",
+	stdio: "inherit",
+});
+console.log(`staged ${Object.keys(runtimeDeps).length} runtime deps`);


### PR DESCRIPTION
## Summary

Single-commit, single-concern: makes \`scripts/build.mjs\` able to stage the CLI's esbuild-external runtime deps into \`dist/node_modules/\` for contexts that don't have an enclosing \`node_modules/\` at runtime. **Opt-in** via \`KANBAN_STAGE_RUNTIME_DEPS=1\` or \`--stage\` — default build behavior is unchanged.

This is a prerequisite for the Electron desktop packaging work (stacked PRs to follow), but it's its own build-infra change and worth reviewing on its own.

## Why

\`dist/cli.js\` has literal \`import \"zod\"\` / \`require(\"ws\")\` for 11 externals (\`zod\`, \`commander\`, \`@trpc/client\`, \`@trpc/server\`, \`@sentry/node\`, \`@modelcontextprotocol/sdk\`, \`ws\`, \`open\`, \`proper-lockfile\`, \`tree-kill\`, \`node-pty\`). Node resolves these via \`node_modules\` lookup at runtime.

This works in two existing contexts:
1. **\`npm i -g kanban\`** — npm installs the package's prod deps at \`lib/node_modules/kanban/node_modules/\`; Node's resolver walks up from \`dist/cli.js\` and finds them.
2. **Monorepo dev** — root \`node_modules/\` satisfies resolution.

It fails in a third: a packaged Electron app at \`Resources/cli/cli.js\` has no enclosing \`node_modules/\` → \`ERR_MODULE_NOT_FOUND\` at runtime.

## What

When opt-in:
1. Synthesize a minimal \`dist/package.json\` listing exactly the \`external\` deps with versions copied from root \`package.json\`.
2. \`npm install --omit=dev --no-audit --no-fund --ignore-scripts\` inside \`dist/\`. Staged tree ends up at \`dist/node_modules/\`.

**Guard**: if any name in \`external\` is missing from root \`package.json\`, the script throws. Keeps the two lists coupled-but-enforced.

## Why opt-in, not default

The staged tree is ~127 MB of transitive deps. Root package.json's \`\"files\": [\"dist\"]\` would drag that into every published npm tarball (tarball ~3 MB → 30 MB, unpacked 13 MB → 154 MB, 10,542 files). And \`npm i -g kanban\` users would then have 127 MB of duplicated deps on disk: once at \`lib/node_modules/kanban/dist/node_modules/\`, once at \`lib/node_modules/kanban/node_modules/\` from npm's own install step.

Making it opt-in keeps the publish path slim and lets packaging workflows opt in when they need a self-contained \`dist/\`.

## Verification

\`\`\`
# Default build — unchanged from before this PR
node scripts/build.mjs
# → \"skipping dist/node_modules staging (pass --stage or set KANBAN_STAGE_RUNTIME_DEPS=1 to enable)\"
# → dist/ ≈ 47 MB (no node_modules)

# Opt-in
KANBAN_STAGE_RUNTIME_DEPS=1 node scripts/build.mjs
# → \"staged 11 runtime deps\"
# → dist/ ≈ 174 MB (127 MB node_modules)

# also works:
node scripts/build.mjs --stage
\`\`\`