### PR TITLE
Reraise signals and don't handle `SIGQUIT`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -586,6 +586,9 @@ async function runMainCommand(options: CliOptions, shouldAutoOpenBrowser: boolea
 		exit: (code) => {
 			process.exit(code);
 		},
+		reraiseSignal: (signal) => {
+			process.kill(process.pid, signal);
+		},
 		onShutdown: async () => {
 			shutdownIndicator.start();
 			try {

--- a/src/core/graceful-shutdown.ts
+++ b/src/core/graceful-shutdown.ts
@@ -47,7 +47,7 @@ it lands inside the duplicate window. In practice that is much less harmful than
 the old behavior, where a single Ctrl+C under `npx` or `cline --kanban` could be
 misread as a double interrupt and force exit immediately.
 */
-const DEFAULT_HANDLED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"] as const;
+const DEFAULT_HANDLED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 const DEFAULT_DUPLICATE_SIGNAL_WINDOW_MS = 750;
 const TRANSIENT_CLI_CACHE_PATH_MARKERS = [
 	"/.npm/_npx/",
@@ -74,6 +74,7 @@ interface GracefulShutdownOptions {
 	onTimeout?: (delayMs: number) => void;
 	process: GracefulShutdownProcess;
 	exit: (code: number) => void;
+	reraiseSignal?: (signal: HandledShutdownSignal) => void;
 	suppressImmediateDuplicateSignals?: boolean;
 	duplicateSignalWindowMs?: number;
 	now?: () => number;
@@ -85,8 +86,6 @@ export function getExitCodeForSignal(signal: HandledShutdownSignal | null): numb
 			return 129;
 		case "SIGINT":
 			return 130;
-		case "SIGQUIT":
-			return 131;
 		case "SIGTERM":
 			return 143;
 		default:
@@ -151,6 +150,10 @@ export function installGracefulShutdownHandlers(options: GracefulShutdownOptions
 		if (timeoutId !== null) {
 			clearTimeout(timeoutId);
 			timeoutId = null;
+		}
+		if (shutdownSignal && options.reraiseSignal) {
+			options.reraiseSignal(shutdownSignal);
+			return;
 		}
 		options.exit(code);
 	};

--- a/test/runtime/graceful-shutdown.test.ts
+++ b/test/runtime/graceful-shutdown.test.ts
@@ -78,6 +78,35 @@ describe("installGracefulShutdownHandlers", () => {
 		expect(exit).toHaveBeenCalledWith(130);
 	});
 
+	it("calls reraiseSignal instead of exit when provided and shutdown was signal-triggered", async () => {
+		vi.useFakeTimers();
+
+		const processDouble = createProcessDouble();
+		const exit = vi.fn();
+		const reraiseSignal = vi.fn();
+		const deferred = createDeferredPromise();
+
+		installGracefulShutdownHandlers({
+			process: processDouble,
+			delayMs: 10_000,
+			exit,
+			reraiseSignal,
+			onShutdown: async () => {
+				await deferred.promise;
+			},
+		});
+
+		processDouble.emitSignal("SIGINT");
+
+		deferred.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(reraiseSignal).toHaveBeenCalledTimes(1);
+		expect(reraiseSignal).toHaveBeenCalledWith("SIGINT");
+		expect(exit).not.toHaveBeenCalled();
+	});
+
 	it("still force-exits on a later second Ctrl+C", () => {
 		vi.useFakeTimers();
 
@@ -145,7 +174,6 @@ describe("getExitCodeForSignal", () => {
 	it("maps handled shutdown signals to shell-standard exit codes", () => {
 		expect(getExitCodeForSignal("SIGHUP")).toBe(129);
 		expect(getExitCodeForSignal("SIGINT")).toBe(130);
-		expect(getExitCodeForSignal("SIGQUIT")).toBe(131);
 		expect(getExitCodeForSignal("SIGTERM")).toBe(143);
 	});
 });


### PR DESCRIPTION
I've experienced infinite reloads when running tsx `--watch`. This PR:
- Reraises signals so that the `watch` process is stopped when stopping kanban.
- Removes the `SIGQUIT` handler, so that node can handle it appropriately: `quit` and core dump.