### PR TITLE
Fetch LiteLLM models from the configured proxy URL

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -21,6 +21,7 @@ import type {
 	RuntimeClineReasoningEffort,
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
+import { fetchOpenAiCompatibleModelsFromBaseUrl } from "./provider-model-discovery";
 import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
@@ -94,6 +95,11 @@ export interface UpdateCustomClineProviderInput {
 	defaultModelId?: string | null;
 	modelsSourceUrl?: string | null;
 	capabilities?: SdkCustomProviderCapability[];
+}
+
+interface ProviderModelsRequestOverrides {
+	baseUrl?: string | null;
+	apiKey?: string | null;
 }
 
 function toErrorMessage(error: unknown): string {
@@ -784,8 +790,28 @@ export function createClineProviderService() {
 			};
 		},
 
-		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
+		async getProviderModels(
+			providerId: string,
+			overrides: ProviderModelsRequestOverrides = {},
+		): Promise<RuntimeClineProviderModelsResponse> {
 			const normalizedProviderId = providerId.trim().toLowerCase();
+			const savedProviderSettings =
+				normalizedProviderId.length > 0 ? getSdkProviderSettings(normalizedProviderId) : null;
+			if (normalizedProviderId === "litellm") {
+				const baseUrl = overrides.baseUrl?.trim() || savedProviderSettings?.baseUrl?.trim() || "";
+				if (baseUrl.length > 0) {
+					const liveModels = await fetchOpenAiCompatibleModelsFromBaseUrl({
+						baseUrl,
+						apiKey: overrides.apiKey?.trim() || resolveVisibleApiKey(savedProviderSettings),
+					}).catch(() => []);
+					if (liveModels.length > 0) {
+						return {
+							providerId: normalizedProviderId,
+							models: liveModels,
+						};
+					}
+				}
+			}
 			const providerModels =
 				normalizedProviderId.length > 0
 					? await listSdkProviderModels(normalizedProviderId)
@@ -801,7 +827,7 @@ export function createClineProviderService() {
 				};
 			}
 
-			const configuredModel = getSdkProviderSettings(normalizedProviderId)?.model?.trim() ?? "";
+			const configuredModel = savedProviderSettings?.model?.trim() ?? "";
 			if (configuredModel.length > 0) {
 				return {
 					providerId: normalizedProviderId || providerId,

--- a/src/cline-sdk/provider-model-discovery.ts
+++ b/src/cline-sdk/provider-model-discovery.ts
@@ -1,0 +1,203 @@
+import type { RuntimeClineProviderModel } from "../core/api-contract";
+
+const DEFAULT_MODEL_DISCOVERY_TIMEOUT_MS = 5_000;
+
+interface NormalizedModelCandidate {
+	id?: unknown;
+	name?: unknown;
+	supportsVision?: unknown;
+	supportsAttachments?: unknown;
+	supportsReasoning?: unknown;
+	supportsReasoningEffort?: unknown;
+}
+
+function ensureTrailingSlash(value: string): string {
+	return value.endsWith("/") ? value : `${value}/`;
+}
+
+function toOptionalBoolean(value: unknown): boolean | undefined {
+	return value === true ? true : undefined;
+}
+
+function normalizeModel(value: unknown): RuntimeClineProviderModel | null {
+	if (typeof value === "string") {
+		const id = value.trim();
+		if (!id) {
+			return null;
+		}
+		return {
+			id,
+			name: id,
+		};
+	}
+	if (!value || typeof value !== "object") {
+		return null;
+	}
+
+	const candidate = value as NormalizedModelCandidate;
+	const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+	if (!id) {
+		return null;
+	}
+
+	const supportsReasoningEffort =
+		toOptionalBoolean(candidate.supportsReasoningEffort) ?? toOptionalBoolean(candidate.supportsReasoning);
+
+	return {
+		id,
+		name: typeof candidate.name === "string" && candidate.name.trim().length > 0 ? candidate.name.trim() : id,
+		...(toOptionalBoolean(candidate.supportsVision) ? { supportsVision: true } : {}),
+		...(toOptionalBoolean(candidate.supportsAttachments) ? { supportsAttachments: true } : {}),
+		...(supportsReasoningEffort ? { supportsReasoningEffort: true } : {}),
+	};
+}
+
+function collectModelsFromList(value: unknown, models: Map<string, RuntimeClineProviderModel>): boolean {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	let added = false;
+	for (const item of value) {
+		const model = normalizeModel(item);
+		if (!model) {
+			continue;
+		}
+		models.set(model.id, model);
+		added = true;
+	}
+	return added;
+}
+
+function collectModelsFromObjectKeys(value: unknown, models: Map<string, RuntimeClineProviderModel>): boolean {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return false;
+	}
+
+	const ids = Object.keys(value)
+		.map((id) => id.trim())
+		.filter((id) => id.length > 0);
+	if (ids.length === 0) {
+		return false;
+	}
+
+	for (const id of ids) {
+		models.set(id, {
+			id,
+			name: id,
+		});
+	}
+	return true;
+}
+
+function extractModelsFromPayload(payload: unknown): RuntimeClineProviderModel[] {
+	const models = new Map<string, RuntimeClineProviderModel>();
+	if (collectModelsFromList(payload, models)) {
+		return [...models.values()];
+	}
+	if (!payload || typeof payload !== "object") {
+		return [];
+	}
+
+	const root = payload as {
+		data?: unknown;
+		models?: unknown;
+		providers?: Record<string, unknown>;
+	};
+
+	if (collectModelsFromList(root.data, models) || collectModelsFromList(root.models, models)) {
+		return [...models.values()];
+	}
+	if (collectModelsFromObjectKeys(root.models, models)) {
+		return [...models.values()];
+	}
+
+	if (root.providers && typeof root.providers === "object") {
+		for (const scopedValue of Object.values(root.providers)) {
+			if (collectModelsFromList(scopedValue, models)) {
+				return [...models.values()];
+			}
+			if (!scopedValue || typeof scopedValue !== "object") {
+				continue;
+			}
+			const scopedObject = scopedValue as { models?: unknown };
+			if (
+				collectModelsFromList(scopedObject.models, models) ||
+				collectModelsFromObjectKeys(scopedObject.models, models)
+			) {
+				return [...models.values()];
+			}
+		}
+	}
+
+	return [...models.values()];
+}
+
+function buildModelDiscoveryUrls(baseUrl: string): string[] {
+	const trimmedBaseUrl = baseUrl.trim();
+	if (!trimmedBaseUrl) {
+		return [];
+	}
+
+	const urls = new Set<string>();
+	const normalizedBaseUrl = ensureTrailingSlash(trimmedBaseUrl);
+	urls.add(new URL("models", normalizedBaseUrl).toString());
+
+	const parsedBaseUrl = new URL(trimmedBaseUrl);
+	const normalizedPath = parsedBaseUrl.pathname.replace(/\/+$/, "");
+	if (!normalizedPath.endsWith("/v1")) {
+		const withV1 = new URL(parsedBaseUrl.toString());
+		withV1.pathname = normalizedPath.length > 0 ? `${normalizedPath}/v1/models` : "/v1/models";
+		withV1.search = "";
+		withV1.hash = "";
+		urls.add(withV1.toString());
+	}
+
+	return [...urls];
+}
+
+export async function fetchOpenAiCompatibleModelsFromBaseUrl(input: {
+	baseUrl: string;
+	apiKey?: string | null;
+	timeoutMs?: number;
+}): Promise<RuntimeClineProviderModel[]> {
+	const urls = buildModelDiscoveryUrls(input.baseUrl);
+	if (urls.length === 0) {
+		return [];
+	}
+
+	const headers = new Headers({
+		Accept: "application/json",
+	});
+	const trimmedApiKey = input.apiKey?.trim() ?? "";
+	if (trimmedApiKey.length > 0) {
+		headers.set("Authorization", `Bearer ${trimmedApiKey}`);
+	}
+
+	let lastError: Error | null = null;
+	for (const url of urls) {
+		try {
+			const response = await fetch(url, {
+				method: "GET",
+				headers,
+				signal: AbortSignal.timeout(input.timeoutMs ?? DEFAULT_MODEL_DISCOVERY_TIMEOUT_MS),
+			});
+			if (!response.ok) {
+				throw new Error(`Model discovery failed for ${url}: HTTP ${response.status}`);
+			}
+
+			const payload = (await response.json()) as unknown;
+			const models = extractModelsFromPayload(payload);
+			if (models.length > 0) {
+				return models.sort((left, right) => left.name.localeCompare(right.name));
+			}
+		} catch (error) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+		}
+	}
+
+	if (lastError) {
+		throw lastError;
+	}
+	return [];
+}

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -683,6 +683,8 @@ export type RuntimeClineProviderCatalogResponse = z.infer<typeof runtimeClinePro
 
 export const runtimeClineProviderModelsRequestSchema = z.object({
 	providerId: z.string(),
+	baseUrl: z.string().nullable().optional(),
+	apiKey: z.string().nullable().optional(),
 });
 export type RuntimeClineProviderModelsRequest = z.infer<typeof runtimeClineProviderModelsRequestSchema>;
 

--- a/src/core/api-validation.ts
+++ b/src/core/api-validation.ts
@@ -328,6 +328,8 @@ export function parseClineProviderModelsRequest(value: unknown): RuntimeClinePro
 	}
 	return {
 		providerId,
+		baseUrl: parsed.baseUrl?.trim() || null,
+		apiKey: parsed.apiKey?.trim() || null,
 	};
 }
 

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -525,7 +525,10 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		},
 		getClineProviderModels: async (_workspaceScope, input) => {
 			const body = parseClineProviderModelsRequest(input);
-			return await clineProviderService.getProviderModels(body.providerId);
+			return await clineProviderService.getProviderModels(body.providerId, {
+				baseUrl: body.baseUrl,
+				apiKey: body.apiKey,
+			});
 		},
 		getClineMcpAuthStatuses: async (_workspaceScope) => {
 			const statuses = await clineMcpRuntimeService.getAuthStatuses();

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -356,6 +356,7 @@ describe("createRuntimeApi startTaskSession", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllGlobals();
 		restoreEnvVar("CLINE_API_KEY", originalClineApiKey);
 		restoreEnvVar("OCA_API_KEY", originalOcaApiKey);
 		if (originalClineMcpSettingsPath === undefined) {
@@ -1849,6 +1850,67 @@ describe("createRuntimeApi startTaskSession", () => {
 					id: "openrouter/free",
 					name: "OpenRouter Free",
 					supportsReasoningEffort: true,
+				},
+			],
+		});
+	});
+
+	it("loads LiteLLM provider models from the configured base URL before falling back to the static registry", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				data: [{ id: "openrouter/openai/gpt-4o-mini" }, { id: "openai/gpt-5" }],
+			}),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const api = createRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => ({}) as never),
+			getScopedClineTaskSessionService: vi.fn(async () => createClineTaskSessionServiceMock() as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+		setSelectedProviderSettings({
+			provider: "litellm",
+			model: "gpt-5.4",
+			apiKey: "litellm-proxy-key",
+			baseUrl: "http://127.0.0.1:4000/v1",
+		});
+		localProviderMocks.getLocalProviderModels.mockResolvedValue({
+			providerId: "litellm",
+			models: [{ id: "gpt-5.4", name: "GPT-5.4" }],
+		});
+
+		const response = await api.getClineProviderModels(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ providerId: "litellm" },
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:4000/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				signal: expect.any(AbortSignal),
+			}),
+		);
+		const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(requestInit.headers).toBeInstanceOf(Headers);
+		expect((requestInit.headers as Headers).get("Authorization")).toBe("Bearer litellm-proxy-key");
+		expect(localProviderMocks.getLocalProviderModels).not.toHaveBeenCalled();
+		expect(response).toEqual({
+			providerId: "litellm",
+			models: [
+				{
+					id: "openai/gpt-5",
+					name: "openai/gpt-5",
+				},
+				{
+					id: "openrouter/openai/gpt-4o-mini",
+					name: "openrouter/openai/gpt-4o-mini",
 				},
 			],
 		});

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
@@ -748,6 +748,76 @@ describe("useRuntimeSettingsClineController", () => {
 		});
 	});
 
