### PR TITLE
fix: avoid blocking Windows Add Project directory picker

### DIFF
--- a/src/server/directory-picker.ts
+++ b/src/server/directory-picker.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { terminateProcessForTimeout } from "./process-termination";
 
 interface DirectoryPickerCommandCandidate {
 	command: string;
@@ -23,8 +24,12 @@ type RunCommand = (command: string, args: string[]) => Promise<DirectoryPickerCo
 interface PickDirectoryPathFromSystemDialogOptions {
 	platform?: NodeJS.Platform;
 	cwd?: string;
+	timeoutMs?: number;
 	runCommand?: RunCommand;
 }
+
+const DEFAULT_DIRECTORY_PICKER_TIMEOUT_MS = 5 * 60 * 1000;
+const DIRECTORY_PICKER_CLOSE_GRACE_MS = 1_000;
 
 const WINDOWS_DIRECTORY_PICKER_SCRIPT = [
 	"$ErrorActionPreference = 'Stop'",
@@ -60,7 +65,20 @@ function parseChildProcessErrorCode(error: unknown): string | null {
 	return typeof code === "string" ? code : null;
 }
 
-async function defaultRunCommand(command: string, args: string[]): Promise<DirectoryPickerCommandExecutionResult> {
+function createDirectoryPickerTimeoutError(timeoutMs: number): NodeJS.ErrnoException {
+	return Object.assign(new Error(`Directory picker timed out after ${timeoutMs}ms.`), {
+		code: "ETIMEDOUT",
+	}) as NodeJS.ErrnoException;
+}
+
+async function defaultRunCommand(
+	command: string,
+	args: string[],
+	options: {
+		platform: NodeJS.Platform;
+		timeoutMs: number;
+	},
+): Promise<DirectoryPickerCommandExecutionResult> {
 	return await new Promise((resolve) => {
 		const child = spawn(command, args, {
 			stdio: ["ignore", "pipe", "pipe"],
@@ -69,12 +87,38 @@ async function defaultRunCommand(command: string, args: string[]): Promise<Direc
 		let stdout = "";
 		let stderr = "";
 		let settled = false;
+		let pendingError: NodeJS.ErrnoException | undefined;
+		let closeGraceHandle: NodeJS.Timeout | null = null;
+		const timeoutHandle =
+			options.timeoutMs > 0
+				? setTimeout(() => {
+						pendingError ??= createDirectoryPickerTimeoutError(options.timeoutMs);
+						terminateProcessForTimeout(child, {
+							platform: options.platform,
+						});
+						closeGraceHandle = setTimeout(() => {
+							finish({
+								stdout,
+								stderr,
+								status: null,
+								signal: null,
+								error: pendingError,
+							});
+						}, DIRECTORY_PICKER_CLOSE_GRACE_MS);
+					}, options.timeoutMs)
+				: null;
 
 		const finish = (result: DirectoryPickerCommandExecutionResult): void => {
 			if (settled) {
 				return;
 			}
 			settled = true;
+			if (timeoutHandle) {
+				clearTimeout(timeoutHandle);
+			}
+			if (closeGraceHandle) {
+				clearTimeout(closeGraceHandle);
+			}
 			resolve(result);
 		};
 
@@ -89,13 +133,7 @@ async function defaultRunCommand(command: string, args: string[]): Promise<Direc
 		});
 
 		child.once("error", (error) => {
-			finish({
-				stdout,
-				stderr,
-				status: null,
-				signal: null,
-				error: error as NodeJS.ErrnoException,
-			});
+			pendingError ??= error as NodeJS.ErrnoException;
 		});
 
 		child.once("close", (status, signal) => {
@@ -104,6 +142,7 @@ async function defaultRunCommand(command: string, args: string[]): Promise<Direc
 				stderr,
 				status,
 				signal,
+				error: pendingError,
 			});
 		});
 	});
@@ -154,7 +193,14 @@ export async function pickDirectoryPathFromSystemDialog(
 ): Promise<string | null> {
 	const platform = options.platform ?? process.platform;
 	const cwd = options.cwd ?? process.cwd();
-	const runCommand = options.runCommand ?? defaultRunCommand;
+	const timeoutMs = options.timeoutMs ?? DEFAULT_DIRECTORY_PICKER_TIMEOUT_MS;
+	const runCommand =
+		options.runCommand ??
+		((command: string, args: string[]) =>
+			defaultRunCommand(command, args, {
+				platform,
+				timeoutMs,
+			}));
 
 	if (platform === "darwin") {
 		const result = await runDirectoryPickerCommand(

--- a/src/server/directory-picker.ts
+++ b/src/server/directory-picker.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 
 interface DirectoryPickerCommandCandidate {
 	command: string;
@@ -10,7 +10,15 @@ type DirectoryPickerCommandResult =
 	| { kind: "cancelled" }
 	| { kind: "unavailable" };
 
-type RunCommand = (command: string, args: string[]) => ReturnType<typeof spawnSync>;
+interface DirectoryPickerCommandExecutionResult {
+	stdout: string;
+	stderr: string;
+	status: number | null;
+	signal: NodeJS.Signals | null;
+	error?: NodeJS.ErrnoException;
+}
+
+type RunCommand = (command: string, args: string[]) => Promise<DirectoryPickerCommandExecutionResult>;
 
 interface PickDirectoryPathFromSystemDialogOptions {
 	platform?: NodeJS.Platform;
@@ -21,10 +29,27 @@ interface PickDirectoryPathFromSystemDialogOptions {
 const WINDOWS_DIRECTORY_PICKER_SCRIPT = [
 	"$ErrorActionPreference = 'Stop'",
 	"Add-Type -AssemblyName System.Windows.Forms",
+	"Add-Type -AssemblyName System.Drawing",
+	"[System.Windows.Forms.Application]::EnableVisualStyles()",
+	"$owner = $null",
+	"try {",
+	"$owner = New-Object System.Windows.Forms.Form",
+	"$owner.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen",
+	"$owner.Size = New-Object System.Drawing.Size(1, 1)",
+	"$owner.Opacity = 0",
+	"$owner.ShowInTaskbar = $false",
+	"$owner.TopMost = $true",
+	"$owner.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::FixedToolWindow",
+	"$owner.Show()",
+	"$owner.Activate()",
 	"$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
 	"$dialog.Description = 'Select a project folder'",
 	"$dialog.ShowNewFolderButton = $false",
-	"if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($dialog.SelectedPath) }",
+	"$dialogResult = $dialog.ShowDialog($owner)",
+	"if ($dialogResult -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($dialog.SelectedPath) }",
+	"} finally {",
+	"if ($owner -ne $null) { $owner.Close(); $owner.Dispose() }",
+	"}",
 ].join("; ");
 
 function parseChildProcessErrorCode(error: unknown): string | null {
@@ -35,18 +60,60 @@ function parseChildProcessErrorCode(error: unknown): string | null {
 	return typeof code === "string" ? code : null;
 }
 
-function defaultRunCommand(command: string, args: string[]): ReturnType<typeof spawnSync> {
-	return spawnSync(command, args, {
-		encoding: "utf8",
-		stdio: ["ignore", "pipe", "pipe"],
+async function defaultRunCommand(command: string, args: string[]): Promise<DirectoryPickerCommandExecutionResult> {
+	return await new Promise((resolve) => {
+		const child = spawn(command, args, {
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: false,
+		});
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+
+		const finish = (result: DirectoryPickerCommandExecutionResult): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			resolve(result);
+		};
+
+		child.stdout?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+
+		child.stderr?.setEncoding("utf8");
+		child.stderr?.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+
+		child.once("error", (error) => {
+			finish({
+				stdout,
+				stderr,
+				status: null,
+				signal: null,
+				error: error as NodeJS.ErrnoException,
+			});
+		});
+
+		child.once("close", (status, signal) => {
+			finish({
+				stdout,
+				stderr,
+				status,
+				signal,
+			});
+		});
 	});
 }
 
-function runDirectoryPickerCommand(
+async function runDirectoryPickerCommand(
 	candidate: DirectoryPickerCommandCandidate,
 	runCommand: RunCommand,
-): DirectoryPickerCommandResult {
-	const result = runCommand(candidate.command, candidate.args);
+): Promise<DirectoryPickerCommandResult> {
+	const result = await runCommand(candidate.command, candidate.args);
 
 	const errorCode = parseChildProcessErrorCode(result.error);
 	if (errorCode === "ENOENT") {
@@ -82,15 +149,15 @@ function runDirectoryPickerCommand(
 	return { kind: "selected", path: selectedPath };
 }
 
-export function pickDirectoryPathFromSystemDialog(
+export async function pickDirectoryPathFromSystemDialog(
 	options: PickDirectoryPathFromSystemDialogOptions = {},
-): string | null {
+): Promise<string | null> {
 	const platform = options.platform ?? process.platform;
 	const cwd = options.cwd ?? process.cwd();
 	const runCommand = options.runCommand ?? defaultRunCommand;
 
 	if (platform === "darwin") {
-		const result = runDirectoryPickerCommand(
+		const result = await runDirectoryPickerCommand(
 			{
 				command: "osascript",
 				args: ["-e", 'POSIX path of (choose folder with prompt "Select a project folder")'],
@@ -119,7 +186,7 @@ export function pickDirectoryPathFromSystemDialog(
 		];
 
 		for (const candidate of candidates) {
-			const result = runDirectoryPickerCommand(candidate, runCommand);
+			const result = await runDirectoryPickerCommand(candidate, runCommand);
 			if (result.kind === "unavailable") {
 				continue;
 			}
@@ -145,7 +212,7 @@ export function pickDirectoryPathFromSystemDialog(
 		];
 
 		for (const candidate of candidates) {
-			const result = runDirectoryPickerCommand(candidate, runCommand);
+			const result = await runDirectoryPickerCommand(candidate, runCommand);
 			if (result.kind === "unavailable") {
 				continue;
 			}

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -65,7 +65,7 @@ export interface CreateRuntimeServerDependencies {
 		},
 	) => DisposeTrackedWorkspaceResult;
 	collectProjectWorktreeTaskIdsForRemoval: (board: RuntimeWorkspaceStateResponse["board"]) => Set<string>;
-	pickDirectoryPathFromSystemDialog: () => string | null;
+	pickDirectoryPathFromSystemDialog: () => Promise<string | null>;
 }
 
 export interface RuntimeServer {

--- a/src/trpc/projects-api.ts
+++ b/src/trpc/projects-api.ts
@@ -54,7 +54,7 @@ export interface CreateProjectsApiDependencies {
 		currentProjectId: string | null;
 		projects: RuntimeProjectSummary[];
 	}>;
-	pickDirectoryPathFromSystemDialog: () => string | null;
+	pickDirectoryPathFromSystemDialog: () => Promise<string | null>;
 	serverCwd: string;
 }
 
@@ -235,7 +235,7 @@ export function createProjectsApi(deps: CreateProjectsApiDependencies): RuntimeT
 		},
 		pickProjectDirectory: async () => {
 			try {
-				const selectedPath = deps.pickDirectoryPathFromSystemDialog();
+				const selectedPath = await deps.pickDirectoryPathFromSystemDialog();
 				if (!selectedPath) {
 					return {
 						ok: false,

--- a/test/runtime/directory-picker.test.ts
+++ b/test/runtime/directory-picker.test.ts
@@ -1,5 +1,3 @@
-import type { spawnSync } from "node:child_process";
-
 import { describe, expect, it } from "vitest";
 
 import { pickDirectoryPathFromSystemDialog } from "../../src/server/directory-picker";
@@ -9,10 +7,16 @@ interface RecordedCommand {
 	args: string[];
 }
 
-function createSpawnResult(overrides: Partial<ReturnType<typeof spawnSync>> = {}): ReturnType<typeof spawnSync> {
+interface MockRunCommandResult {
+	stdout: string;
+	stderr: string;
+	status: number | null;
+	signal: NodeJS.Signals | null;
+	error?: NodeJS.ErrnoException;
+}
+
+function createSpawnResult(overrides: Partial<MockRunCommandResult> = {}): MockRunCommandResult {
 	return {
-		pid: 1,
-		output: [null, "", ""],
 		stdout: "",
 		stderr: "",
 		status: 0,
@@ -23,10 +27,10 @@ function createSpawnResult(overrides: Partial<ReturnType<typeof spawnSync>> = {}
 }
 
 function createRunCommand(
-	responses: Record<string, ReturnType<typeof spawnSync>>,
+	responses: Record<string, MockRunCommandResult>,
 	commands: RecordedCommand[],
-): (command: string, args: string[]) => ReturnType<typeof spawnSync> {
-	return (command: string, args: string[]) => {
+): (command: string, args: string[]) => Promise<MockRunCommandResult> {
+	return async (command: string, args: string[]) => {
 		commands.push({ command, args });
 		const response = responses[command];
 		if (!response) {
@@ -37,9 +41,9 @@ function createRunCommand(
 }
 
 describe("pickDirectoryPathFromSystemDialog", () => {
-	it("falls back to kdialog when zenity is unavailable on linux", () => {
+	it("falls back to kdialog when zenity is unavailable on linux", async () => {
 		const commands: RecordedCommand[] = [];
-		const selectedPath = pickDirectoryPathFromSystemDialog({
+		const selectedPath = await pickDirectoryPathFromSystemDialog({
 			platform: "linux",
 			cwd: "/tmp",
 			runCommand: createRunCommand(
@@ -71,9 +75,9 @@ describe("pickDirectoryPathFromSystemDialog", () => {
 		]);
 	});
 
-	it("returns null when the picker is cancelled", () => {
+	it("returns null when the picker is cancelled", async () => {
 		const commands: RecordedCommand[] = [];
-		const selectedPath = pickDirectoryPathFromSystemDialog({
+		const selectedPath = await pickDirectoryPathFromSystemDialog({
 			platform: "linux",
 			runCommand: createRunCommand(
 				{
@@ -94,9 +98,9 @@ describe("pickDirectoryPathFromSystemDialog", () => {
 		]);
 	});
 
-	it("throws a clear error when no linux picker commands are installed", () => {
+	it("throws a clear error when no linux picker commands are installed", async () => {
 		const commands: RecordedCommand[] = [];
-		expect(() =>
+		await expect(() =>
 			pickDirectoryPathFromSystemDialog({
 				platform: "linux",
 				runCommand: createRunCommand(
@@ -117,11 +121,11 @@ describe("pickDirectoryPathFromSystemDialog", () => {
 					commands,
 				),
 			}),
-		).toThrow('Could not open directory picker. Install "zenity" or "kdialog" and try again.');
+		).rejects.toThrow('Could not open directory picker. Install "zenity" or "kdialog" and try again.');
 	});
 
-	it("throws command stderr when picker fails for a real error", () => {
-		expect(() =>
+	it("throws command stderr when picker fails for a real error", async () => {
+		await expect(() =>
 			pickDirectoryPathFromSystemDialog({
 				platform: "linux",
 				runCommand: createRunCommand(
@@ -134,13 +138,13 @@ describe("pickDirectoryPathFromSystemDialog", () => {
 					[],
 				),
 			}),
-		).toThrow("Could not open directory picker via zenity: Gtk warning");
+		).rejects.toThrow("Could not open directory picker via zenity: Gtk warning");
 	});
 });
 
-it("uses powershell on windows when available", () => {
+it("uses powershell on windows when available", async () => {
 	const commands: RecordedCommand[] = [];
-	const selectedPath = pickDirectoryPathFromSystemDialog({
+	const selectedPath = await pickDirectoryPathFromSystemDialog({
 		platform: "win32",
 		runCommand: createRunCommand(
 			{
@@ -158,9 +162,9 @@ it("uses powershell on windows when available", () => {
 	expect(commands[0]?.args.slice(0, 3)).toEqual(["-NoProfile", "-STA", "-Command"]);
 });
 
-it("falls back to pwsh when powershell is unavailable on windows", () => {
+it("falls back to pwsh when powershell is unavailable on windows", async () => {
 	const commands: RecordedCommand[] = [];
-	const selectedPath = pickDirectoryPathFromSystemDialog({
+	const selectedPath = await pickDirectoryPathFromSystemDialog({
 		platform: "win32",
 		runCommand: createRunCommand(
 			{
@@ -182,8 +186,8 @@ it("falls back to pwsh when powershell is unavailable on windows", () => {
 	expect(commands.map((entry) => entry.command)).toEqual(["powershell", "pwsh"]);
 });
 
-it("returns null when windows picker is cancelled", () => {
-	const selectedPath = pickDirectoryPathFromSystemDialog({
+it("returns null when windows picker is cancelled", async () => {
+	const selectedPath = await pickDirectoryPathFromSystemDialog({
 		platform: "win32",
 		runCommand: createRunCommand(
 			{
@@ -198,8 +202,8 @@ it("returns null when windows picker is cancelled", () => {
 	expect(selectedPath).toBeNull();
 });
 
-it("throws a clear error when no windows picker commands are installed", () => {
-	expect(() =>
+it("throws a clear error when no windows picker commands are installed", async () => {
+	await expect(() =>
 		pickDirectoryPathFromSystemDialog({
 			platform: "win32",
 			runCommand: createRunCommand(
@@ -220,5 +224,5 @@ it("throws a clear error when no windows picker commands are installed", () => {
 				[],
 			),
 		}),
-	).toThrow('Could not open directory picker. Install PowerShell ("powershell" or "pwsh") and try again.');
+	).rejects.toThrow('Could not open directory picker. Install PowerShell ("powershell" or "pwsh") and try again.');
 });

--- a/test/runtime/directory-picker.test.ts
+++ b/test/runtime/directory-picker.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
 
 import { pickDirectoryPathFromSystemDialog } from "../../src/server/directory-picker";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+	spawn: spawnMock,
+}));
 
 interface RecordedCommand {
 	command: string;
@@ -38,6 +45,33 @@ function createRunCommand(
 		}
 		return response;
 	};
+}
+
+interface MockChildStream extends EventEmitter {
+	setEncoding: (encoding: string) => void;
+}
+
+interface MockChildProcess extends EventEmitter {
+	stdout: MockChildStream;
+	stderr: MockChildStream;
+	kill: ReturnType<typeof vi.fn>;
+	pid?: number;
+}
+
+function createMockChild(
+	schedule: (input: { child: MockChildProcess; stdout: MockChildStream; stderr: MockChildStream }) => void,
+): MockChildProcess {
+	const stdout = new EventEmitter() as MockChildStream;
+	stdout.setEncoding = () => {};
+	const stderr = new EventEmitter() as MockChildStream;
+	stderr.setEncoding = () => {};
+	const child = new EventEmitter() as MockChildProcess;
+	child.stdout = stdout;
+	child.stderr = stderr;
+	child.kill = vi.fn(() => true);
+	child.pid = 123;
+	schedule({ child, stdout, stderr });
+	return child;
 }
 
 describe("pickDirectoryPathFromSystemDialog", () => {
@@ -139,6 +173,101 @@ describe("pickDirectoryPathFromSystemDialog", () => {
 				),
 			}),
 		).rejects.toThrow("Could not open directory picker via zenity: Gtk warning");
+	});
+
+	it("waits for close before advancing after an error event", async () => {
+		spawnMock.mockReset();
+		spawnMock
+			.mockImplementationOnce(() =>
+				createMockChild(({ child }) => {
+					queueMicrotask(() => {
+						child.emit(
+							"error",
+							Object.assign(new Error("command not found"), { code: "ENOENT" }) as NodeJS.ErrnoException,
+						);
+					});
+					setTimeout(() => {
+						child.emit("close", null, null);
+					}, 0);
+				}),
+			)
+			.mockImplementationOnce(() =>
+				createMockChild(({ child, stdout }) => {
+					queueMicrotask(() => {
+						stdout.emit("data", "/tmp/from-kdialog\n");
+						child.emit("close", 0, null);
+					});
+				}),
+			);
+
+		const pickerPromise = pickDirectoryPathFromSystemDialog({
+			platform: "linux",
+			cwd: "/tmp",
+		});
+
+		await Promise.resolve();
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+
+		await expect(pickerPromise).resolves.toBe("/tmp/from-kdialog");
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("times out a hung picker process and kills it", async () => {
+		vi.useFakeTimers();
+		try {
+			spawnMock.mockReset();
+			const child = createMockChild(() => {});
+			spawnMock.mockReturnValue(child);
+
+			const pickerPromise = pickDirectoryPathFromSystemDialog({
+				platform: "linux",
+				timeoutMs: 100,
+			});
+			const rejection = expect(pickerPromise).rejects.toThrow(
+				"Could not open directory picker via zenity: Directory picker timed out after 100ms.",
+			);
+
+			await vi.advanceTimersByTimeAsync(100);
+
+			expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+			expect(spawnMock).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(1_000);
+			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("uses close to finish promptly after timing out when kill succeeds", async () => {
+		vi.useFakeTimers();
+		try {
+			spawnMock.mockReset();
+			const child = createMockChild(({ child }) => {
+				child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+					queueMicrotask(() => {
+						child.emit("close", null, typeof signal === "string" ? signal : null);
+					});
+					return true;
+				});
+			});
+			spawnMock.mockReturnValue(child);
+
+			const pickerPromise = pickDirectoryPathFromSystemDialog({
+				platform: "linux",
+				timeoutMs: 100,
+			});
+			const rejection = expect(pickerPromise).rejects.toThrow(
+				"Could not open directory picker via zenity: Directory picker timed out after 100ms.",
+			);
+
+			await vi.advanceTimersByTimeAsync(100);
+
+			await rejection;
+			expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/test/runtime/trpc/projects-api.test.ts
+++ b/test/runtime/trpc/projects-api.test.ts
@@ -46,7 +46,7 @@ function createDefaultDeps(serverCwd: string): CreateProjectsApiDependencies {
 		collectProjectWorktreeTaskIdsForRemoval: vi.fn(() => new Set<string>()),
 		warn: vi.fn(),
 		buildProjectsPayload: vi.fn(async () => ({ currentProjectId: null, projects: [] })),
-		pickDirectoryPathFromSystemDialog: vi.fn(() => null),
+		pickDirectoryPathFromSystemDialog: vi.fn(async () => null),
 		serverCwd,
 	};
 }


### PR DESCRIPTION
Summary
Fixes a Windows-specific hang when clicking Add Project
Keeps the native folder picker flow, including cross-drive selection support
Prevents the runtime from blocking while the native picker is open
Root Cause
The Windows picker path used a synchronous PowerShell invocation around FolderBrowserDialog.ShowDialog()
In some environments the dialog did not reliably surface to the foreground, while the synchronous call blocked
the Kanban runtime thread
Result: the UI looked frozen and no follow-up logging/error surfaced
Changes
Convert the Windows directory picker launcher from synchronous spawnSync to async spawn
Add an explicit invisible topmost owner form before calling FolderBrowserDialog.ShowDialog(owner)
Update the runtime/projects API wiring to await the async picker
Update runtime tests for the async picker contract
Files
src/server/directory-picker.ts
src/server/runtime-server.ts
src/trpc/projects-api.ts
test/runtime/directory-picker.test.ts
test/runtime/trpc/projects-api.test.ts
Validation
npm run typecheck
npx vitest run test/runtime/directory-picker.test.ts test/runtime/trpc/projects-api.test.ts
npm run build
