### PR TITLE
fix(cline-sdk): adapt to @clinebot/core 0.0.35+ API drift

### DIFF
--- a/src/cline-sdk/cline-session-runtime.ts
+++ b/src/cline-sdk/cline-session-runtime.ts
@@ -231,9 +231,9 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 				initialMessages: request.initialMessages,
 				interactive: true,
 				userImages: toSdkUserImages(request.images),
-				localRuntime: request.userInstructionWatcher
-					? { userInstructionWatcher: request.userInstructionWatcher }
-					: undefined,
+				// SDK 0.0.35+ flattened `localRuntime.userInstructionWatcher`
+				// onto the top-level StartSessionInput.
+				userInstructionWatcher: request.userInstructionWatcher,
 				requestToolApproval: request.requestToolApproval,
 			});
 		} catch (error) {

--- a/src/cline-sdk/sdk-runtime-boundary.ts
+++ b/src/cline-sdk/sdk-runtime-boundary.ts
@@ -7,15 +7,15 @@ import {
 	type BasicLogger,
 	buildWorkspaceMetadata,
 	ClineCore,
-	type ClineCoreStartInput,
 	createUserInstructionConfigWatcher,
 	getClineDefaultSystemPrompt,
 	listAvailableRuntimeCommandsFromWatcher,
 	loadRulesForSystemPromptFromWatcher,
 	resolveClineDataDir,
 	resolveRuntimeSlashCommandFromWatcher,
-	type SessionHistoryRecord,
 	type SessionHost,
+	type SessionRecord,
+	type StartSessionInput,
 	type ToolApprovalRequest,
 	type ToolApprovalResult,
 	type UserInstructionConfigWatcher,
@@ -219,8 +219,11 @@ export type ClineSdkSessionEvent =
 			};
 	  };
 
-export type ClineSdkStartSessionInput = ClineCoreStartInput;
-export type ClineSdkSessionRecord = SessionHistoryRecord;
+// Upstream SDK (@clinebot/core) renamed these types during the 0.0.35+
+// drift. We re-export under the stable Kanban aliases so downstream code
+// doesn't have to chase SDK rename churn.
+export type ClineSdkStartSessionInput = StartSessionInput;
+export type ClineSdkSessionRecord = SessionRecord;
 export type ClineSdkPersistedMessage = Llms.MessageWithMetadata;
 export type ClineSdkUserInstructionWatcher = UserInstructionConfigWatcher;
 export interface ClineSdkSlashCommand {
@@ -298,11 +301,8 @@ export async function resolveClineSdkSystemPrompt(input: {
 	// its repo-aware behavior in the same way the official CLI does.
 	const shouldAppendWorkspaceMetadata = input.providerId === "cline";
 	const workspaceMetadata = shouldAppendWorkspaceMetadata ? await buildWorkspaceMetadata(input.cwd) : "";
-	return getClineDefaultSystemPrompt({
-		ide: "Kanban",
-		rootPath: input.cwd,
-		providerId: input.providerId,
-		metadata: workspaceMetadata,
-		rules: input.rules ?? "",
-	});
+	// SDK switched from object-param to positional args; signature is
+	// `(ide, cwd, providerId, metadata?, rules?, platform?)`. See
+	// node_modules/@clinebot/core/dist/prompt/default-system.d.ts.
+	return getClineDefaultSystemPrompt("Kanban", input.cwd, input.providerId, workspaceMetadata, input.rules ?? "");
 }


### PR DESCRIPTION
Upstream SDK renamed two exported types and flattened one nested field, leaving `main` red at `tsc --noEmit` and cascading into **32 failures** in `test/runtime/cline-sdk/cline-task-session-service.test.ts`.

## The drift

| Old | New |
|---|---|
| `ClineCoreStartInput` | `StartSessionInput` |
| `SessionHistoryRecord` | `SessionRecord` |
| `getClineDefaultSystemPrompt({ide, rootPath, …})` | positional `(ide, cwd, providerId, metadata?, rules?, platform?)` |
| `StartSessionInput.localRuntime.userInstructionWatcher` | top-level `userInstructionWatcher` |

Kanban-side alias names (`ClineSdkStartSessionInput`, `ClineSdkSessionRecord`) are preserved so **no downstream refactor is needed**.

## Why now

Per AGENTS.md:
> NEVER remove or downgrade code to fix type errors from outdated dependencies. Upgrade the dependency instead.

This adapts our side of the boundary to the already-installed SDK version.

## Verification

- Root typecheck: **clean**
- Root test suite: **504/536 → 536/536**
- Desktop workspace suite: untouched (40/40)
- Pre-commit hook: passes

## Impact on the desktop PR stack

PRs #370-#373 have been silently inheriting this broken base. Unblocks CI for the entire stack.