### PR TITLE
fix(web-ui): keep Add Project button mounted during project switch

### DIFF
--- a/web-ui/src/components/project-navigation-panel.test.tsx
+++ b/web-ui/src/components/project-navigation-panel.test.tsx
@@ -211,6 +211,16 @@ describe("ProjectNavigationPanel width persistence", () => {
 		expect(container.textContent).not.toContain("Report issue");
 	});
 
+	it("keeps the Add Project button rendered while the project list reloads after a switch", () => {
+		renderPanel({ isLoadingProjects: true });
+		expect(() => getButtonByText(container, "Add Project")).not.toThrow();
+	});
+
+	it("hides the Add Project button on initial load while projects are still being fetched", () => {
+		renderPanel({ projects: [], currentProjectId: null, isLoadingProjects: true });
+		expect(Array.from(container.querySelectorAll("button")).some((b) => b.textContent === "Add Project")).toBe(false);
+	});
+
 	it("persists terminal tips dismissal", () => {
 		renderPanel({
 			activeSection: "agent",

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -381,7 +381,7 @@ export function ProjectNavigationPanel({
 							/>
 						))}
 
-						{!isLoadingProjects ? (
+						{sortedProjects.length === 0 && isLoadingProjects ? null : (
 							<button
 								type="button"
 								className="kb-project-row flex cursor-pointer items-center gap-1.5 rounded-md text-text-secondary hover:text-text-primary"
@@ -392,7 +392,7 @@ export function ProjectNavigationPanel({
 								<Plus size={14} className="shrink-0" />
 								<span className="text-sm">Add Project</span>
 							</button>
-						) : null}
+						)}
 					</div>
 					<ShortcutsCard />
 					<ProjectSupportFooter


### PR DESCRIPTION
## Summary

Fixes #343.

The **Add Project** button briefly unmounted and re-mounted every time the user switched projects, producing a visible flicker alongside the swimlane refresh.

## Root cause

`ProjectNavigationPanel` gates the Add Project button on `!isLoadingProjects`. That prop is driven by `isProjectListLoading = !hasReceivedSnapshot && !streamError` from `use-project-ui-state.ts`. When the user switches projects, the `requested_workspace_changed` action in `use-runtime-state-stream.ts` resets `hasReceivedSnapshot` to `false`:

```ts
// web-ui/src/runtime/use-runtime-state-stream.ts
if (action.type === "requested_workspace_changed") {
    return {
        ...state,
        // ...
        hasReceivedSnapshot: false,
    };
}
```

That flip is brief — the next snapshot arrives almost immediately — but long enough to unmount the button and remount it, causing the flicker.

## Fix

The existing gate `!isLoadingProjects` conflated "initial load (no projects yet)" with "project switch (projects already populated)". The skeleton placeholders above already cover the initial-load case (`sortedProjects.length === 0 && isLoadingProjects`), so the button only needs to be hidden in that specific state. The gate now mirrors the skeleton condition:

```tsx
{sortedProjects.length === 0 && isLoadingProjects ? null : (
    <button ...>Add Project</button>
)}
```

During a project switch `sortedProjects.length > 0` (the project list is preserved across the switch), so the button stays mounted — no flicker. During the genuine initial load it still hides behind the skeletons as before.

## Tests

Two regression tests added to `project-navigation-panel.test.tsx`:

- `keeps the Add Project button rendered while the project list reloads after a switch` — asserts the button is present when `isLoadingProjects=true` and projects are populated.
- `hides the Add Project button on initial load while projects are still being fetched` — asserts the original behavior still holds when there are no projects yet.

Full web-ui test suite: **491 passed**.