+	it("refreshes LiteLLM models after saving the configured proxy base URL", async () => {
+		const config = createRuntimeConfigResponse({
+			providerId: "litellm",
+			oauthProvider: null,
+			modelId: "gpt-5.4",
+			baseUrl: "http://localhost:4000/v1",
+			apiKeyConfigured: false,
+		});
+		let latestSnapshot: HookSnapshot | null = null;
+		fetchClineProviderModelsMock
+			.mockResolvedValueOnce([
+				{
+					id: "gpt-5.4",
+					name: "GPT-5.4",
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					id: "openrouter/openai/gpt-4o-mini",
+					name: "openrouter/openai/gpt-4o-mini",
+				},
+			]);
+		saveClineProviderSettingsMock.mockResolvedValue({
+			providerId: "litellm",
+			modelId: "openrouter/openai/gpt-4o-mini",
+			baseUrl: "http://127.0.0.1:4000/v1",
+			reasoningEffort: null,
+			apiKeyConfigured: true,
+			oauthProvider: null,
+			oauthAccessTokenConfigured: false,
+			oauthRefreshTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					open={true}
+					workspaceId="workspace-1"
+					selectedAgentId="cline"
+					config={config}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			requireSnapshot(latestSnapshot).setBaseUrl("http://127.0.0.1:4000/v1");
+			requireSnapshot(latestSnapshot).setApiKey("litellm-proxy-key");
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			expect(await requireSnapshot(latestSnapshot).saveProviderSettings()).toEqual({ ok: true });
+		});
+
+		expect(fetchClineProviderModelsMock).toHaveBeenLastCalledWith("workspace-1", "litellm", {
+			baseUrl: "http://127.0.0.1:4000/v1",
+			apiKey: "litellm-proxy-key",
+		});
+		expect(requireSnapshot(latestSnapshot).modelId).toBe("openrouter/openai/gpt-4o-mini");
+		expect(requireSnapshot(latestSnapshot).providerModelIds).toEqual(["openrouter/openai/gpt-4o-mini"]);
+		expect(requireSnapshot(latestSnapshot).apiKey).toBe("");
+		expect(requireSnapshot(latestSnapshot).apiKeyConfigured).toBe(true);
+	});
+
 	it("adds a custom provider and refreshes catalog and models", async () => {
 		const config = createRuntimeConfigResponse({
 			providerId: "cline",

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
@@ -545,12 +545,24 @@ export function useRuntimeSettingsClineController(
 					...(nextAws !== undefined ? { aws: nextAws } : {}),
 					...(nextGcp !== undefined ? { gcp: nextGcp } : {}),
 				});
-				setProviderId(savedSettings.providerId ?? savedSettings.oauthProvider ?? trimmedProviderId);
+				const nextProviderId = savedSettings.providerId ?? savedSettings.oauthProvider ?? trimmedProviderId;
+				setProviderId(nextProviderId);
 				setModelId(savedSettings.modelId ?? "");
 				setApiKey("");
 				setBaseUrl(savedSettings.baseUrl ?? "");
 				setReasoningEffort(savedSettings.reasoningEffort ?? "");
 				setProviderSettingsOverride(savedSettings);
+				setIsLoadingProviderModels(true);
+				try {
+					setProviderModels(
+						await fetchClineProviderModels(workspaceId, nextProviderId, {
+							baseUrl: savedSettings.baseUrl ?? trimmedBaseUrl,
+							...(trimmedApiKey !== undefined ? { apiKey: trimmedApiKey } : {}),
+						}),
+					);
+				} finally {
+					setIsLoadingProviderModels(false);
+				}
 				return { ok: true };
 			} catch (error) {
 				return {

--- a/web-ui/src/runtime/runtime-config-query.ts
+++ b/web-ui/src/runtime/runtime-config-query.ts
@@ -146,9 +146,17 @@ export async function fetchFeaturebaseToken(workspaceId: string | null): Promise
 export async function fetchClineProviderModels(
 	workspaceId: string | null,
 	providerId: string,
+	overrides?: {
+		baseUrl?: string | null;
+		apiKey?: string | null;
+	},
 ): Promise<RuntimeClineProviderModel[]> {
 	const trpcClient = getRuntimeTrpcClient(workspaceId);
-	const response = await trpcClient.runtime.getClineProviderModels.query({ providerId });
+	const response = await trpcClient.runtime.getClineProviderModels.query({
+		providerId,
+		...(overrides?.baseUrl !== undefined ? { baseUrl: overrides.baseUrl } : {}),
+		...(overrides?.apiKey !== undefined ? { apiKey: overrides.apiKey } : {}),
+	});
 	return response.models;
 }
 


### PR DESCRIPTION
## Summary
- fetch built-in LiteLLM models from the configured proxy base URL instead of the static SDK default
- allow the settings flow to pass the current LiteLLM base URL and proxy API key through model discovery
- refresh the LiteLLM model list immediately after saving settings and cover the behavior in runtime and web tests

## Verification
- `npm run typecheck`
- `npm run test -- test/runtime/trpc/runtime-api.test.ts`
- `npm --prefix web-ui run test -- src/hooks/use-runtime-settings-cline-controller.test.tsx`