### PR TITLE
[4/5] feat(desktop): Electron main process — windows, deep links, runtime orchestrator

### DIFF
--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -12,8 +12,33 @@
 			},
 			"devDependencies": {
 				"@types/node": "^22.10.5",
+				"electron": "^33.4.0",
+				"esbuild": "^0.27.0",
+				"shx": "^0.4.0",
 				"typescript": "^5.9.3",
 				"vitest": "^4.1.0"
+			}
+		},
+		"node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -50,6 +75,448 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"dev": true,
@@ -72,6 +539,44 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -342,10 +847,36 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -356,6 +887,19 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -377,12 +921,50 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "22.19.17",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -492,6 +1074,67 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"dev": true,
@@ -500,10 +1143,145 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"engines": {
+				"node": ">=4.8"
+			}
+		},
+		"node_modules/cross-spawn/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
@@ -513,10 +1291,152 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/electron": {
+			"version": "33.4.11",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+			"integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^20.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
+		"node_modules/electron/node_modules/@types/node": {
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
@@ -526,12 +1446,130 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
 			}
 		},
 		"node_modules/fsevents": {
@@ -544,6 +1582,302 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
+		"node_modules/global-agent/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/interpret": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -803,6 +2137,16 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"dev": true,
@@ -810,6 +2154,71 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -828,6 +2237,13 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/node-addon-api": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -844,6 +2260,43 @@
 				"node-addon-api": "^7.1.0"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"dev": true,
@@ -853,8 +2306,62 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -862,6 +2369,19 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
 		"node_modules/postcss": {
 			"version": "8.5.10",
@@ -888,6 +2408,145 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+			"dev": true,
+			"dependencies": {
+				"resolve": "^1.1.6"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
 		"node_modules/rolldown": {
@@ -922,8 +2581,133 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
 			}
 		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shelljs": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+			"integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"execa": "^1.0.0",
+				"fast-glob": "^3.3.2",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			},
+			"bin": {
+				"shjs": "bin/shjs"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/shx": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+			"integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.8",
+				"shelljs": "^0.9.2"
+			},
+			"bin": {
+				"shx": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -935,6 +2719,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"dev": true,
@@ -944,6 +2736,42 @@
 			"version": "4.1.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sumchecker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -1008,6 +2836,19 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1015,6 +2856,20 @@
 			"dev": true,
 			"license": "0BSD",
 			"optional": true
+		},
+		"node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
@@ -1032,6 +2887,16 @@
 			"version": "6.21.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/vite": {
 			"version": "8.0.8",
@@ -1219,6 +3084,19 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"dev": true,
@@ -1232,6 +3110,24 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		}
 	}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,12 +4,18 @@
 	"private": true,
 	"description": "Kanban desktop app — Electron shell for the Kanban runtime",
 	"type": "module",
+	"main": "dist/main.js",
 	"scripts": {
+		"clean": "shx rm -rf dist out",
 		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"build:ts": "tsc -p tsconfig.build.json && esbuild src/preload.ts --bundle --platform=node --format=cjs --external:electron --outfile=dist/preload.js && shx cp src/disconnected.html dist/disconnected.html",
 		"test": "vitest run --passWithNoTests"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.5",
+		"electron": "^33.4.0",
+		"esbuild": "^0.27.0",
+		"shx": "^0.4.0",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.0"
 	},

--- a/packages/desktop/src/app-menu.ts
+++ b/packages/desktop/src/app-menu.ts
@@ -1,0 +1,169 @@
+/**
+ * Application menu builder.
+ *
+ * The menu reflects runtime state (edit/navigation entries are greyed out
+ * until a URL is loaded) and the list of open windows (checkboxes focus
+ * back to each one). Rebuild on: window created/closed/focused, runtime
+ * URL change.
+ */
+
+import { Menu, app, shell } from "electron";
+
+import type { RuntimeOrchestrator } from "./runtime-orchestrator.js";
+import type { WindowRegistry } from "./window-registry.js";
+import { extractPersistablePath } from "./window-state.js";
+
+export interface AppMenuOptions {
+	registry: WindowRegistry;
+	orchestrator: RuntimeOrchestrator;
+	/**
+	 * Triggered by File → New Window. If there's a focused window with a
+	 * non-root pathname, it's passed in so the new window can open at the
+	 * same route.
+	 */
+	onNewWindow: (options: { initialPath: string | null }) => void;
+}
+
+export class AppMenu {
+	constructor(private readonly opts: AppMenuOptions) {}
+
+	rebuild(): void {
+		Menu.setApplicationMenu(Menu.buildFromTemplate(this.buildTemplate()));
+	}
+
+	private buildTemplate(): Electron.MenuItemConstructorOptions[] {
+		const isMac = process.platform === "darwin";
+		const ready = this.opts.orchestrator.getUrl() !== null;
+
+		const appMenu: Electron.MenuItemConstructorOptions = {
+			label: app.name,
+			submenu: [
+				{ role: "about" },
+				{ type: "separator" },
+				{ role: "services" },
+				{ type: "separator" },
+				{ role: "hide" },
+				{ role: "hideOthers" },
+				{ role: "unhide" },
+				{ type: "separator" },
+				{ role: "quit" },
+			],
+		};
+
+		const fileMenu: Electron.MenuItemConstructorOptions = {
+			label: "File",
+			submenu: [
+				{
+					label: "New Window",
+					accelerator: isMac ? "CmdOrCtrl+Shift+N" : "Ctrl+Shift+N",
+					click: () => this.handleNewWindow(),
+				},
+				{ type: "separator" },
+				isMac ? { role: "close" } : { role: "quit" },
+			],
+		};
+
+		const editMenu: Electron.MenuItemConstructorOptions = {
+			label: "Edit",
+			submenu: [
+				{ role: "undo", enabled: ready },
+				{ role: "redo", enabled: ready },
+				{ type: "separator" },
+				{ role: "cut", enabled: ready },
+				{ role: "copy", enabled: ready },
+				{ role: "paste", enabled: ready },
+				{ role: "selectAll", enabled: ready },
+			],
+		};
+
+		const viewMenu: Electron.MenuItemConstructorOptions = {
+			label: "View",
+			submenu: [
+				{ role: "reload", enabled: ready },
+				...(!app.isPackaged
+					? ([
+							{ role: "forceReload", enabled: ready },
+							{ role: "toggleDevTools" },
+						] as Electron.MenuItemConstructorOptions[])
+					: []),
+				{ type: "separator" },
+				{ role: "resetZoom", enabled: ready },
+				{ role: "zoomIn", enabled: ready },
+				{ role: "zoomOut", enabled: ready },
+				{ type: "separator" },
+				{ role: "togglefullscreen" },
+			],
+		};
+
+		const helpMenu: Electron.MenuItemConstructorOptions = {
+			label: "Help",
+			submenu: [
+				{
+					label: "Kanban Documentation",
+					click: () => shell.openExternal("https://github.com/cline/kanban"),
+				},
+				{
+					label: "Report Issue",
+					click: () =>
+						shell.openExternal("https://github.com/cline/kanban/issues"),
+				},
+			],
+		};
+
+		const template: Electron.MenuItemConstructorOptions[] = [];
+		if (isMac) template.push(appMenu);
+		template.push(fileMenu, editMenu, viewMenu, this.buildWindowMenu(isMac), helpMenu);
+		return template;
+	}
+
+	private buildWindowMenu(isMac: boolean): Electron.MenuItemConstructorOptions {
+		const windowEntries = this.opts.registry.getVisible();
+		const focused = this.opts.registry.getFocused();
+		const windowListItems: Electron.MenuItemConstructorOptions[] =
+			windowEntries.map((entry) => {
+				const title = entry.window.isDestroyed()
+					? "Kanban"
+					: entry.window.getTitle() || "Kanban";
+				return {
+					label: title,
+					type: "checkbox" as const,
+					checked: focused?.id === entry.window.id,
+					click: () => {
+						if (!entry.window.isDestroyed()) {
+							if (entry.window.isMinimized()) entry.window.restore();
+							entry.window.focus();
+						}
+					},
+				};
+			});
+
+		return {
+			label: "Window",
+			submenu: [
+				{ role: "minimize" },
+				{ role: "zoom" },
+				...(windowListItems.length > 0
+					? [
+							{ type: "separator" } as Electron.MenuItemConstructorOptions,
+							...windowListItems,
+						]
+					: []),
+				...(isMac
+					? [
+							{ type: "separator" } as Electron.MenuItemConstructorOptions,
+							{ role: "front" } as Electron.MenuItemConstructorOptions,
+						]
+					: [{ role: "close" } as Electron.MenuItemConstructorOptions]),
+			],
+		};
+	}
+
+	private handleNewWindow(): void {
+		const focused = this.opts.registry.getFocused();
+		const currentUrl =
+			focused && !focused.isDestroyed()
+				? focused.webContents.getURL()
+				: null;
+		this.opts.onNewWindow({ initialPath: extractPersistablePath(currentUrl) });
+	}
+}

--- a/packages/desktop/src/disconnected.html
+++ b/packages/desktop/src/disconnected.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kanban — Runtime Disconnected</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #1F2428;
+    color: #E6EDF3;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    -webkit-app-region: drag;
+    user-select: none;
+  }
+  .container {
+    max-width: 520px;
+    padding: 40px;
+    text-align: center;
+  }
+  .icon {
+    font-size: 48px;
+    margin-bottom: 20px;
+    opacity: 0.6;
+  }
+  h1 {
+    font-size: 22px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: #E6EDF3;
+  }
+  .lead {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #8B949E;
+    margin-bottom: 28px;
+  }
+  .options {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    text-align: left;
+  }
+  .option {
+    background: #24292E;
+    border: 1px solid #30363D;
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-app-region: no-drag;
+  }
+  .option-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #E6EDF3;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .option-title .num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    background: #0084FF;
+    color: #fff;
+    border-radius: 50%;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .option-body {
+    font-size: 13px;
+    line-height: 1.55;
+    color: #8B949E;
+    margin-bottom: 12px;
+  }
+  button {
+    background: #0084FF;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 18px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+    -webkit-app-region: no-drag;
+    user-select: none;
+  }
+  button:hover { background: #339DFF; }
+  button:active { background: #006ACC; }
+  code {
+    background: #2D3339;
+    border: 1px solid #30363D;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-family: "SF Mono", "Fira Code", Menlo, monospace;
+    font-size: 12.5px;
+    color: #E6EDF3;
+    user-select: text;
+  }
+</style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">⚡</div>
+    <h1>Runtime Disconnected</h1>
+    <p class="lead">
+      The Kanban runtime process is no longer running.
+      Recover using either of these options:
+    </p>
+    <div class="options">
+      <div class="option">
+        <div class="option-title">
+          <span class="num">1</span>
+          Restart the runtime from the desktop app
+        </div>
+        <div class="option-body">
+          Spawn a new child runtime managed by this window.
+        </div>
+        <button id="restart-btn">Restart</button>
+      </div>
+      <div class="option">
+        <div class="option-title">
+          <span class="num">2</span>
+          Start the runtime from your terminal
+        </div>
+        <div class="option-body">
+          Run <code>kanban</code> in any terminal.
+          The desktop app will automatically attach to it.
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.getElementById("restart-btn").addEventListener("click", function () {
+      if (window.desktop && window.desktop.restartRuntime) {
+        window.desktop.restartRuntime();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -1,8 +1,0 @@
-/**
- * @kanban/desktop — Electron shell for the Kanban runtime.
- *
- * This package runs the Kanban CLI as a managed subprocess inside an Electron
- * window. The main-process entry point is `dist/main.js` (bundled in later
- * PRs); this file exists so the package has a well-defined "root" for tooling.
- */
-export {};

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,0 +1,288 @@
+/**
+ * Electron main process — composition root.
+ *
+ * All domain logic lives in the helper modules:
+ *   • {@link RuntimeOrchestrator} — runtime child lifecycle + health.
+ *   • {@link WindowFactory}        — window creation + renderer recovery.
+ *   • {@link AppMenu}              — application menu.
+ *   • {@link WindowRegistry}       — window tracking + state persistence.
+ *   • {@link registerProtocol}     — kanban:// deep-link handling.
+ *
+ * This file wires them together and owns only:
+ *   • App lifecycle events (whenReady / before-quit / will-quit / activate).
+ *   • Single-instance lock and second-instance argv dispatch.
+ *   • IPC handlers backed by the preload bridge.
+ *   • Startup flow: preflight → create windows → connect runtime.
+ */
+
+import { BrowserWindow, app, dialog, ipcMain } from "electron";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { AppMenu } from "./app-menu.js";
+import { runDesktopPreflight } from "./desktop-preflight.js";
+import { relayOAuthCallback } from "./oauth-relay.js";
+import {
+	extractProtocolUrlFromArgv,
+	parseProtocolUrl,
+	registerProtocol,
+} from "./protocol-handler.js";
+import { RuntimeOrchestrator } from "./runtime-orchestrator.js";
+import { WindowFactory } from "./window-factory.js";
+import { WindowRegistry } from "./window-registry.js";
+
+const BACKGROUND_COLOR = "#1F2428";
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 3484;
+const HEALTH_TIMEOUT_MS = 3_000;
+
+const preloadPath = path.join(import.meta.dirname, "preload.js");
+const disconnectedHtmlPath = path.join(import.meta.dirname, "disconnected.html");
+
+// These two calls must run before `app.whenReady()`.
+app.commandLine.appendSwitch("disable-renderer-backgrounding");
+registerProtocol(app);
+
+// E2E state isolation — lets integration tests point Electron at a scratch
+// userData dir so they don't clobber the developer's real window state.
+if (process.env.KANBAN_DESKTOP_USER_DATA) {
+	app.setPath("userData", process.env.KANBAN_DESKTOP_USER_DATA);
+}
+
+// Helper modules — instantiated at module load, wired after lock acquisition.
+let isQuitting = false;
+
+const registry = new WindowRegistry();
+
+const orchestrator = new RuntimeOrchestrator({
+	host: DEFAULT_HOST,
+	port: DEFAULT_PORT,
+	healthTimeoutMs: HEALTH_TIMEOUT_MS,
+	resolveCliShimPath,
+});
+
+const windowFactory = new WindowFactory({
+	preloadPath,
+	isPackaged: app.isPackaged,
+	backgroundColor: BACKGROUND_COLOR,
+	disconnectedHtmlPath,
+	registry,
+	orchestrator,
+	isQuitting: () => isQuitting,
+	onMenuDirty: () => menu.rebuild(),
+});
+
+const menu = new AppMenu({
+	registry,
+	orchestrator,
+	onNewWindow: ({ initialPath }) =>
+		windowFactory.create({ projectId: null, initialPath }),
+});
+
+// Runtime URL changes and crashes both propagate through the factory:
+// URL changes → reload all windows at the new origin; crashes → disconnected.
+orchestrator.on("url-changed", (url) => {
+	if (url) void registry.loadUrlInAllWindows(url);
+	menu.rebuild();
+});
+orchestrator.on("crashed", () => windowFactory.showDisconnectedScreen());
+
+function handleProtocolUrl(raw: string): void {
+	const parsed = parseProtocolUrl(raw);
+	const runtimeUrl = orchestrator.getUrl();
+	if (!parsed?.isOAuthCallback || !runtimeUrl) return;
+
+	const relayTarget = new URL("/kanban-mcp/mcp-oauth-callback", runtimeUrl);
+	for (const [key, value] of parsed.searchParams.entries()) {
+		relayTarget.searchParams.set(key, value);
+	}
+
+	const focusedWindow = registry.getFocused();
+	relayOAuthCallback(relayTarget.toString(), null, {
+		fetch: globalThis.fetch,
+		getMainWindow: () => focusedWindow,
+	}).catch((err) => console.error("[desktop] OAuth relay error:", err));
+
+	if (focusedWindow && !focusedWindow.isDestroyed()) {
+		if (focusedWindow.isMinimized()) focusedWindow.restore();
+		focusedWindow.show();
+		focusedWindow.focus();
+	}
+}
+
+app.on("open-url", (event, url) => {
+	event.preventDefault();
+	handleProtocolUrl(url);
+});
+
+function resolveCliShimPath(): string {
+	if (app.isPackaged) {
+		const shimName = process.platform === "win32" ? "kanban.cmd" : "kanban";
+		return path.join(process.resourcesPath, "bin", shimName);
+	}
+	const devShimName =
+		process.platform === "win32" ? "kanban-dev.cmd" : "kanban-dev";
+	return path.join(import.meta.dirname, "..", "build", "bin", devShimName);
+}
+
+function parseProjectFromArgv(argv: string[]): string | null {
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--project" && i + 1 < argv.length) {
+			const value = argv[i + 1];
+			if (value && !value.startsWith("-")) return value;
+		}
+		if (arg.startsWith("--project=")) {
+			const value = arg.slice("--project=".length);
+			if (value) return value;
+		}
+	}
+	return null;
+}
+
+ipcMain.on("open-project-window", (_event, projectId: string) => {
+	if (typeof projectId === "string" && projectId) {
+		windowFactory.create({ projectId });
+	}
+});
+
+ipcMain.on("restart-runtime", async () => {
+	console.log("[desktop] Restart requested from renderer.");
+	try {
+		await orchestrator.restart();
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		console.error(`[desktop] Failed to restart runtime: ${msg}`);
+		dialog.showErrorBox(
+			"Kanban Startup Error",
+			`Failed to restart runtime:\n\n${msg}`,
+		);
+	}
+});
+
+const gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+	app.quit();
+} else {
+	app.on("second-instance", (_event, argv) => {
+		const protocolUrl = extractProtocolUrlFromArgv(argv);
+		if (protocolUrl) handleProtocolUrl(protocolUrl);
+
+		const projectId = parseProjectFromArgv(argv);
+		if (projectId) {
+			windowFactory.create({ projectId });
+			return;
+		}
+
+		const focused = registry.getFocused();
+		if (focused) {
+			if (focused.isMinimized()) focused.restore();
+			focused.focus();
+		}
+	});
+
+	wireAppLifecycle();
+}
+
+function wireAppLifecycle(): void {
+	app.whenReady().then(async () => {
+		await mkdir(app.getPath("userData"), { recursive: true }).catch(() => {});
+
+		const cliShimPath = resolveCliShimPath();
+		const preflight = runDesktopPreflight({
+			preloadPath,
+			cliShimPath,
+			isPackaged: app.isPackaged,
+		});
+
+		if (!preflight.ok) {
+			const details = preflight.failures
+				.map((f) => `[${f.code}] ${f.message}`)
+				.join("\n\n");
+			dialog.showErrorBox(
+				"Kanban Startup Error",
+				`Startup preflight failed:\n\n${details}`,
+			);
+			return;
+		}
+
+		// Preflight warnings are non-fatal but worth surfacing so that a
+		// user reporting "terminals don't work" has a breadcrumb in logs.
+		for (const warning of preflight.warnings) {
+			console.warn(`[desktop] Preflight warning [${warning.code}]: ${warning.message}`);
+		}
+
+		const persistedStates = WindowRegistry.loadPersistedWindows(
+			app.getPath("userData"),
+		);
+		if (persistedStates.length > 0) {
+			for (const savedState of persistedStates) {
+				windowFactory.create({ projectId: savedState.projectId, savedState });
+			}
+		} else {
+			windowFactory.create();
+		}
+
+		menu.rebuild();
+		orchestrator.startAppNapPrevention();
+
+		try {
+			await orchestrator.connect();
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			console.error(`[desktop] Failed to start runtime: ${msg}`);
+			dialog.showErrorBox(
+				"Kanban Startup Error",
+				`Failed to start runtime:\n\n${msg}`,
+			);
+		}
+
+		// macOS: re-create window when dock icon clicked and no windows exist.
+		app.on("activate", () => {
+			if (BrowserWindow.getAllWindows().length === 0) {
+				windowFactory.create();
+			} else {
+				const focused = registry.getFocused();
+				if (focused && !focused.isVisible()) focused.show();
+			}
+		});
+	});
+
+	app.on("window-all-closed", () => {
+		if (process.platform !== "darwin") app.quit();
+	});
+
+	app.on("before-quit", async (event) => {
+		if (isQuitting) return;
+		isQuitting = true;
+
+		registry.saveAllStates(app.getPath("userData"));
+
+		// Only hold the quit if we need to cleanly shut down a child we own.
+		// Attached-to-existing-runtime mode has nothing to clean up.
+		//
+		// try/finally guarantees `app.quit()` still runs if shutdown()
+		// rejects — otherwise a rejected shutdown would leave the app
+		// hanging after the user asked it to quit.
+		if (orchestrator.isOwned()) {
+			event.preventDefault();
+			try {
+				await orchestrator.shutdown();
+			} catch (err) {
+				console.error(
+					"[desktop] Runtime shutdown error during quit:",
+					err instanceof Error ? err.message : err,
+				);
+			} finally {
+				app.quit();
+			}
+		} else {
+			orchestrator.stopAppNapPrevention();
+		}
+	});
+
+	app.on("will-quit", async () => {
+		await orchestrator.dispose();
+	});
+}

--- a/packages/desktop/src/oauth-relay.ts
+++ b/packages/desktop/src/oauth-relay.ts
@@ -1,0 +1,60 @@
+/**
+ * OAuth callback relay with retry logic.
+ *
+ * When the OS delivers a `kanban://oauth/callback` URL, the Electron shell
+ * relays it to the runtime server via HTTP fetch. If the runtime is temporarily
+ * unreachable (e.g. waking from sleep, mid-restart), a single fire-and-forget
+ * fetch would silently lose the callback. This module wraps the relay in a
+ * retry loop and notifies the user when all attempts are exhausted.
+ */
+
+import type { BrowserWindow } from "electron";
+import { dialog } from "electron";
+
+export interface OAuthRelayDeps {
+	fetch: typeof globalThis.fetch;
+	getMainWindow: () => BrowserWindow | null;
+}
+
+/**
+ * Relay an OAuth callback to the runtime server with retry logic.
+ *
+ * Attempts the fetch up to `retries + 1` times (default: 3 total attempts)
+ * with a 1 second delay between retries. If all attempts fail or return a
+ * non-ok response, a warning dialog is shown to the user.
+ *
+ * @param relayUrl  The fully-qualified URL to fetch (runtime OAuth endpoint).
+ * @param token     The auth token to include as a Bearer header, or null.
+ * @param deps      Injectable dependencies for testability.
+ * @param retries   Number of retry attempts after the first failure (default: 2).
+ */
+export async function relayOAuthCallback(
+	relayUrl: string,
+	token: string | null,
+	deps: OAuthRelayDeps,
+	retries = 2,
+): Promise<void> {
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		try {
+			const response = await deps.fetch(relayUrl, {
+				headers: token ? { Authorization: `Bearer ${token}` } : {},
+			});
+			if (response.ok) return;
+		} catch {
+			/* swallow and retry on next iteration */
+		}
+		if (attempt < retries) await new Promise((r) => setTimeout(r, 1_000));
+	}
+
+	// All retries exhausted — notify the user.
+	const window = deps.getMainWindow();
+	if (window && !window.isDestroyed()) {
+		dialog.showMessageBox(window, {
+			type: "warning",
+			title: "OAuth Callback Failed",
+			message:
+				"The authentication callback could not be delivered. Please try again.",
+			buttons: ["OK"],
+		});
+	}
+}

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,0 +1,33 @@
+/**
+ * Preload script for the Electron renderer process.
+ *
+ * Runs in a sandboxed context with access to a limited set of Node APIs.
+ * Uses contextBridge to safely expose IPC channels to the renderer.
+ */
+
+import { contextBridge, ipcRenderer } from "electron";
+
+/**
+ * Desktop API exposed to the renderer via window.desktop.
+ * Kept minimal; only add methods here when the renderer genuinely needs
+ * main-process capabilities that can't go through the runtime HTTP/WS layer.
+ */
+const desktopApi = {
+	platform: process.platform,
+
+	openProjectWindow(projectId: string): void {
+		ipcRenderer.send("open-project-window", projectId);
+	},
+
+	/**
+	 * Request the main process to restart the runtime child.
+	 * Used by the disconnected screen's "Restart" button.
+	 */
+	restartRuntime(): void {
+		ipcRenderer.send("restart-runtime");
+	},
+} as const;
+
+contextBridge.exposeInMainWorld("desktop", desktopApi);
+
+export type DesktopApi = typeof desktopApi;

--- a/packages/desktop/src/protocol-handler.ts
+++ b/packages/desktop/src/protocol-handler.ts
@@ -1,0 +1,131 @@
+/**
+ * Custom protocol handler for kanban:// deep-links.
+ *
+ * Responsible for:
+ * - Registering `kanban://` as the app's default protocol on the OS
+ * - Parsing incoming kanban:// URLs into a structured result
+ * - Providing helpers to extract OAuth callback parameters (code, state, error)
+ *
+ * The protocol is used by external OAuth providers to redirect back to the
+ * desktop app after authentication completes. A typical flow:
+ *
+ *   1. The app opens the system browser to the OAuth provider's authorize URL,
+ *      with redirect_uri=kanban://oauth/callback
+ *   2. After the user authenticates, the provider redirects to kanban://oauth/callback?code=...&state=...
+ *   3. The OS routes the kanban:// URL to this app (via open-url on macOS,
+ *      or as a command-line argument on Windows/Linux)
+ *   4. This module parses the URL and emits the result so the runtime can
+ *      complete the token exchange
+ */
+
+export const KANBAN_PROTOCOL = "kanban";
+export const OAUTH_CALLBACK_PATH = "/oauth/callback";
+
+export interface OAuthCallbackParams {
+	code: string | null;
+	state: string | null;
+	error: string | null;
+	errorDescription: string | null;
+}
+
+export interface ParsedProtocolUrl {
+	raw: string;
+	pathname: string;
+	searchParams: URLSearchParams;
+	/** Whether this URL matches the OAuth callback path. */
+	isOAuthCallback: boolean;
+	/** OAuth params — only meaningful when `isOAuthCallback` is true. */
+	oauth: OAuthCallbackParams;
+}
+
+/**
+ * Parse a `kanban://` URL into a structured result.
+ *
+ * Returns `null` if the URL is not a valid `kanban://` URL.
+ *
+ * This function is pure and does not depend on Electron, making it
+ * straightforward to test in a plain Node.js environment.
+ */
+export function parseProtocolUrl(raw: string): ParsedProtocolUrl | null {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		return null;
+	}
+
+	if (url.protocol !== `${KANBAN_PROTOCOL}:`) {
+		return null;
+	}
+
+	// URL constructor treats kanban://oauth/callback as:
+	//   protocol = "kanban:", hostname = "oauth", pathname = "/callback"
+	// We normalise so the "logical" pathname is /oauth/callback.
+	const pathname = `/${url.hostname}${url.pathname}`.replace(/\/+$/, "") || "/";
+
+	const searchParams = url.searchParams;
+
+	const isOAuthCallback = pathname === OAUTH_CALLBACK_PATH;
+
+	const oauth: OAuthCallbackParams = {
+		code: searchParams.get("code"),
+		state: searchParams.get("state"),
+		error: searchParams.get("error"),
+		errorDescription: searchParams.get("error_description"),
+	};
+
+	return {
+		raw,
+		pathname,
+		searchParams,
+		isOAuthCallback,
+		oauth,
+	};
+}
+
+/**
+ * Minimal subset of `Electron.App` needed for protocol registration.
+ *
+ * Keeps this module testable without importing the full Electron types at
+ * runtime — mirrors the pattern used in auth.ts.
+ */
+export interface ElectronAppLike {
+	setAsDefaultProtocolClient(protocol: string): boolean;
+	isDefaultProtocolClient(protocol: string): boolean;
+}
+
+/**
+ * Register `kanban://` as the default protocol client for this app.
+ *
+ * On macOS, protocol associations are declared in the Info.plist (handled by
+ * electron-builder), but `setAsDefaultProtocolClient` is still called for
+ * development builds. On Windows/Linux, this call registers the protocol
+ * in the OS registry / XDG system.
+ *
+ * Returns `true` if the registration succeeded (or was already registered).
+ */
+export function registerProtocol(electronApp: ElectronAppLike): boolean {
+	if (electronApp.isDefaultProtocolClient(KANBAN_PROTOCOL)) {
+		return true;
+	}
+	return electronApp.setAsDefaultProtocolClient(KANBAN_PROTOCOL);
+}
+
+/**
+ * Extract a `kanban://` URL from a process argv array.
+ *
+ * On Windows and Linux, when the app is launched via a protocol link, the URL
+ * is passed as a command-line argument. This helper scans argv for the first
+ * argument that starts with `kanban://`.
+ *
+ * Returns `null` if no protocol URL is found.
+ */
+export function extractProtocolUrlFromArgv(argv: readonly string[]): string | null {
+	const prefix = `${KANBAN_PROTOCOL}://`;
+	for (const arg of argv) {
+		if (arg.startsWith(prefix)) {
+			return arg;
+		}
+	}
+	return null;
+}

--- a/packages/desktop/src/protocol-handler.ts
+++ b/packages/desktop/src/protocol-handler.ts
@@ -86,8 +86,9 @@ export function parseProtocolUrl(raw: string): ParsedProtocolUrl | null {
 /**
  * Minimal subset of `Electron.App` needed for protocol registration.
  *
- * Keeps this module testable without importing the full Electron types at
- * runtime — mirrors the pattern used in auth.ts.
+ * Kept as a local interface (rather than importing `Electron.App`) so
+ * this module is testable in a plain Node.js environment without the
+ * Electron runtime.
  */
 export interface ElectronAppLike {
 	setAsDefaultProtocolClient(protocol: string): boolean;

--- a/packages/desktop/src/runtime-orchestrator.ts
+++ b/packages/desktop/src/runtime-orchestrator.ts
@@ -1,0 +1,394 @@
+/**
+ * Runtime orchestrator — owns everything about the runtime's lifecycle.
+ *
+ * Responsibilities:
+ *   • Health-check an origin.
+ *   • On boot: attach to an existing runtime if one is reachable, otherwise
+ *     spawn our own child via RuntimeChildManager.
+ *   • Expose a deduplicated `restart()` for user-initiated recovery.
+ *   • Re-emit crash events so the shell can flip to a disconnected screen.
+ *   • After a crash, poll the last-known origin so a runtime started from
+ *     the user's terminal (`kanban`) auto-reattaches without a restart.
+ *   • Manage the power-save blocker (App Nap prevention) tied to the
+ *     runtime's lifetime.
+ *
+ * This module deliberately owns no window state — it talks to the outside
+ * world via EventEmitter and getter methods, so the shell can wire it to
+ * whatever UI it wants without the orchestrator knowing about BrowserWindow.
+ */
+
+import { EventEmitter } from "node:events";
+import { powerSaveBlocker } from "electron";
+
+import { RuntimeChildManager } from "./runtime-child.js";
+
+export interface RuntimeOrchestratorOptions {
+	host: string;
+	port: number;
+	/** Health check timeout per attempt (ms). */
+	healthTimeoutMs: number;
+	/** Resolved lazily so packaged vs dev mode can differ without extra plumbing. */
+	resolveCliShimPath: () => string;
+	/** Exposed for tests — defaults to `globalThis.fetch`. */
+	fetchImpl?: typeof fetch;
+	/**
+	 * How often to poll an attached (not-owned) runtime for liveness (ms).
+	 * Defaults to 2_000. Set to 0 to disable (e.g. in tests).
+	 */
+	attachedProbeIntervalMs?: number;
+	/**
+	 * Number of consecutive probe failures before we classify an attached
+	 * runtime as crashed. Defaults to 3.
+	 */
+	attachedProbeFailureThreshold?: number;
+	/**
+	 * How often the post-crash recovery probe polls the last-known origin
+	 * looking for a runtime to re-appear (ms). Defaults to 2_000. Set to 0
+	 * to disable the feature (e.g. in tests that would otherwise see
+	 * spurious timers after a simulated crash).
+	 */
+	recoveryProbeIntervalMs?: number;
+}
+
+interface RuntimeOrchestratorEventMap {
+	/** Emitted whenever the active URL changes (connect, restart, crash). */
+	"url-changed": [url: string | null];
+	/** Emitted after the child crashes. Shell should show disconnected UI. */
+	crashed: [];
+}
+
+// Kept deliberately aggressive — the race we're defending against is that
+// an attached runtime's bundled web-ui may render its OWN "disconnected"
+// React fallback within milliseconds of WebSocket loss. We need to replace
+// that with the native `disconnected.html` fast enough that users don't
+// see a stale message. 500 ms × 2 ≈ ~1 s worst-case flip, versus the
+// healthTimeoutMs budget per probe (3 s), which dominates the observed
+// latency when the TCP connect fails fast (ECONNREFUSED is immediate).
+const DEFAULT_ATTACHED_PROBE_INTERVAL_MS = 500;
+const DEFAULT_ATTACHED_PROBE_FAILURE_THRESHOLD = 2;
+
+// The disconnected screen advertises "run kanban in any terminal" as a
+// recovery path, so users reasonably expect the desktop to reconnect on
+// its own. 2 s feels snappy without being chatty — the probe costs one
+// fetch per interval and only runs while we're actually disconnected.
+const DEFAULT_RECOVERY_PROBE_INTERVAL_MS = 2_000;
+
+export class RuntimeOrchestrator extends EventEmitter<RuntimeOrchestratorEventMap> {
+	private manager: RuntimeChildManager | null = null;
+	private url: string | null = null;
+	private ownsChild = false;
+	private restartPromise: Promise<void> | null = null;
+	private powerSaveBlockerId = -1;
+	private attachedProbeTimer: NodeJS.Timeout | null = null;
+	private attachedProbeFailures = 0;
+	private recoveryProbeTimer: NodeJS.Timeout | null = null;
+	/**
+	 * Last origin we were successfully connected to. Remembered across
+	 * crash → reconnect cycles so the post-crash recovery probe knows
+	 * which URL to watch for a returning runtime.
+	 */
+	private lastKnownOrigin: string | null = null;
+
+	constructor(private readonly opts: RuntimeOrchestratorOptions) {
+		super();
+	}
+
+
+	/** Current runtime URL, or null if disconnected. */
+	getUrl(): string | null {
+		return this.url;
+	}
+
+	/** True if we spawned the child (vs attached to an existing runtime). */
+	isOwned(): boolean {
+		return this.ownsChild;
+	}
+
+	/** Default origin used for initial attach probes. */
+	defaultOrigin(): string {
+		return `http://${this.opts.host}:${this.opts.port}`;
+	}
+
+	/**
+	 * Probes an origin to detect whether a Kanban runtime is listening.
+	 *
+	 * Uses `/` instead of `/api/health` because the CLI runtime doesn't
+	 * implement `/api/health` — it only serves the web UI at `/`. A 2xx
+	 * response from `/` is sufficient proof that a runtime is reachable.
+	 */
+	async checkHealth(origin: string): Promise<boolean> {
+		const fetchFn = this.opts.fetchImpl ?? globalThis.fetch;
+		const controller = new AbortController();
+		// Hoisted out of try{} so the finally{} below can always clear it
+		// — otherwise a fetch rejection (network error, abort) would leak
+		// the timer for up to healthTimeoutMs.
+		const timer = setTimeout(
+			() => controller.abort(),
+			this.opts.healthTimeoutMs,
+		);
+		try {
+			const res = await fetchFn(`${origin}/`, {
+				signal: controller.signal,
+			});
+			return res.ok;
+		} catch {
+			return false;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	/**
+	 * Boot the runtime: attach to any existing server on the default port,
+	 * otherwise spawn our own child. Sets {@link getUrl} on success; throws
+	 * on spawn failure (caller should show a startup error dialog).
+	 */
+	async connect(): Promise<void> {
+		const origin = this.defaultOrigin();
+		if (await this.checkHealth(origin)) {
+			console.log(`[desktop] Found existing runtime at ${origin}`);
+			this.setUrl(origin, /* owns */ false);
+			return;
+		}
+		console.log("[desktop] No runtime found — starting child process.");
+		await this.startOwnRuntime();
+	}
+
+	/**
+	 * User-initiated restart. Tears down the current child (if any), spawns
+	 * a fresh one, and updates the URL. Concurrent calls coalesce onto a
+	 * single in-flight attempt.
+	 */
+	async restart(): Promise<void> {
+		if (this.restartPromise) {
+			await this.restartPromise;
+			return;
+		}
+		// A user-initiated restart supersedes any passive recovery attempt.
+		// Stop the recovery timer before teardown so it can't race with the
+		// new child coming up on the same origin.
+		this.stopRecoveryProbe();
+		this.restartPromise = (async () => {
+			if (this.manager) {
+				await this.manager.shutdown().catch(() => {});
+				this.manager = null;
+			}
+			await this.startOwnRuntime();
+		})().finally(() => {
+			this.restartPromise = null;
+		});
+		await this.restartPromise;
+	}
+
+	/** Graceful shutdown for `before-quit`. No-op if we don't own the child. */
+	async shutdown(): Promise<void> {
+		this.stopAppNapPrevention();
+		if (this.manager && this.ownsChild) {
+			await this.manager.shutdown().catch((err) => {
+				console.error(
+					"[desktop] Runtime shutdown error:",
+					err instanceof Error ? err.message : err,
+				);
+			});
+		}
+	}
+
+	/** Final cleanup for `will-quit`. */
+	async dispose(): Promise<void> {
+		this.stopRecoveryProbe();
+		this.stopAttachedProbe();
+		if (this.manager) {
+			await this.manager.dispose().catch(() => {});
+			this.manager = null;
+		}
+	}
+
+
+	startAppNapPrevention(): void {
+		if (this.powerSaveBlockerId !== -1) return;
+		this.powerSaveBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+	}
+
+	stopAppNapPrevention(): void {
+		if (this.powerSaveBlockerId === -1) return;
+		powerSaveBlocker.stop(this.powerSaveBlockerId);
+		this.powerSaveBlockerId = -1;
+	}
+
+	private async startOwnRuntime(): Promise<void> {
+		if (!this.manager) {
+			this.manager = this.createManager();
+		}
+		const url = await this.manager.start({
+			host: this.opts.host,
+			port: this.opts.port,
+		});
+		this.setUrl(url, /* owns */ true);
+	}
+
+	private createManager(): RuntimeChildManager {
+		const manager = new RuntimeChildManager({
+			cliPath: this.opts.resolveCliShimPath(),
+			shutdownTimeoutMs: 5_000,
+		});
+
+		manager.on("crashed", (exitCode, signal, stderrTail) => {
+			console.error(
+				`[desktop] Runtime crashed (code=${exitCode}, signal=${signal})`,
+			);
+			if (stderrTail.trim().length > 0) {
+				// The tail is capped at ~8 KB by RuntimeChildManager; safe
+				// to log in one go. This is invaluable for diagnosing a
+				// CLI that died before becoming reachable (the most common
+				// class of desktop-only packaging failure).
+				console.error(`[desktop] Runtime stderr tail:\n${stderrTail}`);
+			}
+			this.handleCrash();
+		});
+
+		manager.on("error", (message: string) => {
+			console.error(`[desktop] Runtime error: ${message}`);
+		});
+
+		return manager;
+	}
+
+	/**
+	 * Shared crash path used by both owned-child exits and attached-probe
+	 * failure detection. Clears the URL, emits "crashed" so the shell can
+	 * flip to disconnected.html, and kicks off the recovery probe so a
+	 * runtime started from the user's terminal auto-reattaches.
+	 */
+	private handleCrash(): void {
+		this.setUrl(null, /* owns */ false);
+		this.emit("crashed");
+		this.startRecoveryProbe();
+	}
+
+	private setUrl(url: string | null, ownsChild: boolean): void {
+		if (url) {
+			this.lastKnownOrigin = url;
+			// Any successful connection supersedes an in-flight recovery
+			// attempt — whether the user manually restarted, an attach
+			// succeeded, or our own recovery probe just flipped us back.
+			this.stopRecoveryProbe();
+		}
+		this.url = url;
+		this.ownsChild = ownsChild;
+		this.emit("url-changed", url);
+
+		// We only poll in attached mode. When we own the child, the
+		// RuntimeChildManager emits "crashed" directly from the process
+		// exit event — no polling needed.
+		if (url && !ownsChild) {
+			this.startAttachedProbe(url);
+		} else {
+			this.stopAttachedProbe();
+		}
+	}
+
+	/**
+	 * Starts polling an attached runtime for liveness. When it fails
+	 * N consecutive times, emit "crashed" so the shell can flip to the
+	 * disconnected screen — same UX as an owned-child crash.
+	 *
+	 * Without this, a user who started the runtime from their terminal
+	 * and then killed it would be stranded on the last-rendered page with
+	 * no visual feedback from the desktop shell, forcing them to rely on
+	 * whatever fallback the web-ui happens to render (which varies by
+	 * version and is historically inconsistent).
+	 */
+	private startAttachedProbe(origin: string): void {
+		this.stopAttachedProbe();
+		const intervalMs =
+			this.opts.attachedProbeIntervalMs ?? DEFAULT_ATTACHED_PROBE_INTERVAL_MS;
+		if (intervalMs <= 0) return;
+
+		const threshold =
+			this.opts.attachedProbeFailureThreshold ??
+			DEFAULT_ATTACHED_PROBE_FAILURE_THRESHOLD;
+		this.attachedProbeFailures = 0;
+
+		const tick = async (): Promise<void> => {
+			// Guard against a stale timer firing after the URL changed.
+			if (this.url !== origin || this.ownsChild) return;
+			const healthy = await this.checkHealth(origin);
+			if (this.url !== origin || this.ownsChild) return;
+			if (healthy) {
+				this.attachedProbeFailures = 0;
+				return;
+			}
+			this.attachedProbeFailures += 1;
+			if (this.attachedProbeFailures >= threshold) {
+				console.error(
+					`[desktop] Attached runtime at ${origin} unreachable after ${this.attachedProbeFailures} probes — classifying as crashed.`,
+				);
+				this.stopAttachedProbe();
+				this.handleCrash();
+			}
+		};
+
+		this.attachedProbeTimer = setInterval(() => {
+			void tick();
+		}, intervalMs);
+		// Don't let the probe keep the Node event loop alive on its own.
+		this.attachedProbeTimer.unref?.();
+	}
+
+	private stopAttachedProbe(): void {
+		if (this.attachedProbeTimer) {
+			clearInterval(this.attachedProbeTimer);
+			this.attachedProbeTimer = null;
+		}
+		this.attachedProbeFailures = 0;
+	}
+
+	/**
+	 * Starts polling the last-known origin looking for a Kanban runtime
+	 * to re-appear (typically because the user ran `kanban` in a terminal).
+	 * On the first healthy probe, flips back into attached mode — the
+	 * existing `url-changed` listener in the shell reloads every window
+	 * away from the disconnected screen.
+	 *
+	 * No-op if we've never connected (nothing to recover to) or if
+	 * `recoveryProbeIntervalMs` is 0.
+	 */
+	private startRecoveryProbe(): void {
+		this.stopRecoveryProbe();
+		const origin = this.lastKnownOrigin;
+		if (!origin) return;
+		const intervalMs =
+			this.opts.recoveryProbeIntervalMs ?? DEFAULT_RECOVERY_PROBE_INTERVAL_MS;
+		if (intervalMs <= 0) return;
+
+		const tick = async (): Promise<void> => {
+			// Stop chasing if anything else reconnected us (user clicked
+			// Restart, deep-link handler forced a re-attach, etc.).
+			if (this.url !== null) {
+				this.stopRecoveryProbe();
+				return;
+			}
+			const healthy = await this.checkHealth(origin);
+			if (this.url !== null) return;
+			if (!healthy) return;
+			console.log(
+				`[desktop] Recovery probe found runtime at ${origin} — auto-attaching.`,
+			);
+			// setUrl() will stop this recovery timer and promote us to
+			// attached-probe mode.
+			this.setUrl(origin, /* owns */ false);
+		};
+
+		this.recoveryProbeTimer = setInterval(() => {
+			void tick();
+		}, intervalMs);
+		this.recoveryProbeTimer.unref?.();
+	}
+
+	private stopRecoveryProbe(): void {
+		if (this.recoveryProbeTimer) {
+			clearInterval(this.recoveryProbeTimer);
+			this.recoveryProbeTimer = null;
+		}
+	}
+}

--- a/packages/desktop/src/runtime-orchestrator.ts
+++ b/packages/desktop/src/runtime-orchestrator.ts
@@ -33,12 +33,14 @@ export interface RuntimeOrchestratorOptions {
 	fetchImpl?: typeof fetch;
 	/**
 	 * How often to poll an attached (not-owned) runtime for liveness (ms).
-	 * Defaults to 2_000. Set to 0 to disable (e.g. in tests).
+	 * Defaults to {@link DEFAULT_ATTACHED_PROBE_INTERVAL_MS} (500). Set to 0
+	 * to disable (e.g. in tests).
 	 */
 	attachedProbeIntervalMs?: number;
 	/**
 	 * Number of consecutive probe failures before we classify an attached
-	 * runtime as crashed. Defaults to 3.
+	 * runtime as crashed. Defaults to
+	 * {@link DEFAULT_ATTACHED_PROBE_FAILURE_THRESHOLD} (2).
 	 */
 	attachedProbeFailureThreshold?: number;
 	/**
@@ -92,7 +94,6 @@ export class RuntimeOrchestrator extends EventEmitter<RuntimeOrchestratorEventMa
 	constructor(private readonly opts: RuntimeOrchestratorOptions) {
 		super();
 	}
-
 
 	/** Current runtime URL, or null if disconnected. */
 	getUrl(): string | null {
@@ -202,7 +203,6 @@ export class RuntimeOrchestrator extends EventEmitter<RuntimeOrchestratorEventMa
 			this.manager = null;
 		}
 	}
-
 
 	startAppNapPrevention(): void {
 		if (this.powerSaveBlockerId !== -1) return;

--- a/packages/desktop/src/window-factory.ts
+++ b/packages/desktop/src/window-factory.ts
@@ -18,7 +18,10 @@ import { BrowserWindow, dialog } from "electron";
 
 import type { RuntimeOrchestrator } from "./runtime-orchestrator.js";
 import { WindowRegistry } from "./window-registry.js";
-import type { PersistedWindowState } from "./window-state.js";
+import {
+	type PersistedWindowState,
+	isPersistableRuntimePath,
+} from "./window-state.js";
 
 export interface WindowFactoryOptions {
 	preloadPath: string;
@@ -174,7 +177,17 @@ function buildWindowUrl(
 		return WindowRegistry.buildWindowUrl(runtimeUrl, options.projectId);
 	}
 	if (options.initialPath) {
-		if (!isSafeInitialPath(options.initialPath)) {
+		// Two-layer defence: `isSafeInitialPath` rejects malformed or
+		// scheme-ish values (`//foo`, `/file:/…`) that could escape the
+		// runtime origin; `isPersistableRuntimePath` rejects values that
+		// would resolve to 404 against the runtime (filesystem-looking
+		// paths, `.html` routes). This matches the guard in
+		// `window-registry.buildEntryUrl` so any future caller passing an
+		// untrusted path gets the same treatment.
+		if (
+			!isSafeInitialPath(options.initialPath) ||
+			!isPersistableRuntimePath(options.initialPath)
+		) {
 			console.warn(
 				`[desktop] Ignoring unsafe initialPath: ${options.initialPath}`,
 			);

--- a/packages/desktop/src/window-factory.ts
+++ b/packages/desktop/src/window-factory.ts
@@ -1,0 +1,188 @@
+/**
+ * Window factory — creates project-scoped BrowserWindows and handles
+ * renderer-side failure recovery.
+ *
+ * The factory:
+ *   • Delegates raw BrowserWindow construction to {@link WindowRegistry}
+ *     (which also persists window state and tracks focus).
+ *   • Loads the correct runtime URL based on caller-supplied projectId /
+ *     initialPath.
+ *   • Attaches `did-fail-load` and `render-process-gone` listeners that
+ *     distinguish "renderer glitch" (retry) from "runtime died" (flip all
+ *     windows to the disconnected screen).
+ *   • Exposes {@link showDisconnectedScreen} for the shell to call on
+ *     runtime crash events from the orchestrator.
+ */
+
+import { BrowserWindow, dialog } from "electron";
+
+import type { RuntimeOrchestrator } from "./runtime-orchestrator.js";
+import { WindowRegistry } from "./window-registry.js";
+import type { PersistedWindowState } from "./window-state.js";
+
+export interface WindowFactoryOptions {
+	preloadPath: string;
+	isPackaged: boolean;
+	backgroundColor: string;
+	/** Path to disconnected.html (copied to dist/ at build time). */
+	disconnectedHtmlPath: string;
+	registry: WindowRegistry;
+	orchestrator: RuntimeOrchestrator;
+	/** Live signal for `before-quit` — lets the registry skip hide-on-close. */
+	isQuitting: () => boolean;
+	/** Invoked when menu state may have changed (window created/closed/focused). */
+	onMenuDirty: () => void;
+}
+
+export interface CreateWindowOptions {
+	projectId?: string | null;
+	initialPath?: string | null;
+	savedState?: PersistedWindowState;
+}
+
+export class WindowFactory {
+	constructor(private readonly opts: WindowFactoryOptions) {}
+
+	create(options: CreateWindowOptions = {}): BrowserWindow {
+		const window = this.opts.registry.createWindow({
+			projectId: options.projectId ?? null,
+			savedState: options.savedState,
+			preloadPath: this.opts.preloadPath,
+			isPackaged: this.opts.isPackaged,
+			backgroundColor: this.opts.backgroundColor,
+			runtimeUrl: this.opts.orchestrator.getUrl() ?? undefined,
+			hideOnCloseForMac: true,
+			isQuitting: this.opts.isQuitting,
+			onWindowClosed: this.opts.onMenuDirty,
+			onWindowFocused: this.opts.onMenuDirty,
+		});
+
+		this.attachRendererRecovery(window);
+
+		const runtimeUrl = this.opts.orchestrator.getUrl();
+		if (runtimeUrl) {
+			const url = buildWindowUrl(runtimeUrl, options);
+			window.loadURL(url).catch((err: unknown) => {
+				console.error(
+					"[desktop] Failed to load URL in window:",
+					err instanceof Error ? err.message : err,
+				);
+			});
+		}
+
+		this.opts.onMenuDirty();
+		return window;
+	}
+
+	/**
+	 * Loads the disconnected fallback page into every live window. Called
+	 * on runtime crash and on a persistent "runtime unreachable" classification
+	 * from {@link attachRendererRecovery}.
+	 */
+	showDisconnectedScreen(): void {
+		for (const win of BrowserWindow.getAllWindows()) {
+			if (win.isDestroyed()) continue;
+			win.loadFile(this.opts.disconnectedHtmlPath).catch(() => {});
+		}
+		this.opts.onMenuDirty();
+	}
+
+	private attachRendererRecovery(window: BrowserWindow): void {
+		// Distinguish renderer-local failures (retryable) from runtime
+		// unreachability (disconnected screen). Probe the runtime origin
+		// via checkHealth() before deciding how to recover.
+		window.webContents.on(
+			"did-fail-load",
+			(_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
+				// -3 (ERR_ABORTED) is emitted for user-initiated navigations
+				// and in-flight loads cancelled by a subsequent loadURL — not
+				// an actual failure.
+				if (errorCode === -3 || !isMainFrame) return;
+				console.error(
+					`[desktop] Renderer load failed: ${errorDescription} (code ${errorCode})`,
+				);
+
+				const origin =
+					this.opts.orchestrator.getUrl() ??
+					this.opts.orchestrator.defaultOrigin();
+				void this.opts.orchestrator.checkHealth(origin).then((healthy) => {
+					if (window.isDestroyed()) return;
+
+					if (!healthy) {
+						this.showDisconnectedScreen();
+						return;
+					}
+
+					const choice = dialog.showMessageBoxSync(window, {
+						type: "error",
+						title: "Page Load Failed",
+						message: `The app failed to load:\n\n${errorDescription}`,
+						buttons: ["Retry", "Dismiss"],
+						defaultId: 0,
+					});
+					const runtimeUrl = this.opts.orchestrator.getUrl();
+					if (choice === 0 && runtimeUrl) {
+						window.loadURL(runtimeUrl).catch(() => {});
+					}
+				});
+			},
+		);
+
+		window.webContents.on("render-process-gone", (_event, details) => {
+			console.error(`[desktop] Renderer process gone: reason=${details.reason}`);
+			if (window.isDestroyed()) return;
+
+			const origin =
+				this.opts.orchestrator.getUrl() ??
+				this.opts.orchestrator.defaultOrigin();
+			void this.opts.orchestrator.checkHealth(origin).then((healthy) => {
+				if (window.isDestroyed()) return;
+				const runtimeUrl = this.opts.orchestrator.getUrl();
+				if (healthy && runtimeUrl) {
+					window.loadURL(runtimeUrl).catch(() => {});
+				} else {
+					this.showDisconnectedScreen();
+				}
+			});
+		});
+	}
+}
+
+/**
+ * Accept only within-app paths: single leading slash, no scheme, no
+ * protocol-relative authority. `initialPath` can originate from untrusted
+ * deep links (`kanban://…?path=…`), so even though `URL.pathname` would
+ * normalise the origin back to the runtime, we reject obviously-crafted
+ * values up front rather than hand them to the in-page router.
+ */
+function isSafeInitialPath(p: string): boolean {
+	if (!p.startsWith("/")) return false;
+	// `//foo` would be parsed by URL as protocol-relative; reject to avoid
+	// surprises in downstream consumers that concatenate paths without
+	// going through URL parsing.
+	if (p.startsWith("//")) return false;
+	// `scheme:…` — reject anything that looks like a URL with a scheme.
+	if (/^\/[a-z][a-z0-9+\-.]*:/i.test(p)) return false;
+	return true;
+}
+
+function buildWindowUrl(
+	runtimeUrl: string,
+	options: CreateWindowOptions,
+): string {
+	if (options.projectId) {
+		return WindowRegistry.buildWindowUrl(runtimeUrl, options.projectId);
+	}
+	if (options.initialPath) {
+		if (!isSafeInitialPath(options.initialPath)) {
+			console.warn(
+				`[desktop] Ignoring unsafe initialPath: ${options.initialPath}`,
+			);
+			return runtimeUrl;
+		}
+		const parsed = new URL(runtimeUrl);
+		parsed.pathname = options.initialPath;
+		return parsed.toString();
+	}
+	return runtimeUrl;
+}

--- a/packages/desktop/src/window-registry.ts
+++ b/packages/desktop/src/window-registry.ts
@@ -1,0 +1,254 @@
+import { BrowserWindow, shell } from "electron";
+
+import {
+	type PersistedWindowState,
+	extractPersistablePath,
+	isPersistableRuntimePath,
+	loadAllWindowStates,
+	saveAllWindowStates,
+} from "./window-state.js";
+
+export interface WindowEntry {
+	window: BrowserWindow;
+	projectId: string | null;
+	lastViewedPath: string | null;
+}
+
+export interface CreateWindowOptions {
+	projectId?: string | null;
+	savedState?: PersistedWindowState;
+	preloadPath: string;
+	isPackaged: boolean;
+	backgroundColor?: string;
+	runtimeUrl?: string | null;
+	onWindowClosed?: (windowId: number) => void;
+	onWindowFocused?: (windowId: number) => void;
+	hideOnCloseForMac?: boolean;
+	isQuitting?: () => boolean;
+}
+
+const DEFAULT_WIDTH = 1400;
+const DEFAULT_HEIGHT = 900;
+const MIN_WIDTH = 800;
+const MIN_HEIGHT = 600;
+const DEFAULT_BACKGROUND_COLOR = "#1F2428";
+
+export class WindowRegistry {
+	private readonly windows = new Map<number, WindowEntry>();
+	private lastFocusedId: number | null = null;
+
+	get size(): number {
+		return this.windows.size;
+	}
+
+	createWindow(options: CreateWindowOptions): BrowserWindow {
+		const projectId = options.projectId ?? null;
+		const savedState = options.savedState;
+		const backgroundColor = options.backgroundColor ?? DEFAULT_BACKGROUND_COLOR;
+
+		const window = new BrowserWindow({
+			x: savedState?.x,
+			y: savedState?.y,
+			width: savedState?.width ?? DEFAULT_WIDTH,
+			height: savedState?.height ?? DEFAULT_HEIGHT,
+			minWidth: MIN_WIDTH,
+			minHeight: MIN_HEIGHT,
+			title: "Kanban",
+			backgroundColor,
+			show: false,
+			webPreferences: {
+				preload: options.preloadPath,
+				contextIsolation: true,
+				nodeIntegration: false,
+				sandbox: true,
+				webSecurity: true,
+				devTools: !options.isPackaged,
+			},
+		});
+
+		if (savedState?.isMaximized) {
+			window.maximize();
+		}
+
+		const entry: WindowEntry = {
+			window,
+			projectId,
+			lastViewedPath: options.savedState?.lastViewedPath ?? null,
+		};
+		this.windows.set(window.id, entry);
+		this.lastFocusedId = window.id;
+
+		window.once("ready-to-show", () => {
+			window.show();
+		});
+
+		window.on("focus", () => {
+			this.lastFocusedId = window.id;
+			options.onWindowFocused?.(window.id);
+		});
+
+		window.webContents.on("will-navigate", (event: Electron.Event, url: string) => {
+			// Dynamically resolve trusted origin from the window's current URL,
+			// not captured at creation time (which would be null for startup windows).
+			const currentUrl = window.webContents.getURL();
+			if (currentUrl) {
+				try {
+					const trustedOrigin = new URL(currentUrl).origin;
+					if (new URL(url).origin !== trustedOrigin) {
+						event.preventDefault();
+					}
+				} catch {
+					event.preventDefault();
+				}
+			}
+		});
+
+		window.webContents.setWindowOpenHandler(({ url }) => {
+			shell.openExternal(url);
+			return { action: "deny" };
+		});
+
+		window.on("close", (event) => {
+			if (
+				options.hideOnCloseForMac &&
+				process.platform === "darwin" &&
+				!(options.isQuitting?.() ?? false)
+			) {
+				if (this.countVisibleWindows() <= 1) {
+					event.preventDefault();
+					window.hide();
+					return;
+				}
+			}
+		});
+
+		window.on("closed", () => {
+			this.windows.delete(window.id);
+			if (this.lastFocusedId === window.id) {
+				this.lastFocusedId = null;
+			}
+			options.onWindowClosed?.(window.id);
+		});
+
+		return window;
+	}
+
+	getVisible(): WindowEntry[] {
+		return [...this.windows.values()].filter(
+			(entry) => !entry.window.isDestroyed() && entry.window.isVisible(),
+		);
+	}
+
+	countVisibleWindows(): number {
+		return this.getVisible().length;
+	}
+
+	getFocused(): BrowserWindow | null {
+		const focused = BrowserWindow.getFocusedWindow();
+		if (focused && this.windows.has(focused.id)) {
+			return focused;
+		}
+
+		if (this.lastFocusedId !== null) {
+			const entry = this.windows.get(this.lastFocusedId);
+			if (entry && !entry.window.isDestroyed()) {
+				return entry.window;
+			}
+			this.lastFocusedId = null;
+		}
+
+		for (const entry of this.windows.values()) {
+			if (!entry.window.isDestroyed()) {
+				return entry.window;
+			}
+		}
+
+		return null;
+	}
+
+	saveAllStates(userDataPath: string): void {
+		const states: PersistedWindowState[] = [];
+		for (const entry of this.windows.values()) {
+			if (entry.window.isDestroyed()) continue;
+			const isMaximized = entry.window.isMaximized();
+			const bounds = isMaximized
+				? entry.window.getNormalBounds()
+				: entry.window.getBounds();
+
+			// Only persist runtime http(s) pathnames — skip disconnected.html
+			// and other non-runtime URLs that would 404 on replay. See
+			// extractPersistablePath for the full set of rejection rules.
+			const persistable = extractPersistablePath(
+				entry.window.webContents.getURL(),
+			);
+			if (persistable) entry.lastViewedPath = persistable;
+
+			states.push({
+				x: bounds.x,
+				y: bounds.y,
+				width: bounds.width,
+				height: bounds.height,
+				isMaximized,
+				projectId: entry.projectId,
+				lastViewedPath: entry.lastViewedPath,
+			});
+		}
+		saveAllWindowStates(userDataPath, states);
+	}
+
+	static loadPersistedWindows(userDataPath: string): PersistedWindowState[] {
+		return loadAllWindowStates(userDataPath);
+	}
+
+	/**
+	 * Build the renderer URL for a window opened to a specific project.
+	 *
+	 * Uses path-based encoding (`/<projectId>`) to match the web-ui's
+	 * existing project-routing scheme (parseProjectIdFromPathname). This
+	 * keeps the renderer free of any desktop-specific URL handling — the
+	 * window simply lands on the project's normal pathname like a regular
+	 * tab, and the user is free to navigate anywhere from there.
+	 */
+	static buildWindowUrl(baseUrl: string, projectId: string | null): string {
+		if (!projectId) return baseUrl;
+		const url = new URL(baseUrl);
+		url.pathname = `/${encodeURIComponent(projectId)}`;
+		return url.toString();
+	}
+
+	private buildEntryUrl(baseUrl: string, entry: WindowEntry): string {
+		// Prefer lastViewedPath so user-navigation is restored on relaunch.
+		// projectId is only the *initial* project the window was opened to;
+		// the window is not locked to it, so the user may have navigated
+		// elsewhere before quitting.
+		//
+		// Defense in depth: the save-time path already rejects non-http(s)
+		// pathnames, but users upgrading from a build that persisted them
+		// will still have `/Users/.../disconnected.html` in their state
+		// file. Validate here so a one-time-bad state auto-heals on next
+		// launch instead of stranding the user on a "Not Found" screen.
+		if (entry.lastViewedPath && isPersistableRuntimePath(entry.lastViewedPath)) {
+			try {
+				const url = new URL(baseUrl);
+				url.pathname = entry.lastViewedPath;
+				return url.toString();
+			} catch {
+				/* fall through */
+			}
+		}
+		if (entry.projectId) {
+			return WindowRegistry.buildWindowUrl(baseUrl, entry.projectId);
+		}
+		return baseUrl;
+	}
+
+	async loadUrlInAllWindows(baseUrl: string): Promise<void> {
+		const promises: Promise<void>[] = [];
+		for (const entry of this.windows.values()) {
+			if (entry.window.isDestroyed()) continue;
+			const url = this.buildEntryUrl(baseUrl, entry);
+			promises.push(entry.window.loadURL(url));
+		}
+		await Promise.all(promises);
+	}
+}

--- a/packages/desktop/src/window-state.ts
+++ b/packages/desktop/src/window-state.ts
@@ -1,0 +1,173 @@
+/**
+ * Window state persistence — stores BrowserWindow position, size, and
+ * maximized state to userData so windows reopen in the same position.
+ *
+ * Multi-window format: `window-states.json` (array of PersistedWindowState).
+ * A one-time migration converts the legacy `window-state.json` on first read.
+ *
+ * Intentionally free of Electron imports so pure functions can be unit-tested.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export interface WindowState {
+	x: number | undefined;
+	y: number | undefined;
+	width: number;
+	height: number;
+	isMaximized: boolean;
+}
+
+export interface PersistedWindowState extends WindowState {
+	projectId: string | null;
+	lastViewedPath?: string | null;
+}
+
+const LEGACY_STATE_FILE = "window-state.json";
+const MULTI_STATE_FILE = "window-states.json";
+
+export function resolveWindowStatePath(userDataPath: string): string {
+	return path.join(userDataPath, LEGACY_STATE_FILE);
+}
+
+export function resolveMultiWindowStatePath(userDataPath: string): string {
+	return path.join(userDataPath, MULTI_STATE_FILE);
+}
+
+function parseWindowState(parsed: Record<string, unknown>): WindowState | undefined {
+	if (
+		typeof parsed.width !== "number" ||
+		typeof parsed.height !== "number" ||
+		typeof parsed.isMaximized !== "boolean"
+	) {
+		return undefined;
+	}
+	return {
+		x: typeof parsed.x === "number" ? parsed.x : undefined,
+		y: typeof parsed.y === "number" ? parsed.y : undefined,
+		width: parsed.width,
+		height: parsed.height,
+		isMaximized: parsed.isMaximized,
+	};
+}
+
+/**
+ * Whether a string is a sane `lastViewedPath` value to replay on the next
+ * launch by setting it as the pathname on the runtime origin.
+ *
+ * Must be defended at both save-time (so we don't write bad values) and
+ * load-time (so existing bad values from older builds auto-heal instead
+ * of stranding the user on a 404 "Not Found" screen they can't escape
+ * without deleting `window-states.json`).
+ *
+ * The specific footgun this guards against: `webContents.getURL()` on a
+ * window that was flipped to the local disconnected.html fallback returns
+ * a `file:///Users/.../disconnected.html` URL whose `.pathname` looks
+ * superficially like a normal "/…" pathname, but replaying it against
+ * `http://host:port` gets a 404.
+ *
+ * Rules: the pathname must start with `/`, must not look like an absolute
+ * filesystem path (`/Users/`, `/home/`, `/private/`, `/tmp/`, `/var/`,
+ * `/C:/`, etc.), and must not have a `.html` extension — the runtime's
+ * SPA never exposes `.html` routes to the user.
+ */
+export function isPersistableRuntimePath(pathname: string): boolean {
+	if (typeof pathname !== "string" || !pathname.startsWith("/")) return false;
+	if (pathname === "/") return false;
+	if (pathname.toLowerCase().endsWith(".html")) return false;
+	const absFsPrefixes = ["/Users/", "/home/", "/private/", "/tmp/", "/var/", "/opt/", "/Applications/"];
+	for (const prefix of absFsPrefixes) {
+		if (pathname.startsWith(prefix)) return false;
+	}
+	// Windows file URLs surface as `/C:/…`, `/D:/…`, etc.
+	if (/^\/[A-Za-z]:\//.test(pathname)) return false;
+	return true;
+}
+
+/**
+ * Extracts the pathname from a runtime URL if it's safe to persist or replay.
+ *
+ * Returns null unless the input is a real http(s) URL whose pathname passes
+ * {@link isPersistableRuntimePath}. Used by:
+ *   - window-registry's state-save path, to skip disconnected.html / file://
+ *     URLs that look valid but 404 when replayed against the runtime origin.
+ *   - app-menu's File → New Window handler, to inherit the source window's
+ *     path when it's safe to replay.
+ */
+export function extractPersistablePath(
+	currentUrl: string | undefined | null,
+): string | null {
+	if (!currentUrl) return null;
+	try {
+		const url = new URL(currentUrl);
+		const isHttp = url.protocol === "http:" || url.protocol === "https:";
+		if (isHttp && isPersistableRuntimePath(url.pathname)) {
+			return url.pathname;
+		}
+	} catch {
+		/* malformed URL */
+	}
+	return null;
+}
+
+function parsePersistedWindowState(raw: Record<string, unknown>): PersistedWindowState | undefined {
+	const base = parseWindowState(raw);
+	if (!base) return undefined;
+	const state: PersistedWindowState = {
+		...base,
+		projectId: typeof raw.projectId === "string" ? raw.projectId : null,
+	};
+	if (typeof raw.lastViewedPath === "string" && isPersistableRuntimePath(raw.lastViewedPath)) {
+		state.lastViewedPath = raw.lastViewedPath;
+	}
+	return state;
+}
+
+
+export function migrateWindowStateIfNeeded(userDataPath: string): boolean {
+	const legacyPath = resolveWindowStatePath(userDataPath);
+	const multiPath = resolveMultiWindowStatePath(userDataPath);
+	if (existsSync(multiPath)) return false;
+	if (!existsSync(legacyPath)) return false;
+	try {
+		const raw = readFileSync(legacyPath, "utf-8");
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		const state = parseWindowState(parsed);
+		if (!state) return false;
+		const persisted: PersistedWindowState = { ...state, projectId: null };
+		writeFileSync(multiPath, JSON.stringify([persisted], null, "\t"), "utf-8");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function loadAllWindowStates(userDataPath: string): PersistedWindowState[] {
+	migrateWindowStateIfNeeded(userDataPath);
+	const filePath = resolveMultiWindowStatePath(userDataPath);
+	if (!existsSync(filePath)) return [];
+	try {
+		const raw = readFileSync(filePath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		const results: PersistedWindowState[] = [];
+		for (const entry of parsed) {
+			if (typeof entry !== "object" || entry === null) continue;
+			const state = parsePersistedWindowState(entry as Record<string, unknown>);
+			if (state) results.push(state);
+		}
+		return results;
+	} catch {
+		return [];
+	}
+}
+
+export function saveAllWindowStates(userDataPath: string, states: PersistedWindowState[]): void {
+	try {
+		const filePath = resolveMultiWindowStatePath(userDataPath);
+		writeFileSync(filePath, JSON.stringify(states, null, "\t"), "utf-8");
+	} catch {
+		// Best-effort — don't crash if userData is read-only.
+	}
+}

--- a/packages/desktop/test/main.test.ts
+++ b/packages/desktop/test/main.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// before-quit shutdown safety
+//
+// Regression tests for the macOS quit bug where a "Quit Kanban" from the
+// app menu would leave an orphaned node process running because:
+//   1. main.ts's before-quit handler didn't await the runtime shutdown
+//      before calling app.quit().
+//   2. orchestrator.shutdown() didn't catch errors from the underlying
+//      manager.shutdown() and didn't always stop the power-save blocker.
+//
+// These are source-level structural assertions because the full quit flow
+// requires a real Electron app. If either layer changes shape, these tests
+// will catch it.
+// ---------------------------------------------------------------------------
+
+describe("before-quit shutdown safety", () => {
+	const mainSrc = readFileSync(
+		new URL("../src/main.ts", import.meta.url),
+		"utf-8",
+	);
+	const orchestratorSrc = readFileSync(
+		new URL("../src/runtime-orchestrator.ts", import.meta.url),
+		"utf-8",
+	);
+
+	/** Extracts a handler body by scanning for a marker line + brace balancing. */
+	function extractBlock(src: string, marker: string, label: string): string {
+		const lines = src.split("\n");
+		const startIdx = lines.findIndex((l) => l.includes(marker));
+		if (startIdx === -1) throw new Error(`${label} not found`);
+
+		let depth = 0;
+		let started = false;
+		const collected: string[] = [];
+		for (let i = startIdx; i < lines.length; i++) {
+			for (const ch of lines[i]) {
+				if (ch === "{") {
+					depth++;
+					started = true;
+				}
+				if (ch === "}") depth--;
+			}
+			collected.push(lines[i]);
+			if (started && depth === 0) break;
+		}
+		return collected.join("\n");
+	}
+
+	it("main.ts calls orchestrator.shutdown() then app.quit() after event.preventDefault()", () => {
+		const handler = extractBlock(
+			mainSrc,
+			'app.on("before-quit"',
+			"before-quit handler",
+		);
+
+		expect(handler).toContain("event.preventDefault()");
+		expect(handler).toContain("orchestrator.shutdown()");
+		expect(handler).toContain("app.quit()");
+
+		// Order within the preventDefault branch: preventDefault → shutdown → quit.
+		const preventIdx = handler.indexOf("event.preventDefault()");
+		const shutdownIdx = handler.indexOf("orchestrator.shutdown()", preventIdx);
+		const quitIdx = handler.indexOf("app.quit()", shutdownIdx);
+
+		expect(shutdownIdx).toBeGreaterThan(preventIdx);
+		expect(quitIdx).toBeGreaterThan(shutdownIdx);
+	});
+
+	it("orchestrator.shutdown() catches and logs manager.shutdown errors", () => {
+		const shutdownBody = extractBlock(
+			orchestratorSrc,
+			"async shutdown(): Promise<void>",
+			"RuntimeOrchestrator.shutdown",
+		);
+
+		// manager.shutdown() must be wrapped so it never rejects — either
+		// via try/catch or .catch(...). The log prefix lets grep-level
+		// triage pin down startup hangs immediately.
+		expect(shutdownBody).toContain("manager.shutdown()");
+		expect(shutdownBody).toMatch(/\.catch\(|try\s*\{/);
+		expect(shutdownBody).toContain("[desktop] Runtime shutdown error:");
+	});
+
+	it("orchestrator.shutdown() always stops the power-save blocker", () => {
+		const shutdownBody = extractBlock(
+			orchestratorSrc,
+			"async shutdown(): Promise<void>",
+			"RuntimeOrchestrator.shutdown",
+		);
+
+		// Called before manager.shutdown() so it runs even if there is no
+		// owned child — and always before any awaited work that could hang.
+		expect(shutdownBody).toContain("stopAppNapPrevention()");
+		const stopIdx = shutdownBody.indexOf("stopAppNapPrevention()");
+		const mgrIdx = shutdownBody.indexOf("manager.shutdown()");
+		expect(stopIdx).toBeGreaterThan(-1);
+		if (mgrIdx !== -1) expect(stopIdx).toBeLessThan(mgrIdx);
+	});
+});

--- a/packages/desktop/test/oauth-relay.test.ts
+++ b/packages/desktop/test/oauth-relay.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock Electron
+// ---------------------------------------------------------------------------
+
+const { showMessageBoxMock } = vi.hoisted(() => ({
+	showMessageBoxMock: vi.fn().mockResolvedValue({ response: 0 }),
+}));
+
+vi.mock("electron", () => ({
+	dialog: { showMessageBox: showMessageBoxMock },
+}));
+
+import { type OAuthRelayDeps, relayOAuthCallback } from "../src/oauth-relay.js";
+import type { BrowserWindow } from "electron";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeWindow(destroyed = false): BrowserWindow {
+	return { isDestroyed: () => destroyed } as unknown as BrowserWindow;
+}
+
+function makeDeps(overrides?: Partial<OAuthRelayDeps>): OAuthRelayDeps {
+	return {
+		fetch: overrides?.fetch ?? vi.fn().mockResolvedValue({ ok: true }),
+		getMainWindow: overrides?.getMainWindow ?? (() => fakeWindow()),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("relayOAuthCallback", () => {
+	beforeEach(() => { vi.clearAllMocks(); vi.useFakeTimers(); });
+	afterEach(() => { vi.useRealTimers(); });
+
+	it("succeeds on first attempt without retrying", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/cb", {
+			headers: { Authorization: "Bearer tok" },
+		});
+		expect(showMessageBoxMock).not.toHaveBeenCalled();
+	});
+
+	it("sends no Authorization header when token is null", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", null, deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/cb", {
+			headers: {},
+		});
+	});
+
+	it("retries on fetch failure and succeeds on second attempt", async () => {
+		const fetchMock = vi.fn()
+			.mockRejectedValueOnce(new Error("ECONNREFUSED"))
+			.mockResolvedValueOnce({ ok: true });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(showMessageBoxMock).not.toHaveBeenCalled();
+	});
+
+	it("retries on non-ok response and succeeds on second attempt", async () => {
+		const fetchMock = vi.fn()
+			.mockResolvedValueOnce({ ok: false, status: 503 })
+			.mockResolvedValueOnce({ ok: true });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(showMessageBoxMock).not.toHaveBeenCalled();
+	});
+
+	it("retries up to 2 times (3 total attempts) before exhausting", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("shows dialog after exhausting all retries", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const window = fakeWindow();
+		const deps = makeDeps({ fetch: fetchMock, getMainWindow: () => window });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+		expect(showMessageBoxMock).toHaveBeenCalledWith(window, {
+			type: "warning",
+			title: "OAuth Callback Failed",
+			message: "The authentication callback could not be delivered. Please try again.",
+			buttons: ["OK"],
+		});
+	});
+
+	it("shows dialog when all responses are non-ok", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not show dialog when mainWindow is null", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const deps = makeDeps({ fetch: fetchMock, getMainWindow: () => null });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(showMessageBoxMock).not.toHaveBeenCalled();
+	});
+
+	it("does not show dialog when mainWindow is destroyed", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const deps = makeDeps({ fetch: fetchMock, getMainWindow: () => fakeWindow(true) });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(showMessageBoxMock).not.toHaveBeenCalled();
+	});
+
+	it("respects custom retry count", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps, 0);
+		await vi.runAllTimersAsync();
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("delays 1 second between retry attempts", async () => {
+		const fetchMock = vi.fn()
+			.mockRejectedValueOnce(new Error("fail"))
+			.mockResolvedValueOnce({ ok: true });
+		const deps = makeDeps({ fetch: fetchMock });
+		const p = relayOAuthCallback("http://localhost:3000/cb", "tok", deps);
+		// After first failed attempt, second should not have been called yet
+		await vi.advanceTimersByTimeAsync(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		// Advance past the 1s delay
+		await vi.advanceTimersByTimeAsync(1_000);
+		await p;
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/desktop/test/protocol-handler.test.ts
+++ b/packages/desktop/test/protocol-handler.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	KANBAN_PROTOCOL,
+	OAUTH_CALLBACK_PATH,
+	type ElectronAppLike,
+	extractProtocolUrlFromArgv,
+	parseProtocolUrl,
+	registerProtocol,
+} from "../src/protocol-handler.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("Constants", () => {
+	it("KANBAN_PROTOCOL is 'kanban'", () => {
+		expect(KANBAN_PROTOCOL).toBe("kanban");
+	});
+
+	it("OAUTH_CALLBACK_PATH is '/oauth/callback'", () => {
+		expect(OAUTH_CALLBACK_PATH).toBe("/oauth/callback");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseProtocolUrl
+// ---------------------------------------------------------------------------
+
+describe("parseProtocolUrl", () => {
+	it("returns null for an invalid URL", () => {
+		expect(parseProtocolUrl("not a url")).toBeNull();
+	});
+
+	it("returns null for a non-kanban protocol", () => {
+		expect(parseProtocolUrl("https://example.com/oauth/callback")).toBeNull();
+	});
+
+	it("returns null for http:// URLs", () => {
+		expect(parseProtocolUrl("http://oauth/callback?code=abc")).toBeNull();
+	});
+
+	it("parses a basic kanban:// URL", () => {
+		const result = parseProtocolUrl("kanban://oauth/callback");
+		expect(result).not.toBeNull();
+		expect(result!.raw).toBe("kanban://oauth/callback");
+		expect(result!.pathname).toBe("/oauth/callback");
+		expect(result!.isOAuthCallback).toBe(true);
+	});
+
+	it("parses OAuth callback with code and state", () => {
+		const result = parseProtocolUrl(
+			"kanban://oauth/callback?code=auth-code-123&state=random-state",
+		);
+		expect(result).not.toBeNull();
+		expect(result!.isOAuthCallback).toBe(true);
+		expect(result!.oauth.code).toBe("auth-code-123");
+		expect(result!.oauth.state).toBe("random-state");
+		expect(result!.oauth.error).toBeNull();
+		expect(result!.oauth.errorDescription).toBeNull();
+	});
+
+	it("parses OAuth callback with error parameters", () => {
+		const result = parseProtocolUrl(
+			"kanban://oauth/callback?error=access_denied&error_description=User+denied+access",
+		);
+		expect(result).not.toBeNull();
+		expect(result!.isOAuthCallback).toBe(true);
+		expect(result!.oauth.code).toBeNull();
+		expect(result!.oauth.error).toBe("access_denied");
+		expect(result!.oauth.errorDescription).toBe("User denied access");
+	});
+
+	it("sets isOAuthCallback to false for non-callback paths", () => {
+		const result = parseProtocolUrl("kanban://settings/general");
+		expect(result).not.toBeNull();
+		expect(result!.pathname).toBe("/settings/general");
+		expect(result!.isOAuthCallback).toBe(false);
+	});
+
+	it("normalises the root path", () => {
+		const result = parseProtocolUrl("kanban://");
+		expect(result).not.toBeNull();
+		expect(result!.pathname).toBe("/");
+		expect(result!.isOAuthCallback).toBe(false);
+	});
+
+	it("preserves all search params in the searchParams map", () => {
+		const result = parseProtocolUrl(
+			"kanban://oauth/callback?code=c&state=s&extra=foo",
+		);
+		expect(result).not.toBeNull();
+		expect(result!.searchParams.get("code")).toBe("c");
+		expect(result!.searchParams.get("state")).toBe("s");
+		expect(result!.searchParams.get("extra")).toBe("foo");
+	});
+
+	it("handles trailing slash on the callback path", () => {
+		const result = parseProtocolUrl("kanban://oauth/callback/?code=123");
+		expect(result).not.toBeNull();
+		expect(result!.pathname).toBe("/oauth/callback");
+		expect(result!.isOAuthCallback).toBe(true);
+		expect(result!.oauth.code).toBe("123");
+	});
+
+	it("handles URL-encoded parameters", () => {
+		const result = parseProtocolUrl(
+			"kanban://oauth/callback?error_description=Something%20went%20wrong%21",
+		);
+		expect(result).not.toBeNull();
+		expect(result!.oauth.errorDescription).toBe("Something went wrong!");
+	});
+
+	it("returns all null oauth fields for a non-callback path", () => {
+		const result = parseProtocolUrl("kanban://other/path");
+		expect(result).not.toBeNull();
+		expect(result!.oauth.code).toBeNull();
+		expect(result!.oauth.state).toBeNull();
+		expect(result!.oauth.error).toBeNull();
+		expect(result!.oauth.errorDescription).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// registerProtocol
+// ---------------------------------------------------------------------------
+
+describe("registerProtocol", () => {
+	it("calls setAsDefaultProtocolClient when not already registered", () => {
+		const mockApp: ElectronAppLike = {
+			setAsDefaultProtocolClient: vi.fn().mockReturnValue(true),
+			isDefaultProtocolClient: vi.fn().mockReturnValue(false),
+		};
+
+		const result = registerProtocol(mockApp);
+
+		expect(mockApp.isDefaultProtocolClient).toHaveBeenCalledWith("kanban");
+		expect(mockApp.setAsDefaultProtocolClient).toHaveBeenCalledWith("kanban");
+		expect(result).toBe(true);
+	});
+
+	it("skips setAsDefaultProtocolClient when already registered", () => {
+		const mockApp: ElectronAppLike = {
+			setAsDefaultProtocolClient: vi.fn().mockReturnValue(true),
+			isDefaultProtocolClient: vi.fn().mockReturnValue(true),
+		};
+
+		const result = registerProtocol(mockApp);
+
+		expect(mockApp.isDefaultProtocolClient).toHaveBeenCalledWith("kanban");
+		expect(mockApp.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+		expect(result).toBe(true);
+	});
+
+	it("returns false when registration fails", () => {
+		const mockApp: ElectronAppLike = {
+			setAsDefaultProtocolClient: vi.fn().mockReturnValue(false),
+			isDefaultProtocolClient: vi.fn().mockReturnValue(false),
+		};
+
+		const result = registerProtocol(mockApp);
+
+		expect(result).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractProtocolUrlFromArgv
+// ---------------------------------------------------------------------------
+
+describe("extractProtocolUrlFromArgv", () => {
+	it("returns the kanban:// URL from argv", () => {
+		const argv = [
+			"/usr/bin/kanban",
+			"--some-flag",
+			"kanban://oauth/callback?code=abc",
+		];
+		expect(extractProtocolUrlFromArgv(argv)).toBe(
+			"kanban://oauth/callback?code=abc",
+		);
+	});
+
+	it("returns the first kanban:// URL if there are multiple", () => {
+		const argv = ["kanban://first", "kanban://second"];
+		expect(extractProtocolUrlFromArgv(argv)).toBe("kanban://first");
+	});
+
+	it("returns null when no kanban:// URL is present", () => {
+		const argv = ["/usr/bin/kanban", "--flag", "https://example.com"];
+		expect(extractProtocolUrlFromArgv(argv)).toBeNull();
+	});
+
+	it("returns null for an empty argv", () => {
+		expect(extractProtocolUrlFromArgv([])).toBeNull();
+	});
+
+	it("does not match kanban: without //", () => {
+		const argv = ["kanban:something"];
+		expect(extractProtocolUrlFromArgv(argv)).toBeNull();
+	});
+
+	it("does not match kanban:// when embedded in another argument", () => {
+		const argv = ["--url=kanban://foo"];
+		expect(extractProtocolUrlFromArgv(argv)).toBeNull();
+	});
+});
+

--- a/packages/desktop/test/runtime-orchestrator.test.ts
+++ b/packages/desktop/test/runtime-orchestrator.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Electron's powerSaveBlocker is touched by the orchestrator. It has no
+// value in these unit tests — just return a stub so the constructor and
+// lifecycle calls don't throw.
+vi.mock("electron", () => ({
+	powerSaveBlocker: {
+		start: vi.fn(() => 1),
+		stop: vi.fn(),
+	},
+}));
+
+// The child manager is imported but never exercised in these attached-mode
+// tests. Stub it out to avoid pulling in spawn/node-pty.
+vi.mock("../src/runtime-child.js", () => ({
+	RuntimeChildManager: class {
+		on() {
+			return this;
+		}
+		async start() {
+			return "http://127.0.0.1:3484";
+		}
+		async shutdown() {}
+		async dispose() {}
+	},
+}));
+
+const { RuntimeOrchestrator } = await import("../src/runtime-orchestrator.js");
+
+describe("RuntimeOrchestrator attached-runtime crash detection", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("emits 'crashed' when attached runtime fails probes past threshold", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		});
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 3,
+		});
+
+		const crashed = vi.fn();
+		orchestrator.on("crashed", crashed);
+
+		// Initial probe succeeds (before attaching).
+		await orchestrator.connect();
+		expect(orchestrator.getUrl()).toBe("http://127.0.0.1:3484");
+		expect(orchestrator.isOwned()).toBe(false);
+
+		// Simulate the external runtime dying.
+		healthy = false;
+
+		// Advance time, flushing each probe's async work between ticks.
+		for (let i = 0; i < 3; i += 1) {
+			await vi.advanceTimersByTimeAsync(100);
+		}
+
+		expect(crashed).toHaveBeenCalledTimes(1);
+		expect(orchestrator.getUrl()).toBeNull();
+	});
+
+	it("does not emit 'crashed' while attached runtime stays healthy", async () => {
+		const fetchImpl = vi.fn(
+			async () => ({ ok: true }) as Response,
+		) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+		});
+
+		const crashed = vi.fn();
+		orchestrator.on("crashed", crashed);
+
+		await orchestrator.connect();
+
+		for (let i = 0; i < 5; i += 1) {
+			await vi.advanceTimersByTimeAsync(100);
+		}
+
+		expect(crashed).not.toHaveBeenCalled();
+		expect(orchestrator.getUrl()).toBe("http://127.0.0.1:3484");
+	});
+
+	it("resets failure count after a transient probe failure recovers", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 3,
+		});
+
+		const crashed = vi.fn();
+		orchestrator.on("crashed", crashed);
+
+		await orchestrator.connect();
+
+		// Two failures, then recover, then two failures again — should NOT crash.
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+		healthy = true;
+		await vi.advanceTimersByTimeAsync(100);
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(crashed).not.toHaveBeenCalled();
+	});
+
+	it("stops probing after dispose()", async () => {
+		const fetchImpl = vi.fn(async () => ({ ok: true }) as Response);
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+		});
+
+		await orchestrator.connect();
+		const callsBeforeDispose = fetchImpl.mock.calls.length;
+
+		await orchestrator.dispose();
+
+		await vi.advanceTimersByTimeAsync(500);
+		// No additional probes after dispose.
+		expect(fetchImpl.mock.calls.length).toBe(callsBeforeDispose);
+	});
+
+	it("does not start probing when we own the child (post-restart)", async () => {
+		const fetchImpl = vi.fn(async () => ({ ok: true }) as Response);
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+		});
+
+		await orchestrator.connect();
+		// After connect() we're in attached mode; a restart flips us to owned.
+		await orchestrator.restart();
+		expect(orchestrator.isOwned()).toBe(true);
+
+		const crashed = vi.fn();
+		orchestrator.on("crashed", crashed);
+		const callsAfterRestart = fetchImpl.mock.calls.length;
+
+		await vi.advanceTimersByTimeAsync(500);
+
+		// Owned mode relies on child manager "crashed" events, not our
+		// probe. So no extra fetch calls.
+		expect(fetchImpl.mock.calls.length).toBe(callsAfterRestart);
+		expect(crashed).not.toHaveBeenCalled();
+	});
+});
+
+describe("RuntimeOrchestrator post-crash recovery probe", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("auto-reattaches when a runtime returns at the last-known origin", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+			recoveryProbeIntervalMs: 200,
+		});
+
+		const crashed = vi.fn();
+		const urlChanges: Array<string | null> = [];
+		orchestrator.on("crashed", crashed);
+		orchestrator.on("url-changed", (url) => urlChanges.push(url));
+
+		// Connect, then simulate the external runtime dying → crash path.
+		await orchestrator.connect();
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(crashed).toHaveBeenCalledTimes(1);
+		expect(orchestrator.getUrl()).toBeNull();
+
+		// While on the disconnected screen, the recovery probe is polling
+		// the last-known origin. Simulate the user running `kanban` in a
+		// terminal — runtime returns on the same origin.
+		healthy = true;
+
+		// Wait one recovery interval for the probe to notice.
+		await vi.advanceTimersByTimeAsync(200);
+
+		// Orchestrator should have auto-reattached without a second crash.
+		expect(orchestrator.getUrl()).toBe("http://127.0.0.1:3484");
+		expect(orchestrator.isOwned()).toBe(false);
+		expect(crashed).toHaveBeenCalledTimes(1);
+		// The shell's url-changed listener would now reload every window
+		// away from disconnected.html back to the runtime.
+		expect(urlChanges).toEqual([
+			"http://127.0.0.1:3484",
+			null,
+			"http://127.0.0.1:3484",
+		]);
+	});
+
+	it("keeps polling silently while the runtime stays down", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+			recoveryProbeIntervalMs: 200,
+		});
+
+		const crashed = vi.fn();
+		orchestrator.on("crashed", crashed);
+
+		await orchestrator.connect();
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(crashed).toHaveBeenCalledTimes(1);
+
+		// Runtime never comes back. Recovery probe should keep polling
+		// without re-emitting "crashed" and without accidentally flipping
+		// into a connected state.
+		for (let i = 0; i < 5; i += 1) {
+			await vi.advanceTimersByTimeAsync(200);
+		}
+
+		expect(crashed).toHaveBeenCalledTimes(1);
+		expect(orchestrator.getUrl()).toBeNull();
+	});
+
+	it("stops the recovery probe when the user clicks Restart", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+			recoveryProbeIntervalMs: 200,
+		});
+
+		await orchestrator.connect();
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(orchestrator.getUrl()).toBeNull();
+
+		// User clicks Restart while still down. The mocked child manager
+		// returns a fixed URL from start(), so restart() flips us into
+		// owned mode — recovery must stop.
+		await orchestrator.restart();
+		expect(orchestrator.isOwned()).toBe(true);
+
+		const callsAfterRestart = (fetchImpl as unknown as ReturnType<typeof vi.fn>)
+			.mock.calls.length;
+
+		// Advance well past several recovery intervals; no more probes.
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(
+			(fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
+		).toBe(callsAfterRestart);
+	});
+
+	it("stops the recovery probe after dispose()", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+			recoveryProbeIntervalMs: 200,
+		});
+
+		await orchestrator.connect();
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+
+		const callsBeforeDispose = (
+			fetchImpl as unknown as ReturnType<typeof vi.fn>
+		).mock.calls.length;
+
+		await orchestrator.dispose();
+
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(
+			(fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
+		).toBe(callsBeforeDispose);
+	});
+
+	it("does not start recovery when recoveryProbeIntervalMs is 0", async () => {
+		let healthy = true;
+		const fetchImpl = vi.fn(async () => {
+			return healthy
+				? ({ ok: true } as Response)
+				: Promise.reject(new Error("ECONNREFUSED"));
+		}) as unknown as typeof fetch;
+
+		const orchestrator = new RuntimeOrchestrator({
+			host: "127.0.0.1",
+			port: 3484,
+			healthTimeoutMs: 500,
+			resolveCliShimPath: () => "/unused",
+			fetchImpl,
+			attachedProbeIntervalMs: 100,
+			attachedProbeFailureThreshold: 2,
+			recoveryProbeIntervalMs: 0,
+		});
+
+		await orchestrator.connect();
+		healthy = false;
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(100);
+		expect(orchestrator.getUrl()).toBeNull();
+
+		const callsAfterCrash = (
+			fetchImpl as unknown as ReturnType<typeof vi.fn>
+		).mock.calls.length;
+
+		// Bring the runtime back — with recovery disabled, nothing watches.
+		healthy = true;
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(
+			(fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length,
+		).toBe(callsAfterCrash);
+		expect(orchestrator.getUrl()).toBeNull();
+	});
+});

--- a/packages/desktop/test/window-registry.test.ts
+++ b/packages/desktop/test/window-registry.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => {
+	class MockBrowserWindow {
+		static instances: MockBrowserWindow[] = [];
+		static nextId = 1;
+
+		static getFocusedWindow(): MockBrowserWindow | null {
+			return null;
+		}
+
+		static resetMock(): void {
+			MockBrowserWindow.instances = [];
+			MockBrowserWindow.nextId = 1;
+		}
+
+		id: number;
+		private readonly _listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+		private _destroyed = false;
+		private _visible = true;
+
+		webContents = {
+			on: vi.fn(),
+			setWindowOpenHandler: vi.fn(),
+		};
+
+		constructor() {
+			this.id = MockBrowserWindow.nextId++;
+			MockBrowserWindow.instances.push(this);
+		}
+
+		on(event: string, handler: (...args: unknown[]) => void): void {
+			const handlers = this._listeners.get(event) ?? [];
+			handlers.push(handler);
+			this._listeners.set(event, handlers);
+		}
+
+		once(event: string, handler: (...args: unknown[]) => void): void {
+			this.on(event, handler);
+		}
+
+		simulateClose(): boolean {
+			const event = {
+				defaultPrevented: false,
+				preventDefault() {
+					this.defaultPrevented = true;
+				},
+			};
+			for (const handler of this._listeners.get("close") ?? []) {
+				handler(event);
+			}
+			if (!event.defaultPrevented) {
+				this._destroyed = true;
+				this._visible = false;
+				for (const handler of this._listeners.get("closed") ?? []) {
+					handler();
+				}
+			}
+			return event.defaultPrevented;
+		}
+
+		hide(): void {
+			this._visible = false;
+		}
+
+		show(): void {
+			this._visible = true;
+		}
+
+		isVisible(): boolean {
+			return this._visible;
+		}
+
+		isDestroyed(): boolean {
+			return this._destroyed;
+		}
+
+		maximize(): void {}
+		isMaximized(): boolean {
+			return false;
+		}
+		getTitle(): string {
+			return "Kanban";
+		}
+		getBounds(): { x: number; y: number; width: number; height: number } {
+			return { x: 0, y: 0, width: 1400, height: 900 };
+		}
+		getNormalBounds(): { x: number; y: number; width: number; height: number } {
+			return this.getBounds();
+		}
+		isMinimized(): boolean {
+			return false;
+		}
+		restore(): void {}
+		focus(): void {}
+		setTitle(): void {}
+	}
+
+	return {
+		BrowserWindow: MockBrowserWindow,
+		shell: { openExternal: vi.fn() },
+	};
+});
+
+import { BrowserWindow } from "electron";
+import { WindowRegistry } from "../src/window-registry.js";
+
+interface MockWindow {
+	simulateClose(): boolean;
+	hide(): void;
+	show(): void;
+	isVisible(): boolean;
+	isDestroyed(): boolean;
+}
+
+const DEFAULT_OPTIONS = {
+	preloadPath: "/tmp/preload.js",
+	isPackaged: false,
+};
+
+beforeEach(() => {
+	const Mock = BrowserWindow as unknown as { resetMock(): void };
+	Mock.resetMock();
+});
+
+function withDarwin<T>(fn: () => T): T {
+	const original = process.platform;
+	Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+	try {
+		return fn();
+	} finally {
+		Object.defineProperty(process, "platform", { value: original, configurable: true });
+	}
+}
+
+describe("WindowRegistry.buildWindowUrl", () => {
+	it("returns base URL unchanged when projectId is null", () => {
+		expect(WindowRegistry.buildWindowUrl("http://localhost:52341", null)).toBe(
+			"http://localhost:52341",
+		);
+	});
+
+	it("encodes projectId as the URL pathname", () => {
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341", "project-abc");
+		expect(url).toBe("http://localhost:52341/project-abc");
+	});
+
+	it("overwrites any existing path in the base URL", () => {
+		// The path is the project; any pre-existing path on the base URL
+		// is irrelevant and gets replaced.
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341/some/path", "proj-1");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/proj-1");
+	});
+
+	it("preserves existing query parameters", () => {
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341/?token=abc", "proj-2");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/proj-2");
+		expect(parsed.searchParams.get("token")).toBe("abc");
+	});
+
+	it("URL-encodes projectIds containing slashes or whitespace", () => {
+		// Matches the web-ui's buildProjectPathname encoding so that
+		// parseProjectIdFromPathname round-trips the value back via
+		// decodeURIComponent on the first path segment.
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341", "/Users/john/my project");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/%2FUsers%2Fjohn%2Fmy%20project");
+		expect(decodeURIComponent(parsed.pathname.slice(1))).toBe("/Users/john/my project");
+	});
+
+	it("returns base URL unchanged when projectId is empty string", () => {
+		expect(WindowRegistry.buildWindowUrl("http://localhost:52341", "")).toBe(
+			"http://localhost:52341",
+		);
+	});
+});
+
+describe("WindowRegistry.loadPersistedWindows", () => {
+	it("returns empty array for non-existent directory", () => {
+		const states = WindowRegistry.loadPersistedWindows("/tmp/non-existent-dir-" + Date.now());
+		expect(states).toEqual([]);
+	});
+});
+
+describe("WindowRegistry macOS close behavior", () => {
+	const macOptions = { ...DEFAULT_OPTIONS, hideOnCloseForMac: true, isQuitting: () => false };
+
+	it("hides the last visible window on macOS close", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({ ...macOptions, projectId: null });
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(true);
+			expect(registry.size).toBe(1);
+		});
+	});
+
+	it("destroys a non-last window on macOS close", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			registry.createWindow({ ...macOptions, projectId: null });
+			const win2 = registry.createWindow({ ...macOptions, projectId: "project-abc" });
+			expect(registry.size).toBe(2);
+			const prevented = (win2 as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(false);
+			expect(registry.size).toBe(1);
+			expect((win2 as unknown as MockWindow).isDestroyed()).toBe(true);
+		});
+	});
+
+	it("hides the last window even if it is a project window", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({ ...macOptions, projectId: "project-abc" });
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(true);
+			expect(registry.size).toBe(1);
+		});
+	});
+
+	it("always closes when quitting", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({
+				...macOptions,
+				projectId: null,
+				isQuitting: () => true,
+			});
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(false);
+			expect(registry.size).toBe(0);
+		});
+	});
+});
+
+describe("WindowRegistry visibility helpers", () => {
+	it("getVisible() excludes hidden windows", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		(win1 as unknown as MockWindow).hide();
+		const visible = registry.getVisible();
+		expect(visible.length).toBe(1);
+		expect(visible[0].projectId).toBe("project-a");
+	});
+
+	it("countVisibleWindows() returns correct count", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-b" });
+		expect(registry.countVisibleWindows()).toBe(3);
+		(win1 as unknown as MockWindow).hide();
+		expect(registry.countVisibleWindows()).toBe(2);
+	});
+});
+
+describe("WindowRegistry multi-window creation", () => {
+	it("allows duplicate project windows (same projectId)", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+
+	it("allows multiple overview windows (projectId null)", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+
+	it("allows different project windows", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-b" });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+});

--- a/packages/desktop/test/window-registry.test.ts
+++ b/packages/desktop/test/window-registry.test.ts
@@ -18,15 +18,55 @@ vi.mock("electron", () => {
 		private readonly _listeners = new Map<string, Array<(...args: unknown[]) => void>>();
 		private _destroyed = false;
 		private _visible = true;
+		// Driven directly by tests — represents what Electron would return
+		// from `webContents.getURL()` in the real app. Starts empty because
+		// a freshly-created BrowserWindow has not yet loaded a document.
+		private _currentUrl = "";
+
+		// Record listeners so simulate* helpers can invoke them later. A
+		// plain `vi.fn()` would accept the registration but leave us no
+		// way to trigger the callback in assertions.
+		private readonly _webContentsListeners = new Map<
+			string,
+			Array<(...args: unknown[]) => void>
+		>();
 
 		webContents = {
-			on: vi.fn(),
+			on: (event: string, handler: (...args: unknown[]) => void): void => {
+				const handlers = this._webContentsListeners.get(event) ?? [];
+				handlers.push(handler);
+				this._webContentsListeners.set(event, handlers);
+			},
 			setWindowOpenHandler: vi.fn(),
+			getURL: (): string => this._currentUrl,
 		};
 
 		constructor() {
 			this.id = MockBrowserWindow.nextId++;
 			MockBrowserWindow.instances.push(this);
+		}
+
+		/** Test helper — mirror what `loadURL()` would do in the real app. */
+		_setCurrentUrl(url: string): void {
+			this._currentUrl = url;
+		}
+
+		/**
+		 * Fire the `will-navigate` handlers that production code registered
+		 * via `window.webContents.on("will-navigate", …)`.
+		 * Returns whether the synthetic event was prevented.
+		 */
+		simulateWillNavigate(url: string): boolean {
+			const event = {
+				defaultPrevented: false,
+				preventDefault() {
+					this.defaultPrevented = true;
+				},
+			};
+			for (const handler of this._webContentsListeners.get("will-navigate") ?? []) {
+				handler(event, url);
+			}
+			return event.defaultPrevented;
 		}
 
 		on(event: string, handler: (...args: unknown[]) => void): void {
@@ -111,6 +151,8 @@ interface MockWindow {
 	show(): void;
 	isVisible(): boolean;
 	isDestroyed(): boolean;
+	_setCurrentUrl(url: string): void;
+	simulateWillNavigate(url: string): boolean;
 }
 
 const DEFAULT_OPTIONS = {
@@ -254,6 +296,96 @@ describe("WindowRegistry visibility helpers", () => {
 		expect(registry.countVisibleWindows()).toBe(3);
 		(win1 as unknown as MockWindow).hide();
 		expect(registry.countVisibleWindows()).toBe(2);
+	});
+});
+
+describe("WindowRegistry will-navigate origin guard", () => {
+	// The will-navigate handler is the last-line security defence against
+	// a compromised renderer escaping the runtime origin. The guard derives
+	// the trusted origin from `webContents.getURL()` at event time (not
+	// from a value captured at window creation) so that startup windows —
+	// which have no URL until after loadURL() resolves — still enforce the
+	// correct origin once loading completes.
+
+	const RUNTIME_ORIGIN = "http://localhost:52341";
+
+	function makeLoadedWindow(currentUrl: string) {
+		const registry = new WindowRegistry();
+		const window = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		(window as unknown as MockWindow)._setCurrentUrl(currentUrl);
+		return window as unknown as MockWindow;
+	}
+
+	it("allows same-origin navigation", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate(`${RUNTIME_ORIGIN}/project-b/task-1`);
+		expect(prevented).toBe(false);
+	});
+
+	it("allows same-origin navigation when only the path/query differs", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate(
+			`${RUNTIME_ORIGIN}/project-a?foo=bar#section`,
+		);
+		expect(prevented).toBe(false);
+	});
+
+	it("blocks cross-origin HTTP navigation", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("http://evil.example.com/pwn");
+		expect(prevented).toBe(true);
+	});
+
+	it("blocks cross-origin navigation even to the same host on a different port", () => {
+		// Origin is scheme + host + port, so 52341 vs 3000 must be treated
+		// as different origins — a port-scan pivot from a compromised
+		// renderer would otherwise be allowed.
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("http://localhost:3000/");
+		expect(prevented).toBe(true);
+	});
+
+	it("blocks navigation to non-http schemes", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		for (const url of [
+			"file:///etc/passwd",
+			"javascript:alert(1)",
+			"data:text/html,<script>alert(1)</script>",
+		]) {
+			expect(window.simulateWillNavigate(url)).toBe(true);
+		}
+	});
+
+	it("blocks navigation when the target URL is malformed", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("not a url :::");
+		expect(prevented).toBe(true);
+	});
+
+	it("is a no-op while the window has not yet loaded a URL", () => {
+		// Startup windows construct before the runtime URL is known; the
+		// disconnected screen is loaded via loadFile in that case. Guarding
+		// before the first load would either stall the initial navigation
+		// or force us to bake in an assumed trusted origin, both of which
+		// are worse than trusting Electron's internal flow for the first
+		// load. Production code relies on this behaviour — lock it in.
+		const registry = new WindowRegistry();
+		const window = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		const prevented = (window as unknown as MockWindow).simulateWillNavigate(
+			"http://evil.example.com/",
+		);
+		expect(prevented).toBe(false);
+	});
+
+	it("picks up the new trusted origin after the URL changes (e.g. restart)", () => {
+		// Restarting the runtime can move it to a different ephemeral port;
+		// the guard must reflect the window's _current_ URL, not the origin
+		// it had at creation time.
+		const window = makeLoadedWindow("http://localhost:52341/project-a");
+		expect(window.simulateWillNavigate("http://localhost:52341/other")).toBe(false);
+		window._setCurrentUrl("http://localhost:40000/project-a");
+		expect(window.simulateWillNavigate("http://localhost:40000/other")).toBe(false);
+		expect(window.simulateWillNavigate("http://localhost:52341/other")).toBe(true);
 	});
 });
 

--- a/packages/desktop/test/window-state.test.ts
+++ b/packages/desktop/test/window-state.test.ts
@@ -1,0 +1,545 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	type PersistedWindowState,
+	type WindowState,
+	extractPersistablePath,
+	isPersistableRuntimePath,
+	loadAllWindowStates,
+	migrateWindowStateIfNeeded,
+	resolveMultiWindowStatePath,
+	resolveWindowStatePath,
+	saveAllWindowStates,
+} from "../src/window-state.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function freshTmpDir(): string {
+	const dir = path.join(
+		import.meta.dirname,
+		".tmp-window-state-test",
+		String(Date.now()) + "-" + String(Math.random()).slice(2, 8),
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+const SAMPLE_LEGACY_STATE: WindowState = {
+	x: 100,
+	y: 200,
+	width: 1400,
+	height: 900,
+	isMaximized: false,
+};
+
+const SAMPLE_PERSISTED_STATES: PersistedWindowState[] = [
+	{
+		x: 100,
+		y: 200,
+		width: 1400,
+		height: 900,
+		isMaximized: false,
+		projectId: null,
+	},
+	{
+		x: 500,
+		y: 300,
+		width: 1200,
+		height: 800,
+		isMaximized: true,
+		projectId: "project-abc",
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	tmpDir = freshTmpDir();
+});
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+describe("migrateWindowStateIfNeeded", () => {
+	it("returns false when neither file exists", () => {
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(false);
+	});
+
+	it("returns false when new file already exists", () => {
+		// Write both files — migration should be skipped.
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify(SAMPLE_LEGACY_STATE),
+			"utf-8",
+		);
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify([]),
+			"utf-8",
+		);
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(false);
+	});
+
+	it("migrates legacy file into a one-element array", () => {
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify(SAMPLE_LEGACY_STATE),
+			"utf-8",
+		);
+
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(true);
+
+		// New file should exist now.
+		const multiPath = resolveMultiWindowStatePath(tmpDir);
+		expect(existsSync(multiPath)).toBe(true);
+
+		const contents = JSON.parse(
+			readFileSync(multiPath, "utf-8"),
+		) as PersistedWindowState[];
+		expect(contents).toHaveLength(1);
+		expect(contents[0]).toEqual({
+			...SAMPLE_LEGACY_STATE,
+			projectId: null,
+		});
+	});
+
+	it("returns false for a legacy file with invalid shape", () => {
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify({ broken: true }),
+			"utf-8",
+		);
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(false);
+	});
+
+	it("is idempotent — second call is a no-op", () => {
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify(SAMPLE_LEGACY_STATE),
+			"utf-8",
+		);
+
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(true);
+		expect(migrateWindowStateIfNeeded(tmpDir)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Multi-window persistence
+// ---------------------------------------------------------------------------
+
+describe("saveAllWindowStates / loadAllWindowStates", () => {
+	it("returns empty array when no file exists", () => {
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("round-trips multiple window states", () => {
+		saveAllWindowStates(tmpDir, SAMPLE_PERSISTED_STATES);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toEqual(SAMPLE_PERSISTED_STATES);
+	});
+
+	it("round-trips an empty array", () => {
+		saveAllWindowStates(tmpDir, []);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toEqual([]);
+	});
+
+	it("preserves projectId: null for overview windows", () => {
+		const states: PersistedWindowState[] = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false, projectId: null },
+		];
+		saveAllWindowStates(tmpDir, states);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].projectId).toBeNull();
+	});
+
+	it("preserves projectId strings", () => {
+		const states: PersistedWindowState[] = [
+			{
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "my-project-id",
+			},
+		];
+		saveAllWindowStates(tmpDir, states);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].projectId).toBe("my-project-id");
+	});
+
+	it("returns empty array for corrupt JSON", () => {
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			"not valid json",
+			"utf-8",
+		);
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("returns empty array when file contains a non-array JSON value", () => {
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify({ x: 0 }),
+			"utf-8",
+		);
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("skips invalid entries in the array", () => {
+		const raw = [
+			SAMPLE_PERSISTED_STATES[0],
+			"not an object",
+			null,
+			{ broken: true },
+			SAMPLE_PERSISTED_STATES[1],
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(2);
+		expect(loaded[0]).toEqual(SAMPLE_PERSISTED_STATES[0]);
+		expect(loaded[1]).toEqual(SAMPLE_PERSISTED_STATES[1]);
+	});
+
+	it("treats missing projectId as null", () => {
+		const raw = [
+			{ x: 10, y: 20, width: 800, height: 600, isMaximized: false },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].projectId).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadAllWindowStates migration integration
+// ---------------------------------------------------------------------------
+
+describe("loadAllWindowStates with automatic migration", () => {
+	it("migrates legacy file on first load and returns states", () => {
+		// Only the legacy file exists.
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify(SAMPLE_LEGACY_STATE),
+			"utf-8",
+		);
+
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0]).toEqual({
+			...SAMPLE_LEGACY_STATE,
+			projectId: null,
+		});
+
+		// The new file should now exist on disk.
+		expect(existsSync(resolveMultiWindowStatePath(tmpDir))).toBe(true);
+	});
+
+	it("does not re-migrate if multi file already exists", () => {
+		// Write legacy state with one position.
+		writeFileSync(
+			resolveWindowStatePath(tmpDir),
+			JSON.stringify(SAMPLE_LEGACY_STATE),
+			"utf-8",
+		);
+
+		// Write multi file with different data — should be respected over legacy.
+		saveAllWindowStates(tmpDir, SAMPLE_PERSISTED_STATES);
+
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toEqual(SAMPLE_PERSISTED_STATES);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+	it("handles x/y as undefined when not present in persisted data", () => {
+		const raw = [
+			{ width: 800, height: 600, isMaximized: false, projectId: null },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].x).toBeUndefined();
+		expect(loaded[0].y).toBeUndefined();
+	});
+
+	it("handles x/y as undefined when they are non-numeric", () => {
+		const raw = [
+			{
+				x: "not a number",
+				y: true,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "proj-1",
+			},
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].x).toBeUndefined();
+		expect(loaded[0].y).toBeUndefined();
+	});
+
+	it("treats numeric projectId as null (only strings are valid)", () => {
+		const raw = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false, projectId: 42 },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].projectId).toBeNull();
+	});
+
+	it("preserves duplicate projectId entries (multiple windows per project)", () => {
+		const raw = [
+			{ x: 10, y: 20, width: 800, height: 600, isMaximized: false, projectId: "proj-a" },
+			{ x: 30, y: 40, width: 900, height: 700, isMaximized: true, projectId: "proj-a" },
+			{ x: 50, y: 60, width: 1000, height: 800, isMaximized: false, projectId: "proj-b" },
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(3);
+		expect(loaded[0].x).toBe(10);
+		expect(loaded[1].x).toBe(30);
+		expect(loaded[2].projectId).toBe("proj-b");
+	});
+
+	it("preserves multiple overview windows (projectId null)", () => {
+		const raw = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false },
+			{ x: 100, y: 100, width: 900, height: 700, isMaximized: true },
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(2);
+		expect(loaded[0].x).toBe(0);
+		expect(loaded[1].x).toBe(100);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// lastViewedPath validation — guards against the "Not Found" footgun where
+// a file:// URL's pathname gets replayed on the runtime origin.
+// ---------------------------------------------------------------------------
+
+describe("isPersistableRuntimePath", () => {
+	it.each([
+		["/my-project", true],
+		["/my-project/tasks/abc-123", true],
+		["/workspace%2Fabc", true],
+		["/a/b/c/d", true],
+	])("accepts legitimate runtime path %s", (input, expected) => {
+		expect(isPersistableRuntimePath(input)).toBe(expected);
+	});
+
+	it.each([
+		// file:// URLs from disconnected.html fallback — the original bug.
+		"/Users/someone/main/kanban-desktop/packages/desktop/out/mac-arm64/Kanban.app/Contents/Resources/app.asar/dist/disconnected.html",
+		"/Users/johnchoi1/Library/whatever.html",
+		"/private/var/folders/x/y/z/Kanban.app/Contents/disconnected.html",
+		"/tmp/disconnected.html",
+		"/home/user/kanban/disconnected.html",
+		"/var/folders/abc/disconnected.html",
+		"/opt/kanban/disconnected.html",
+		"/Applications/Kanban.app/Contents/Resources/disconnected.html",
+		// Windows file URL pathnames.
+		"/C:/Users/someone/disconnected.html",
+		"/D:/temp/file.html",
+		// Any .html pathname — the runtime SPA never exposes those.
+		"/index.html",
+		"/some/deep/page.html",
+		// Degenerate inputs.
+		"/",
+		"",
+		"relative/path",
+	])("rejects %s", (input) => {
+		expect(isPersistableRuntimePath(input)).toBe(false);
+	});
+});
+
+describe("loadAllWindowStates heals stale file:// lastViewedPath", () => {
+	it("drops a disconnected.html lastViewedPath from existing on-disk state", () => {
+		// This mirrors the exact shape written by an older build when the
+		// window had been flipped to the local disconnected.html fallback
+		// and then the app was quit. On the next launch, without this
+		// validation, the window would navigate to
+		// http://127.0.0.1:3484/Users/.../disconnected.html → 404.
+		const raw = [
+			{
+				x: 100,
+				y: 200,
+				width: 1400,
+				height: 900,
+				isMaximized: false,
+				projectId: null,
+				lastViewedPath:
+					"/Users/alice/main/kanban-desktop/packages/desktop/out/mac-arm64/Kanban.app/Contents/Resources/app.asar/dist/disconnected.html",
+			},
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].lastViewedPath).toBeUndefined();
+	});
+
+	it("preserves a legitimate lastViewedPath like /<projectId>", () => {
+		const raw = [
+			{
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "proj-a",
+				lastViewedPath: "/proj-a/tasks/task-1",
+			},
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].lastViewedPath).toBe("/proj-a/tasks/task-1");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractPersistablePath — URL-to-pathname helper shared by window-registry's
+// state-save path and app-menu's File → New Window handler.
+//
+// The key defensive case: when a window shows the local `disconnected.html`
+// fallback, its URL is a `file://` URL whose pathname looks like
+// `/Users/.../disconnected.html`. Replaying that pathname against the
+// runtime origin would strand the window on a 404.
+// ---------------------------------------------------------------------------
+
+describe("extractPersistablePath", () => {
+	// ── Happy path ────────────────────────────────────────────────────
+
+	it("returns the pathname for a normal http runtime URL", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/my-project")).toBe(
+			"/my-project",
+		);
+	});
+
+	it("returns the pathname for a normal https runtime URL", () => {
+		expect(extractPersistablePath("https://example.com/project/task-42")).toBe(
+			"/project/task-42",
+		);
+	});
+
+	it("preserves multi-segment pathnames", () => {
+		expect(
+			extractPersistablePath("http://localhost:3484/team/alpha/task/123"),
+		).toBe("/team/alpha/task/123");
+	});
+
+	// ── Guards against the disconnected.html footgun ──────────────────
+
+	it("returns null for a file:// URL pointing at a disconnected.html fallback", () => {
+		const url =
+			"file:///Users/dev/Library/Application%20Support/Kanban/disconnected.html";
+		expect(extractPersistablePath(url)).toBeNull();
+	});
+
+	it("returns null for a file:// URL pointing at a /home/ path (Linux)", () => {
+		const url = "file:///home/dev/.config/Kanban/disconnected.html";
+		expect(extractPersistablePath(url)).toBeNull();
+	});
+
+	it("returns null for any file:// URL regardless of path", () => {
+		expect(extractPersistablePath("file:///tmp/something")).toBeNull();
+	});
+
+	// ── Other defensive cases ─────────────────────────────────────────
+
+	it("returns null for the root pathname (no useful route to inherit)", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/")).toBeNull();
+	});
+
+	it("returns null for about:blank", () => {
+		expect(extractPersistablePath("about:blank")).toBeNull();
+	});
+
+	it("returns null for a pathname ending in .html", () => {
+		expect(
+			extractPersistablePath("http://127.0.0.1:3484/foo.html"),
+		).toBeNull();
+	});
+
+	it("returns null for a Windows-style file URL (/C:/…)", () => {
+		expect(
+			extractPersistablePath("http://127.0.0.1:3484/C:/Users/dev/app"),
+		).toBeNull();
+	});
+
+	it("returns null for a malformed URL", () => {
+		expect(extractPersistablePath("not a url")).toBeNull();
+	});
+
+	it("returns null for undefined input", () => {
+		expect(extractPersistablePath(undefined)).toBeNull();
+	});
+
+	it("returns null for null input", () => {
+		expect(extractPersistablePath(null)).toBeNull();
+	});
+
+	it("returns null for empty string input", () => {
+		expect(extractPersistablePath("")).toBeNull();
+	});
+
+	// ── Query strings and fragments are ignored (not part of pathname) ──
+
+	it("strips query strings (not part of the pathname)", () => {
+		expect(
+			extractPersistablePath("http://127.0.0.1:3484/project?foo=bar"),
+		).toBe("/project");
+	});
+
+	it("strips fragments (not part of the pathname)", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/project#top")).toBe(
+			"/project",
+		);
+	});
+});
+


### PR DESCRIPTION
Part 4 of the desktop split. Stacked on the PR for `pr/desktop-5-preflight`.

The Electron main process wiring that sits on top of the runtime subprocess (#4) and preflight (#5):

**Windows & state**
- `window-registry.ts`: multi-window tracking with focus/close lifecycle
- `window-state.ts`: per-window state persistence (bounds, last viewed path, display affinity)
- `window-factory.ts`: creates BrowserWindows from persisted state

**Deep links & OAuth**
- `protocol-handler.ts`: `kanban://` scheme, URL parsing, focus-existing-window dispatch
- `oauth-relay.ts`: `kanban-oauth://` callback handling

**Runtime orchestration** (`runtime-orchestrator.ts`)
- At boot, probes `http://127.0.0.1:3484/`. If a runtime answers → *attached mode*; else spawn one ourselves via `RuntimeChildManager` (#4) → *owned mode*
- Attached mode runs a ~1s-worst-case health probe (configurable interval + failure threshold with a reset-on-recovery window). On crash, emits `crashed` so the main process can swap to the native disconnected screen
- Owned mode relies on the child manager's `crashed` event — no redundant probing
- `disconnected.html`: native Electron page with two recovery paths (restart runtime, retry connect)

**Fixes bundled in**
- Probe `/` instead of `/api/health` (the runtime's health route is different)
- Clear stale `file://` `lastViewedPath` so disconnect→quit→relaunch can't strand the window on a 404

Tests: 170 unit tests total, including 5 new tests for the attached-runtime crash detection (transient-failure reset, dispose stops probing, owned-mode doesn't probe, etc).
