### PR TITLE
[4a/5] feat(desktop): window management primitives

### DIFF
--- a/packages/desktop/build/bin/kanban
+++ b/packages/desktop/build/bin/kanban
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Kanban CLI shim — bundled with the desktop app.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOURCES_DIR="$(dirname "$SCRIPT_DIR")"
+CLI_ENTRY="$RESOURCES_DIR/app.asar.unpacked/cli/cli.js"
+
+if [ ! -f "$CLI_ENTRY" ]; then
+  echo "error: Kanban CLI not found at $CLI_ENTRY" >&2
+  exit 1
+fi
+
+exec node "$CLI_ENTRY" "$@"

--- a/packages/desktop/build/bin/kanban-dev
+++ b/packages/desktop/build/bin/kanban-dev
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Dev-mode CLI shim. Resolves the repo-root `dist/cli.js` so `npm run dev`
+# spawns in-tree sources instead of the packaged app.asar layout.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DESKTOP_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+REPO_ROOT="$(dirname "$(dirname "$DESKTOP_ROOT")")"
+CLI_ENTRY="$REPO_ROOT/dist/cli.js"
+
+if [ ! -f "$CLI_ENTRY" ]; then
+  echo "error: Kanban CLI not found at $CLI_ENTRY" >&2
+  echo "hint: Run 'npm run build' at the repo root first" >&2
+  exit 1
+fi
+
+exec node "$CLI_ENTRY" "$@"

--- a/packages/desktop/build/bin/kanban-dev.cmd
+++ b/packages/desktop/build/bin/kanban-dev.cmd
@@ -1,0 +1,24 @@
+@echo off
+REM Windows counterpart to `kanban-dev`. Resolves the repo-root CLI so
+REM `npm run dev` on Windows can spawn the in-tree sources instead of the
+REM packaged app.asar layout.
+
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\..\..\.." >nul
+set "REPO_ROOT=%CD%"
+popd >nul
+
+set "CLI_ENTRY=%REPO_ROOT%\dist\cli.js"
+
+if not exist "%CLI_ENTRY%" (
+  echo error: Kanban CLI not found at %CLI_ENTRY% >&2
+  echo hint: Run 'npm run build' at the repo root first >&2
+  endlocal
+  exit /b 1
+)
+
+node "%CLI_ENTRY%" %*
+set "NODE_EXIT=%ERRORLEVEL%"
+endlocal & exit /b %NODE_EXIT%

--- a/packages/desktop/build/bin/kanban.cmd
+++ b/packages/desktop/build/bin/kanban.cmd
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "RESOURCES_DIR=%SCRIPT_DIR%.."
+set "CLI_ENTRY=%RESOURCES_DIR%\app.asar.unpacked\cli\cli.js"
+
+if not exist "%CLI_ENTRY%" (
+  echo error: Kanban CLI not found at %CLI_ENTRY% >&2
+  endlocal
+  exit /b 1
+)
+
+node "%CLI_ENTRY%" %*
+set "NODE_EXIT=%ERRORLEVEL%"
+endlocal & exit /b %NODE_EXIT%

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -9,8 +9,31 @@
 			"version": "0.0.1",
 			"devDependencies": {
 				"@types/node": "^22.10.5",
+				"electron": "^33.4.0",
 				"typescript": "^5.9.3",
 				"vitest": "^4.1.0"
+			}
+		},
+		"node_modules/@electron/get": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -339,10 +362,36 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
@@ -353,6 +402,19 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -374,12 +436,50 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "22.19.17",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -489,6 +589,54 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/boolean": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"dev": true,
@@ -497,10 +645,118 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decompress-response/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
@@ -510,10 +766,111 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/electron": {
+			"version": "33.4.11",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+			"integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/get": "^2.0.0",
+				"@types/node": "^20.9.0",
+				"extract-zip": "^2.0.1"
+			},
+			"bin": {
+				"electron": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.20.55"
+			}
+		},
+		"node_modules/electron/node_modules/@types/node": {
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
@@ -531,6 +888,52 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"dev": true,
@@ -541,6 +944,190 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/global-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"es6-error": "^4.1.1",
+				"matcher": "^3.0.0",
+				"roarr": "^2.15.3",
+				"semver": "^7.3.2",
+				"serialize-error": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			}
+		},
+		"node_modules/global-agent/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -800,6 +1387,16 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"dev": true,
@@ -807,6 +1404,37 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
+		},
+		"node_modules/matcher": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"escape-string-regexp": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -825,6 +1453,30 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"dev": true,
@@ -834,8 +1486,35 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -871,6 +1550,79 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/roarr": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"dependencies": {
+				"boolean": "^3.0.1",
+				"detect-node": "^2.0.4",
+				"globalthis": "^1.0.1",
+				"json-stringify-safe": "^5.0.1",
+				"semver-compare": "^1.0.0",
+				"sprintf-js": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.15",
 			"dev": true,
@@ -903,6 +1655,41 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
 			}
 		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"dev": true,
@@ -916,6 +1703,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"dev": true,
@@ -925,6 +1720,19 @@
 			"version": "4.1.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/sumchecker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -997,6 +1805,20 @@
 			"license": "0BSD",
 			"optional": true
 		},
+		"node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"dev": true,
@@ -1013,6 +1835,16 @@
 			"version": "6.21.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/vite": {
 			"version": "8.0.8",
@@ -1213,6 +2045,24 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		}
 	}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,6 +10,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.5",
+		"electron": "^33.4.0",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.0"
 	}

--- a/packages/desktop/src/disconnected.html
+++ b/packages/desktop/src/disconnected.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Kanban — Runtime Disconnected</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #1F2428;
+    color: #E6EDF3;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    -webkit-app-region: drag;
+  }
+  /* Allow users to copy URLs and error text into bug reports. */
+  h1, .lead, .option-title, .option-body, code {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+  .container {
+    max-width: 520px;
+    padding: 40px;
+    text-align: center;
+  }
+  .icon {
+    font-size: 48px;
+    margin-bottom: 20px;
+    opacity: 0.6;
+  }
+  h1 {
+    font-size: 22px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    color: #E6EDF3;
+  }
+  .lead {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #8B949E;
+    margin-bottom: 28px;
+  }
+  .options {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    text-align: left;
+  }
+  .option {
+    background: #24292E;
+    border: 1px solid #30363D;
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-app-region: no-drag;
+  }
+  .option-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #E6EDF3;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .option-title .num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    background: #0084FF;
+    color: #fff;
+    border-radius: 50%;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .option-body {
+    font-size: 13px;
+    line-height: 1.55;
+    color: #8B949E;
+    margin-bottom: 12px;
+  }
+  button {
+    background: #0084FF;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 18px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+    -webkit-app-region: no-drag;
+    user-select: none;
+  }
+  button:hover { background: #339DFF; }
+  button:active { background: #006ACC; }
+  code {
+    background: #2D3339;
+    border: 1px solid #30363D;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-family: "SF Mono", "Fira Code", Menlo, monospace;
+    font-size: 12.5px;
+    color: #E6EDF3;
+    user-select: text;
+  }
+</style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">⚡</div>
+    <h1>Runtime Disconnected</h1>
+    <p class="lead">
+      The Kanban runtime process is no longer running.
+      Recover using either of these options:
+    </p>
+    <div class="options">
+      <div class="option">
+        <div class="option-title">
+          <span class="num">1</span>
+          Restart the runtime from the desktop app
+        </div>
+        <div class="option-body">
+          Spawn a new child runtime managed by this window.
+        </div>
+        <button id="restart-btn">Restart</button>
+      </div>
+      <div class="option">
+        <div class="option-title">
+          <span class="num">2</span>
+          Start the runtime from your terminal
+        </div>
+        <div class="option-body">
+          Run <code>kanban</code> in any terminal.
+          The desktop app will automatically attach to it.
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    document.getElementById("restart-btn").addEventListener("click", function () {
+      if (window.desktop && window.desktop.restartRuntime) {
+        window.desktop.restartRuntime();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,0 +1,17 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+const desktopApi = {
+	platform: process.platform,
+
+	openProjectWindow(projectId: string): void {
+		ipcRenderer.send("open-project-window", projectId);
+	},
+
+	restartRuntime(): void {
+		ipcRenderer.send("restart-runtime");
+	},
+} as const;
+
+contextBridge.exposeInMainWorld("desktop", desktopApi);
+
+export type DesktopApi = typeof desktopApi;

--- a/packages/desktop/src/window-factory.ts
+++ b/packages/desktop/src/window-factory.ts
@@ -1,0 +1,188 @@
+import { dialog, type BrowserWindow } from "electron";
+
+import { WindowRegistry } from "./window-registry.js";
+import {
+	type PersistedWindowState,
+	isPersistableRuntimePath,
+} from "./window-state.js";
+
+export interface RuntimeOrchestratorLike {
+	getUrl(): string | null;
+	defaultOrigin(): string;
+	checkHealth(origin: string): Promise<boolean>;
+}
+
+// Electron emits -3 (ERR_ABORTED) on navigations superseded by another load —
+// those are expected flow events, not real failures.
+const ERR_ABORTED = -3;
+
+export interface WindowFactoryOptions {
+	preloadPath: string;
+	isPackaged: boolean;
+	backgroundColor: string;
+	disconnectedHtmlPath: string;
+	registry: WindowRegistry;
+	orchestrator: RuntimeOrchestratorLike;
+	isQuitting: () => boolean;
+	onMenuDirty: () => void;
+}
+
+export interface CreateWindowOptions {
+	projectId?: string | null;
+	initialPath?: string | null;
+	savedState?: PersistedWindowState;
+}
+
+export class WindowFactory {
+	constructor(private readonly opts: WindowFactoryOptions) {}
+
+	create(options: CreateWindowOptions = {}): BrowserWindow {
+		const window = this.opts.registry.createWindow({
+			projectId: options.projectId ?? null,
+			savedState: options.savedState,
+			preloadPath: this.opts.preloadPath,
+			isPackaged: this.opts.isPackaged,
+			backgroundColor: this.opts.backgroundColor,
+			runtimeUrl: this.opts.orchestrator.getUrl() ?? undefined,
+			hideOnCloseForMac: true,
+			isQuitting: this.opts.isQuitting,
+			onWindowClosed: this.opts.onMenuDirty,
+			onWindowFocused: this.opts.onMenuDirty,
+		});
+
+		this.attachRendererRecovery(window);
+
+		const runtimeUrl = this.opts.orchestrator.getUrl();
+		if (runtimeUrl) {
+			const url = buildWindowUrl(runtimeUrl, options);
+			window.loadURL(url).catch((err: unknown) => {
+				console.error(
+					"[desktop] Failed to load URL in window:",
+					err instanceof Error ? err.message : err,
+				);
+			});
+		}
+
+		this.opts.onMenuDirty();
+		return window;
+	}
+
+	showDisconnectedScreen(): void {
+		// Iterate the registry rather than `BrowserWindow.getAllWindows()` so
+		// we only flip windows we own — matches every other broadcast site
+		// (loadUrlInAllWindows, saveAllStates).
+		for (const win of this.opts.registry.getAllLive()) {
+			win.loadFile(this.opts.disconnectedHtmlPath).catch((err: unknown) => {
+				// If this fails the window is left blank with no diagnostic.
+				// Surface it so packaging/path mistakes are visible in the log.
+				console.warn(
+					"[desktop] Failed to load disconnected screen from",
+					this.opts.disconnectedHtmlPath,
+					"—",
+					err instanceof Error ? err.message : err,
+				);
+			});
+		}
+		this.opts.onMenuDirty();
+	}
+
+	private attachRendererRecovery(window: BrowserWindow): void {
+		// Probe the runtime on renderer failures so we can distinguish a transient
+		// renderer glitch (retry) from an unreachable runtime (disconnected screen).
+		window.webContents.on(
+			"did-fail-load",
+			(_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+				if (errorCode === ERR_ABORTED || !isMainFrame) return;
+				console.error(
+					`[desktop] Renderer load failed: ${errorDescription} (code ${errorCode})`,
+				);
+
+				const origin =
+					this.opts.orchestrator.getUrl() ??
+					this.opts.orchestrator.defaultOrigin();
+				void this.opts.orchestrator.checkHealth(origin).then((healthy) => {
+					if (window.isDestroyed()) return;
+
+					if (!healthy) {
+						this.showDisconnectedScreen();
+						return;
+					}
+
+					const choice = dialog.showMessageBoxSync(window, {
+						type: "error",
+						title: "Page Load Failed",
+						message: `The app failed to load:\n\n${errorDescription}`,
+						buttons: ["Retry", "Dismiss"],
+						defaultId: 0,
+					});
+					if (choice === 0) {
+						window.loadURL(validatedURL).catch((err: unknown) => {
+							console.warn(
+								"[desktop] Retry loadURL failed:",
+								err instanceof Error ? err.message : err,
+							);
+						});
+					}
+				});
+			},
+		);
+
+		window.webContents.on("render-process-gone", (_event, details) => {
+			console.error(`[desktop] Renderer process gone: reason=${details.reason}`);
+			if (window.isDestroyed()) return;
+
+			const origin =
+				this.opts.orchestrator.getUrl() ??
+				this.opts.orchestrator.defaultOrigin();
+			void this.opts.orchestrator.checkHealth(origin).then((healthy) => {
+				if (window.isDestroyed()) return;
+				const runtimeUrl = this.opts.orchestrator.getUrl();
+				if (healthy && runtimeUrl) {
+					window.loadURL(runtimeUrl).catch((err: unknown) => {
+						console.warn(
+							"[desktop] Renderer-recovery loadURL failed:",
+							err instanceof Error ? err.message : err,
+						);
+					});
+				} else {
+					this.showDisconnectedScreen();
+				}
+			});
+		});
+	}
+}
+
+/**
+ * Reject protocol-relative and scheme-prefixed paths that could escape the
+ * runtime origin when combined with `new URL(base)`.
+ */
+function isSafeInitialPath(p: string): boolean {
+	if (!p.startsWith("/")) return false;
+	if (p.startsWith("//")) return false;
+	if (/^\/[a-z][a-z0-9+\-.]*:/i.test(p)) return false;
+	return true;
+}
+
+function buildWindowUrl(
+	runtimeUrl: string,
+	options: CreateWindowOptions,
+): string {
+	if (options.projectId) {
+		return WindowRegistry.buildWindowUrl(runtimeUrl, options.projectId);
+	}
+	if (options.initialPath) {
+		if (
+			!isSafeInitialPath(options.initialPath) ||
+			!isPersistableRuntimePath(options.initialPath)
+		) {
+			console.warn(
+				`[desktop] Ignoring unsafe initialPath: ${options.initialPath}`,
+			);
+			return runtimeUrl;
+		}
+		const parsed = new URL(runtimeUrl);
+		parsed.pathname = options.initialPath;
+		return parsed.toString();
+	}
+	return runtimeUrl;
+}

--- a/packages/desktop/src/window-factory.ts
+++ b/packages/desktop/src/window-factory.ts
@@ -130,6 +130,13 @@ export class WindowFactory {
 			console.error(`[desktop] Renderer process gone: reason=${details.reason}`);
 			if (window.isDestroyed()) return;
 
+			// Capture the URL the renderer was on *synchronously*, before the
+			// async health probe. Without this, recovery loads the bare runtime
+			// URL and silently drops whichever project/path the user was on.
+			// `did-fail-load` already preserves the URL (it's passed in as
+			// `validatedURL`); this brings the crash path to parity.
+			const lastUrl = window.webContents.getURL();
+
 			const origin =
 				this.opts.orchestrator.getUrl() ??
 				this.opts.orchestrator.defaultOrigin();
@@ -137,7 +144,8 @@ export class WindowFactory {
 				if (window.isDestroyed()) return;
 				const runtimeUrl = this.opts.orchestrator.getUrl();
 				if (healthy && runtimeUrl) {
-					window.loadURL(runtimeUrl).catch((err: unknown) => {
+					const target = pickRecoveryUrl(lastUrl, runtimeUrl);
+					window.loadURL(target).catch((err: unknown) => {
 						console.warn(
 							"[desktop] Renderer-recovery loadURL failed:",
 							err instanceof Error ? err.message : err,
@@ -149,6 +157,32 @@ export class WindowFactory {
 			});
 		});
 	}
+}
+
+/**
+ * Choose the URL to reload after a renderer crash, preferring the route the
+ * renderer was on so the user lands back in the same place. Falls back to the
+ * bare runtime URL if `lastUrl` is missing, unparseable, not http(s), or on a
+ * different origin than the current runtime (e.g. the runtime restarted on a
+ * new port, or the renderer was already on a `file://` disconnected screen).
+ *
+ * Exported only for tests — internal helper.
+ */
+export function pickRecoveryUrl(lastUrl: string, runtimeUrl: string): string {
+	if (!lastUrl) return runtimeUrl;
+	let last: URL;
+	let rt: URL;
+	try {
+		last = new URL(lastUrl);
+		rt = new URL(runtimeUrl);
+	} catch {
+		return runtimeUrl;
+	}
+	if (last.protocol !== "http:" && last.protocol !== "https:") {
+		return runtimeUrl;
+	}
+	if (last.origin !== rt.origin) return runtimeUrl;
+	return lastUrl;
 }
 
 /**

--- a/packages/desktop/src/window-factory.ts
+++ b/packages/desktop/src/window-factory.ts
@@ -43,7 +43,6 @@ export class WindowFactory {
 			preloadPath: this.opts.preloadPath,
 			isPackaged: this.opts.isPackaged,
 			backgroundColor: this.opts.backgroundColor,
-			runtimeUrl: this.opts.orchestrator.getUrl() ?? undefined,
 			hideOnCloseForMac: true,
 			isQuitting: this.opts.isQuitting,
 			onWindowClosed: this.opts.onMenuDirty,

--- a/packages/desktop/src/window-registry.ts
+++ b/packages/desktop/src/window-registry.ts
@@ -1,0 +1,289 @@
+import { BrowserWindow, screen, shell } from "electron";
+
+import {
+	type PersistedWindowState,
+	clampBoundsToDisplays,
+	extractPersistablePath,
+	isPersistableRuntimePath,
+	loadAllWindowStates,
+	saveAllWindowStates,
+} from "./window-state.js";
+
+
+export interface WindowEntry {
+	window: BrowserWindow;
+	projectId: string | null;
+	lastViewedPath: string | null;
+}
+
+export interface CreateWindowOptions {
+	projectId?: string | null;
+	savedState?: PersistedWindowState;
+	preloadPath: string;
+	isPackaged: boolean;
+	backgroundColor?: string;
+	runtimeUrl?: string | null;
+	onWindowClosed?: (windowId: number) => void;
+	onWindowFocused?: (windowId: number) => void;
+	hideOnCloseForMac?: boolean;
+	isQuitting?: () => boolean;
+}
+
+const DEFAULT_WIDTH = 1400;
+const DEFAULT_HEIGHT = 900;
+const MIN_WIDTH = 800;
+const MIN_HEIGHT = 600;
+const DEFAULT_BACKGROUND_COLOR = "#1F2428";
+
+export class WindowRegistry {
+	private readonly windows = new Map<number, WindowEntry>();
+	private lastFocusedId: number | null = null;
+
+	get size(): number {
+		return this.windows.size;
+	}
+
+	createWindow(options: CreateWindowOptions): BrowserWindow {
+		const projectId = options.projectId ?? null;
+		// Clamp the saved bounds against currently-attached displays before
+		// constructing the BrowserWindow. Without this, a window saved on a
+		// secondary monitor that has since been disconnected lands off-screen
+		// with no recovery path short of editing the state file by hand.
+		const savedState = options.savedState
+			? clampBoundsToDisplays(options.savedState, screen.getAllDisplays())
+			: undefined;
+		const backgroundColor = options.backgroundColor ?? DEFAULT_BACKGROUND_COLOR;
+
+		const window = new BrowserWindow({
+			x: savedState?.x,
+			y: savedState?.y,
+			width: savedState?.width ?? DEFAULT_WIDTH,
+			height: savedState?.height ?? DEFAULT_HEIGHT,
+
+			minWidth: MIN_WIDTH,
+			minHeight: MIN_HEIGHT,
+			title: "Kanban",
+			backgroundColor,
+			show: false,
+			webPreferences: {
+				preload: options.preloadPath,
+				contextIsolation: true,
+				nodeIntegration: false,
+				sandbox: true,
+				webSecurity: true,
+				devTools: !options.isPackaged,
+			},
+		});
+
+		if (savedState?.isMaximized) {
+			window.maximize();
+		}
+
+		const entry: WindowEntry = {
+			window,
+			projectId,
+			lastViewedPath: options.savedState?.lastViewedPath ?? null,
+		};
+		this.windows.set(window.id, entry);
+		this.lastFocusedId = window.id;
+
+		window.once("ready-to-show", () => {
+			window.show();
+		});
+
+		window.on("focus", () => {
+			this.lastFocusedId = window.id;
+			options.onWindowFocused?.(window.id);
+		});
+
+		window.webContents.on("will-navigate", (event: Electron.Event, url: string) => {
+			// Resolve trusted origin from the window's current URL (not at creation
+			// time — startup windows haven't loaded yet).
+			const currentUrl = window.webContents.getURL();
+			if (currentUrl) {
+				try {
+					const parsed = new URL(url);
+					if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+						event.preventDefault();
+						return;
+					}
+					const trustedOrigin = new URL(currentUrl).origin;
+					if (parsed.origin !== trustedOrigin) {
+						event.preventDefault();
+					}
+				} catch {
+					event.preventDefault();
+				}
+			}
+		});
+
+		window.webContents.setWindowOpenHandler(({ url }) => {
+			try {
+				const parsed = new URL(url);
+				if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+					shell.openExternal(url);
+				} else {
+					// Non-http(s) schemes (`javascript:`, `file:`, custom protocols)
+					// are intentionally rejected. Log so unexpected drops are
+					// traceable instead of vanishing into a `deny`.
+					console.debug(
+						`[desktop] Refusing window.open for non-http(s) URL: ${url}`,
+					);
+				}
+			} catch (err) {
+				console.debug(
+					`[desktop] Refusing window.open for unparseable URL: ${url}`,
+					err instanceof Error ? err.message : err,
+				);
+			}
+			return { action: "deny" };
+		});
+
+		window.on("close", (event) => {
+			if (
+				options.hideOnCloseForMac &&
+				process.platform === "darwin" &&
+				!(options.isQuitting?.() ?? false)
+			) {
+				if (this.countVisibleWindows() <= 1) {
+					event.preventDefault();
+					window.hide();
+					return;
+				}
+			}
+		});
+
+		window.on("closed", () => {
+			this.windows.delete(window.id);
+			if (this.lastFocusedId === window.id) {
+				this.lastFocusedId = null;
+			}
+			options.onWindowClosed?.(window.id);
+		});
+
+		return window;
+	}
+
+	getVisible(): WindowEntry[] {
+		return [...this.windows.values()].filter(
+			(entry) => !entry.window.isDestroyed() && entry.window.isVisible(),
+		);
+	}
+
+	countVisibleWindows(): number {
+		return this.getVisible().length;
+	}
+
+	/**
+	 * All live (non-destroyed) windows we own. Used by callers that need to
+	 * broadcast to "every Kanban window" without picking up renderers we
+	 * didn't create (e.g. devtools, preload-spawned helpers).
+	 */
+	getAllLive(): BrowserWindow[] {
+		const out: BrowserWindow[] = [];
+		for (const entry of this.windows.values()) {
+			if (!entry.window.isDestroyed()) out.push(entry.window);
+		}
+		return out;
+	}
+
+	/** Electron focus → our last focus → any live window. */
+	getFocused(): BrowserWindow | null {
+		const focused = BrowserWindow.getFocusedWindow();
+		if (focused && this.windows.has(focused.id)) {
+			return focused;
+		}
+
+		if (this.lastFocusedId !== null) {
+			const entry = this.windows.get(this.lastFocusedId);
+			if (entry && !entry.window.isDestroyed()) {
+				return entry.window;
+			}
+			this.lastFocusedId = null;
+		}
+
+		for (const entry of this.windows.values()) {
+			if (!entry.window.isDestroyed()) {
+				return entry.window;
+			}
+		}
+
+		return null;
+	}
+
+	saveAllStates(userDataPath: string): void {
+		const states: PersistedWindowState[] = [];
+		for (const entry of this.windows.values()) {
+			if (entry.window.isDestroyed()) continue;
+			const isMaximized = entry.window.isMaximized();
+			const bounds = isMaximized
+				? entry.window.getNormalBounds()
+				: entry.window.getBounds();
+
+			const persistable = extractPersistablePath(
+				entry.window.webContents.getURL(),
+			);
+			if (persistable) entry.lastViewedPath = persistable;
+
+			states.push({
+				x: bounds.x,
+				y: bounds.y,
+				width: bounds.width,
+				height: bounds.height,
+				isMaximized,
+				projectId: entry.projectId,
+				lastViewedPath: entry.lastViewedPath,
+			});
+		}
+		saveAllWindowStates(userDataPath, states);
+	}
+
+	static loadPersistedWindows(userDataPath: string): PersistedWindowState[] {
+		return loadAllWindowStates(userDataPath);
+	}
+
+	static buildWindowUrl(baseUrl: string, projectId: string | null): string {
+		if (!projectId) return baseUrl;
+		const url = new URL(baseUrl);
+		url.pathname = `/${encodeURIComponent(projectId)}`;
+		return url.toString();
+	}
+
+	private buildEntryUrl(baseUrl: string, entry: WindowEntry): string {
+		// Defense in depth against upgraded users whose persisted state still
+		// contains a `/Users/.../disconnected.html` pathname from older builds.
+		if (entry.lastViewedPath && isPersistableRuntimePath(entry.lastViewedPath)) {
+			try {
+				const url = new URL(baseUrl);
+				url.pathname = entry.lastViewedPath;
+				return url.toString();
+			} catch {
+				/* fall through */
+			}
+		}
+		if (entry.projectId) {
+			return WindowRegistry.buildWindowUrl(baseUrl, entry.projectId);
+		}
+		return baseUrl;
+	}
+
+	async loadUrlInAllWindows(baseUrl: string): Promise<void> {
+		const tasks: Array<{ id: number; promise: Promise<void> }> = [];
+		for (const entry of this.windows.values()) {
+			if (entry.window.isDestroyed()) continue;
+			const url = this.buildEntryUrl(baseUrl, entry);
+			tasks.push({ id: entry.window.id, promise: entry.window.loadURL(url) });
+		}
+		const results = await Promise.allSettled(tasks.map((t) => t.promise));
+		results.forEach((result, index) => {
+			if (result.status === "rejected") {
+				const task = tasks[index];
+				const reason = result.reason;
+				console.warn(
+					`[desktop] loadURL failed for window ${task?.id}:`,
+					reason instanceof Error ? reason.message : reason,
+				);
+			}
+		});
+	}
+}

--- a/packages/desktop/src/window-registry.ts
+++ b/packages/desktop/src/window-registry.ts
@@ -22,7 +22,6 @@ export interface CreateWindowOptions {
 	preloadPath: string;
 	isPackaged: boolean;
 	backgroundColor?: string;
-	runtimeUrl?: string | null;
 	onWindowClosed?: (windowId: number) => void;
 	onWindowFocused?: (windowId: number) => void;
 	hideOnCloseForMac?: boolean;

--- a/packages/desktop/src/window-state.ts
+++ b/packages/desktop/src/window-state.ts
@@ -176,4 +176,3 @@ export function saveAllWindowStates(userDataPath: string, states: PersistedWindo
 		);
 	}
 }
-

--- a/packages/desktop/src/window-state.ts
+++ b/packages/desktop/src/window-state.ts
@@ -1,0 +1,179 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export interface WindowState {
+	x: number | undefined;
+	y: number | undefined;
+	width: number;
+	height: number;
+	isMaximized: boolean;
+}
+
+export interface PersistedWindowState extends WindowState {
+	projectId: string | null;
+	lastViewedPath?: string | null;
+}
+
+/**
+ * Hard cap on restored window count. A hand-edited or corrupted state file
+ * with thousands of entries would otherwise cause the startup code to spawn
+ * thousands of `BrowserWindow` instances, exhausting system resources before
+ * the user could intervene.
+ */
+export const MAX_RESTORED_WINDOWS = 50;
+
+export function resolveMultiWindowStatePath(userDataPath: string): string {
+	return path.join(userDataPath, "window-states.json");
+}
+
+/**
+ * Clear `x`/`y` if the saved position falls outside every attached display.
+ *
+ * Electron does not auto-constrain a `BrowserWindow` to a visible display, so
+ * a window whose state was saved on a now-disconnected secondary monitor
+ * would be placed off-screen on next launch with no recovery path. Dropping
+ * the coordinates lets Electron fall back to its default placement.
+ */
+export interface DisplayWorkArea {
+	workArea: { x: number; y: number; width: number; height: number };
+}
+
+export function clampBoundsToDisplays<T extends WindowState>(
+	state: T,
+	displays: ReadonlyArray<DisplayWorkArea>,
+): T {
+	if (state.x === undefined || state.y === undefined) return state;
+	if (displays.length === 0) return state;
+	const x = state.x;
+	const y = state.y;
+	const onScreen = displays.some(
+		(d) =>
+			x >= d.workArea.x &&
+			y >= d.workArea.y &&
+			x < d.workArea.x + d.workArea.width &&
+			y < d.workArea.y + d.workArea.height,
+	);
+	if (onScreen) return state;
+	return { ...state, x: undefined, y: undefined };
+}
+
+
+function parseWindowState(parsed: Record<string, unknown>): WindowState | undefined {
+	if (
+		typeof parsed.width !== "number" ||
+		typeof parsed.height !== "number" ||
+		typeof parsed.isMaximized !== "boolean"
+	) {
+		return undefined;
+	}
+	return {
+		x: typeof parsed.x === "number" ? parsed.x : undefined,
+		y: typeof parsed.y === "number" ? parsed.y : undefined,
+		width: parsed.width,
+		height: parsed.height,
+		isMaximized: parsed.isMaximized,
+	};
+}
+
+/**
+ * A crashed runtime leaves windows on `file:///…/disconnected.html`, whose
+ * `.pathname` looks replayable but 404s against `http://host:port`. Reject
+ * filesystem-looking paths and `.html` routes at both save- and load-time
+ * so older bad state auto-heals.
+ */
+export function isPersistableRuntimePath(pathname: string): boolean {
+	if (typeof pathname !== "string" || !pathname.startsWith("/")) return false;
+	if (pathname === "/") return false;
+	if (pathname.toLowerCase().endsWith(".html")) return false;
+	// Heuristic guard against filesystem-looking paths leaking in via
+	// hand-edited or corrupted state files. Not exhaustive; the `.html`
+	// check above catches the realistic crash-page case.
+	const absFsPrefixes = ["/Users/", "/home/", "/private/", "/tmp/", "/var/", "/opt/", "/Applications/"];
+	for (const prefix of absFsPrefixes) {
+		if (pathname.startsWith(prefix)) return false;
+	}
+	return true;
+}
+
+export function extractPersistablePath(
+	currentUrl: string | undefined | null,
+): string | null {
+	if (!currentUrl) return null;
+	try {
+		const url = new URL(currentUrl);
+		const isHttp = url.protocol === "http:" || url.protocol === "https:";
+		if (isHttp && isPersistableRuntimePath(url.pathname)) {
+			return url.pathname;
+		}
+	} catch {
+		/* malformed URL */
+	}
+	return null;
+}
+
+function parsePersistedWindowState(raw: Record<string, unknown>): PersistedWindowState | undefined {
+	const base = parseWindowState(raw);
+	if (!base) return undefined;
+	const state: PersistedWindowState = {
+		...base,
+		projectId: typeof raw.projectId === "string" ? raw.projectId : null,
+	};
+	if (typeof raw.lastViewedPath === "string" && isPersistableRuntimePath(raw.lastViewedPath)) {
+		state.lastViewedPath = raw.lastViewedPath;
+	}
+	return state;
+}
+
+export function loadAllWindowStates(userDataPath: string): PersistedWindowState[] {
+	const filePath = resolveMultiWindowStatePath(userDataPath);
+	if (!existsSync(filePath)) return [];
+	try {
+		const raw = readFileSync(filePath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		const results: PersistedWindowState[] = [];
+		for (const entry of parsed) {
+			if (typeof entry !== "object" || entry === null) continue;
+			const state = parsePersistedWindowState(entry as Record<string, unknown>);
+			if (state) results.push(state);
+			if (results.length >= MAX_RESTORED_WINDOWS) {
+				console.warn(
+					`[desktop] Window state file contains ${parsed.length} entries — capping at ${MAX_RESTORED_WINDOWS} to prevent resource exhaustion.`,
+				);
+				break;
+			}
+		}
+		return results;
+
+	} catch (err) {
+		// A corrupt state file would otherwise silently lose every saved
+		// window — log so support can spot it.
+		console.warn(
+			"[desktop] Failed to read window states from",
+			filePath,
+			"—",
+			err instanceof Error ? err.message : err,
+		);
+		return [];
+	}
+}
+
+export function saveAllWindowStates(userDataPath: string, states: PersistedWindowState[]): void {
+	try {
+		const filePath = resolveMultiWindowStatePath(userDataPath);
+		// Write to a sibling tmp file then rename onto the target. `rename`
+		// is atomic on POSIX and Windows (ReplaceFile semantics in Node),
+		// so a crash mid-`writeFileSync` can no longer leave the canonical
+		// state file truncated and unparseable — which would otherwise
+		// silently drop every saved window position on the next launch.
+		const tmpPath = `${filePath}.tmp`;
+		writeFileSync(tmpPath, JSON.stringify(states, null, "\t"), "utf-8");
+		renameSync(tmpPath, filePath);
+	} catch (err) {
+		console.warn(
+			"[desktop] Failed to save window states:",
+			err instanceof Error ? err.message : err,
+		);
+	}
+}
+

--- a/packages/desktop/test/window-factory.test.ts
+++ b/packages/desktop/test/window-factory.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { pickRecoveryUrl } from "../src/window-factory.js";
+
+describe("pickRecoveryUrl", () => {
+	const runtimeUrl = "http://127.0.0.1:55555/";
+
+	it("returns runtimeUrl when lastUrl is empty", () => {
+		expect(pickRecoveryUrl("", runtimeUrl)).toBe(runtimeUrl);
+	});
+
+	it("returns runtimeUrl when lastUrl is unparseable", () => {
+		expect(pickRecoveryUrl("not a url", runtimeUrl)).toBe(runtimeUrl);
+	});
+
+	it("falls back to runtimeUrl for file:// URLs (e.g. disconnected screen)", () => {
+		expect(
+			pickRecoveryUrl(
+				"file:///Applications/Kanban.app/Contents/Resources/disconnected.html",
+				runtimeUrl,
+			),
+		).toBe(runtimeUrl);
+	});
+
+	it("falls back to runtimeUrl when origins differ (runtime restarted on new port)", () => {
+		expect(
+			pickRecoveryUrl("http://127.0.0.1:44444/some-project", runtimeUrl),
+		).toBe(runtimeUrl);
+	});
+
+	it("falls back when scheme differs (https vs http)", () => {
+		expect(
+			pickRecoveryUrl("https://127.0.0.1:55555/some-project", runtimeUrl),
+		).toBe(runtimeUrl);
+	});
+
+	it("preserves lastUrl when it shares the runtime origin", () => {
+		const lastUrl = "http://127.0.0.1:55555/my-project/board";
+		expect(pickRecoveryUrl(lastUrl, runtimeUrl)).toBe(lastUrl);
+	});
+
+	it("preserves lastUrl with query and hash on the same origin", () => {
+		const lastUrl = "http://127.0.0.1:55555/my-project?tab=tasks#row-12";
+		expect(pickRecoveryUrl(lastUrl, runtimeUrl)).toBe(lastUrl);
+	});
+
+	it("falls back when runtimeUrl itself is unparseable", () => {
+		expect(
+			pickRecoveryUrl("http://127.0.0.1:55555/some-project", "garbage"),
+		).toBe("garbage");
+	});
+});

--- a/packages/desktop/test/window-registry.test.ts
+++ b/packages/desktop/test/window-registry.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => {
+	class MockBrowserWindow {
+		static instances: MockBrowserWindow[] = [];
+		static nextId = 1;
+
+		static getFocusedWindow(): MockBrowserWindow | null {
+			return null;
+		}
+
+		static resetMock(): void {
+			MockBrowserWindow.instances = [];
+			MockBrowserWindow.nextId = 1;
+		}
+
+		id: number;
+		private readonly _listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+		private _destroyed = false;
+		private _visible = true;
+		// Driven directly by tests — represents what Electron would return
+		// from `webContents.getURL()` in the real app. Starts empty because
+		// a freshly-created BrowserWindow has not yet loaded a document.
+		private _currentUrl = "";
+
+		// Record listeners so simulate* helpers can invoke them later. A
+		// plain `vi.fn()` would accept the registration but leave us no
+		// way to trigger the callback in assertions.
+		private readonly _webContentsListeners = new Map<
+			string,
+			Array<(...args: unknown[]) => void>
+		>();
+
+		webContents = {
+			on: (event: string, handler: (...args: unknown[]) => void): void => {
+				const handlers = this._webContentsListeners.get(event) ?? [];
+				handlers.push(handler);
+				this._webContentsListeners.set(event, handlers);
+			},
+			setWindowOpenHandler: vi.fn(),
+			getURL: (): string => this._currentUrl,
+		};
+
+		constructor() {
+			this.id = MockBrowserWindow.nextId++;
+			MockBrowserWindow.instances.push(this);
+		}
+
+		/** Test helper — mirror what `loadURL()` would do in the real app. */
+		_setCurrentUrl(url: string): void {
+			this._currentUrl = url;
+		}
+
+		/**
+		 * Fire the `will-navigate` handlers that production code registered
+		 * via `window.webContents.on("will-navigate", …)`.
+		 * Returns whether the synthetic event was prevented.
+		 */
+		simulateWillNavigate(url: string): boolean {
+			const event = {
+				defaultPrevented: false,
+				preventDefault() {
+					this.defaultPrevented = true;
+				},
+			};
+			for (const handler of this._webContentsListeners.get("will-navigate") ?? []) {
+				handler(event, url);
+			}
+			return event.defaultPrevented;
+		}
+
+		on(event: string, handler: (...args: unknown[]) => void): void {
+			const handlers = this._listeners.get(event) ?? [];
+			handlers.push(handler);
+			this._listeners.set(event, handlers);
+		}
+
+		once(event: string, handler: (...args: unknown[]) => void): void {
+			this.on(event, handler);
+		}
+
+		simulateClose(): boolean {
+			const event = {
+				defaultPrevented: false,
+				preventDefault() {
+					this.defaultPrevented = true;
+				},
+			};
+			for (const handler of this._listeners.get("close") ?? []) {
+				handler(event);
+			}
+			if (!event.defaultPrevented) {
+				this._destroyed = true;
+				this._visible = false;
+				for (const handler of this._listeners.get("closed") ?? []) {
+					handler();
+				}
+			}
+			return event.defaultPrevented;
+		}
+
+		hide(): void {
+			this._visible = false;
+		}
+
+		show(): void {
+			this._visible = true;
+		}
+
+		isVisible(): boolean {
+			return this._visible;
+		}
+
+		isDestroyed(): boolean {
+			return this._destroyed;
+		}
+
+		maximize(): void {}
+		isMaximized(): boolean {
+			return false;
+		}
+		getTitle(): string {
+			return "Kanban";
+		}
+		getBounds(): { x: number; y: number; width: number; height: number } {
+			return { x: 0, y: 0, width: 1400, height: 900 };
+		}
+		getNormalBounds(): { x: number; y: number; width: number; height: number } {
+			return this.getBounds();
+		}
+		isMinimized(): boolean {
+			return false;
+		}
+		restore(): void {}
+		focus(): void {}
+		setTitle(): void {}
+	}
+
+	const screenMock = {
+		_displays: [
+			{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } },
+		] as Array<{ workArea: { x: number; y: number; width: number; height: number } }>,
+		getAllDisplays() {
+			return screenMock._displays;
+		},
+		_setDisplays(
+			displays: Array<{ workArea: { x: number; y: number; width: number; height: number } }>,
+		): void {
+			screenMock._displays = displays;
+		},
+	};
+
+	return {
+		BrowserWindow: MockBrowserWindow,
+		shell: { openExternal: vi.fn() },
+		screen: screenMock,
+	};
+});
+
+
+import { BrowserWindow } from "electron";
+import { WindowRegistry } from "../src/window-registry.js";
+
+interface MockWindow {
+	simulateClose(): boolean;
+	hide(): void;
+	show(): void;
+	isVisible(): boolean;
+	isDestroyed(): boolean;
+	_setCurrentUrl(url: string): void;
+	simulateWillNavigate(url: string): boolean;
+}
+
+const DEFAULT_OPTIONS = {
+	preloadPath: "/tmp/preload.js",
+	isPackaged: false,
+};
+
+beforeEach(() => {
+	const Mock = BrowserWindow as unknown as { resetMock(): void };
+	Mock.resetMock();
+});
+
+function withDarwin<T>(fn: () => T): T {
+	const original = process.platform;
+	Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+	try {
+		return fn();
+	} finally {
+		Object.defineProperty(process, "platform", { value: original, configurable: true });
+	}
+}
+
+describe("WindowRegistry.buildWindowUrl", () => {
+	it("returns base URL unchanged when projectId is null", () => {
+		expect(WindowRegistry.buildWindowUrl("http://localhost:52341", null)).toBe(
+			"http://localhost:52341",
+		);
+	});
+
+	it("encodes projectId as the URL pathname", () => {
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341", "project-abc");
+		expect(url).toBe("http://localhost:52341/project-abc");
+	});
+
+	it("overwrites any existing path in the base URL", () => {
+		// The path is the project; any pre-existing path on the base URL
+		// is irrelevant and gets replaced.
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341/some/path", "proj-1");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/proj-1");
+	});
+
+	it("preserves existing query parameters", () => {
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341/?token=abc", "proj-2");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/proj-2");
+		expect(parsed.searchParams.get("token")).toBe("abc");
+	});
+
+	it("URL-encodes projectIds containing slashes or whitespace", () => {
+		// Matches the web-ui's buildProjectPathname encoding so that
+		// parseProjectIdFromPathname round-trips the value back via
+		// decodeURIComponent on the first path segment.
+		const url = WindowRegistry.buildWindowUrl("http://localhost:52341", "/Users/john/my project");
+		const parsed = new URL(url);
+		expect(parsed.pathname).toBe("/%2FUsers%2Fjohn%2Fmy%20project");
+		expect(decodeURIComponent(parsed.pathname.slice(1))).toBe("/Users/john/my project");
+	});
+
+	it("returns base URL unchanged when projectId is empty string", () => {
+		expect(WindowRegistry.buildWindowUrl("http://localhost:52341", "")).toBe(
+			"http://localhost:52341",
+		);
+	});
+});
+
+describe("WindowRegistry.loadPersistedWindows", () => {
+	it("returns empty array for non-existent directory", () => {
+		const states = WindowRegistry.loadPersistedWindows("/tmp/non-existent-dir-" + Date.now());
+		expect(states).toEqual([]);
+	});
+});
+
+describe("WindowRegistry macOS close behavior", () => {
+	const macOptions = { ...DEFAULT_OPTIONS, hideOnCloseForMac: true, isQuitting: () => false };
+
+	it("hides the last visible window on macOS close", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({ ...macOptions, projectId: null });
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(true);
+			expect(registry.size).toBe(1);
+		});
+	});
+
+	it("destroys a non-last window on macOS close", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			registry.createWindow({ ...macOptions, projectId: null });
+			const win2 = registry.createWindow({ ...macOptions, projectId: "project-abc" });
+			expect(registry.size).toBe(2);
+			const prevented = (win2 as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(false);
+			expect(registry.size).toBe(1);
+			expect((win2 as unknown as MockWindow).isDestroyed()).toBe(true);
+		});
+	});
+
+	it("hides the last window even if it is a project window", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({ ...macOptions, projectId: "project-abc" });
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(true);
+			expect(registry.size).toBe(1);
+		});
+	});
+
+	it("always closes when quitting", () => {
+		withDarwin(() => {
+			const registry = new WindowRegistry();
+			const window = registry.createWindow({
+				...macOptions,
+				projectId: null,
+				isQuitting: () => true,
+			});
+			const prevented = (window as unknown as MockWindow).simulateClose();
+			expect(prevented).toBe(false);
+			expect(registry.size).toBe(0);
+		});
+	});
+});
+
+describe("WindowRegistry visibility helpers", () => {
+	it("getVisible() excludes hidden windows", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		(win1 as unknown as MockWindow).hide();
+		const visible = registry.getVisible();
+		expect(visible.length).toBe(1);
+		expect(visible[0].projectId).toBe("project-a");
+	});
+
+	it("countVisibleWindows() returns correct count", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-b" });
+		expect(registry.countVisibleWindows()).toBe(3);
+		(win1 as unknown as MockWindow).hide();
+		expect(registry.countVisibleWindows()).toBe(2);
+	});
+});
+
+describe("WindowRegistry will-navigate origin guard", () => {
+	// The will-navigate handler is the last-line security defence against
+	// a compromised renderer escaping the runtime origin. The guard derives
+	// the trusted origin from `webContents.getURL()` at event time (not
+	// from a value captured at window creation) so that startup windows —
+	// which have no URL until after loadURL() resolves — still enforce the
+	// correct origin once loading completes.
+
+	const RUNTIME_ORIGIN = "http://localhost:52341";
+
+	function makeLoadedWindow(currentUrl: string) {
+		const registry = new WindowRegistry();
+		const window = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		(window as unknown as MockWindow)._setCurrentUrl(currentUrl);
+		return window as unknown as MockWindow;
+	}
+
+	it("allows same-origin navigation", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate(`${RUNTIME_ORIGIN}/project-b/task-1`);
+		expect(prevented).toBe(false);
+	});
+
+	it("allows same-origin navigation when only the path/query differs", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate(
+			`${RUNTIME_ORIGIN}/project-a?foo=bar#section`,
+		);
+		expect(prevented).toBe(false);
+	});
+
+	it("blocks cross-origin HTTP navigation", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("http://evil.example.com/pwn");
+		expect(prevented).toBe(true);
+	});
+
+	it("blocks cross-origin navigation even to the same host on a different port", () => {
+		// Origin is scheme + host + port, so 52341 vs 3000 must be treated
+		// as different origins — a port-scan pivot from a compromised
+		// renderer would otherwise be allowed.
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("http://localhost:3000/");
+		expect(prevented).toBe(true);
+	});
+
+	it("blocks navigation to non-http schemes", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		for (const url of [
+			"file:///etc/passwd",
+			"javascript:alert(1)",
+			"data:text/html,<script>alert(1)</script>",
+		]) {
+			expect(window.simulateWillNavigate(url)).toBe(true);
+		}
+	});
+
+	it("blocks navigation when the target URL is malformed", () => {
+		const window = makeLoadedWindow(`${RUNTIME_ORIGIN}/project-a`);
+		const prevented = window.simulateWillNavigate("not a url :::");
+		expect(prevented).toBe(true);
+	});
+
+	it("is a no-op while the window has not yet loaded a URL", () => {
+		// Startup windows construct before the runtime URL is known; the
+		// disconnected screen is loaded via loadFile in that case. Guarding
+		// before the first load would either stall the initial navigation
+		// or force us to bake in an assumed trusted origin, both of which
+		// are worse than trusting Electron's internal flow for the first
+		// load. Production code relies on this behaviour — lock it in.
+		const registry = new WindowRegistry();
+		const window = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		const prevented = (window as unknown as MockWindow).simulateWillNavigate(
+			"http://evil.example.com/",
+		);
+		expect(prevented).toBe(false);
+	});
+
+	it("picks up the new trusted origin after the URL changes (e.g. restart)", () => {
+		// Restarting the runtime can move it to a different ephemeral port;
+		// the guard must reflect the window's _current_ URL, not the origin
+		// it had at creation time.
+		const window = makeLoadedWindow("http://localhost:52341/project-a");
+		expect(window.simulateWillNavigate("http://localhost:52341/other")).toBe(false);
+		window._setCurrentUrl("http://localhost:40000/project-a");
+		expect(window.simulateWillNavigate("http://localhost:40000/other")).toBe(false);
+		expect(window.simulateWillNavigate("http://localhost:52341/other")).toBe(true);
+	});
+});
+
+describe("WindowRegistry multi-window creation", () => {
+	it("allows duplicate project windows (same projectId)", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+
+	it("allows multiple overview windows (projectId null)", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: null });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+
+	it("allows different project windows", () => {
+		const registry = new WindowRegistry();
+		const win1 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-a" });
+		const win2 = registry.createWindow({ ...DEFAULT_OPTIONS, projectId: "project-b" });
+		expect(win1.id).not.toBe(win2.id);
+		expect(registry.size).toBe(2);
+	});
+});

--- a/packages/desktop/test/window-state.test.ts
+++ b/packages/desktop/test/window-state.test.ts
@@ -1,0 +1,591 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	MAX_RESTORED_WINDOWS,
+	type PersistedWindowState,
+	clampBoundsToDisplays,
+	extractPersistablePath,
+	isPersistableRuntimePath,
+	loadAllWindowStates,
+	resolveMultiWindowStatePath,
+	saveAllWindowStates,
+} from "../src/window-state.js";
+
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function freshTmpDir(): string {
+	const dir = path.join(
+		import.meta.dirname,
+		".tmp-window-state-test",
+		String(Date.now()) + "-" + String(Math.random()).slice(2, 8),
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+const SAMPLE_PERSISTED_STATES: PersistedWindowState[] = [
+	{
+		x: 100,
+		y: 200,
+		width: 1400,
+		height: 900,
+		isMaximized: false,
+		projectId: null,
+	},
+	{
+		x: 500,
+		y: 300,
+		width: 1200,
+		height: 800,
+		isMaximized: true,
+		projectId: "project-abc",
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	tmpDir = freshTmpDir();
+});
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-window persistence
+// ---------------------------------------------------------------------------
+
+describe("saveAllWindowStates / loadAllWindowStates", () => {
+	it("returns empty array when no file exists", () => {
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("round-trips multiple window states", () => {
+		saveAllWindowStates(tmpDir, SAMPLE_PERSISTED_STATES);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toEqual(SAMPLE_PERSISTED_STATES);
+	});
+
+	it("round-trips an empty array", () => {
+		saveAllWindowStates(tmpDir, []);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toEqual([]);
+	});
+
+	it("preserves projectId: null for overview windows", () => {
+		const states: PersistedWindowState[] = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false, projectId: null },
+		];
+		saveAllWindowStates(tmpDir, states);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].projectId).toBeNull();
+	});
+
+	it("preserves projectId strings", () => {
+		const states: PersistedWindowState[] = [
+			{
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "my-project-id",
+			},
+		];
+		saveAllWindowStates(tmpDir, states);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].projectId).toBe("my-project-id");
+	});
+
+	it("returns empty array for corrupt JSON", () => {
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			"not valid json",
+			"utf-8",
+		);
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("returns empty array when file contains a non-array JSON value", () => {
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify({ x: 0 }),
+			"utf-8",
+		);
+		expect(loadAllWindowStates(tmpDir)).toEqual([]);
+	});
+
+	it("skips invalid entries in the array", () => {
+		const raw = [
+			SAMPLE_PERSISTED_STATES[0],
+			"not an object",
+			null,
+			{ broken: true },
+			SAMPLE_PERSISTED_STATES[1],
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(2);
+		expect(loaded[0]).toEqual(SAMPLE_PERSISTED_STATES[0]);
+		expect(loaded[1]).toEqual(SAMPLE_PERSISTED_STATES[1]);
+	});
+
+	it("treats missing projectId as null", () => {
+		const raw = [
+			{ x: 10, y: 20, width: 800, height: 600, isMaximized: false },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].projectId).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+	it("handles x/y as undefined when not present in persisted data", () => {
+		const raw = [
+			{ width: 800, height: 600, isMaximized: false, projectId: null },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].x).toBeUndefined();
+		expect(loaded[0].y).toBeUndefined();
+	});
+
+	it("handles x/y as undefined when they are non-numeric", () => {
+		const raw = [
+			{
+				x: "not a number",
+				y: true,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "proj-1",
+			},
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].x).toBeUndefined();
+		expect(loaded[0].y).toBeUndefined();
+	});
+
+	it("treats numeric projectId as null (only strings are valid)", () => {
+		const raw = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false, projectId: 42 },
+		];
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].projectId).toBeNull();
+	});
+
+	it("preserves duplicate projectId entries (multiple windows per project)", () => {
+		const raw = [
+			{ x: 10, y: 20, width: 800, height: 600, isMaximized: false, projectId: "proj-a" },
+			{ x: 30, y: 40, width: 900, height: 700, isMaximized: true, projectId: "proj-a" },
+			{ x: 50, y: 60, width: 1000, height: 800, isMaximized: false, projectId: "proj-b" },
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(3);
+		expect(loaded[0].x).toBe(10);
+		expect(loaded[1].x).toBe(30);
+		expect(loaded[2].projectId).toBe("proj-b");
+	});
+
+	it("preserves multiple overview windows (projectId null)", () => {
+		const raw = [
+			{ x: 0, y: 0, width: 800, height: 600, isMaximized: false },
+			{ x: 100, y: 100, width: 900, height: 700, isMaximized: true },
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(2);
+		expect(loaded[0].x).toBe(0);
+		expect(loaded[1].x).toBe(100);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// lastViewedPath validation — guards against the "Not Found" footgun where
+// a file:// URL's pathname gets replayed on the runtime origin.
+// ---------------------------------------------------------------------------
+
+describe("isPersistableRuntimePath", () => {
+	it.each([
+		["/my-project", true],
+		["/my-project/tasks/abc-123", true],
+		["/workspace%2Fabc", true],
+		["/a/b/c/d", true],
+	])("accepts legitimate runtime path %s", (input, expected) => {
+		expect(isPersistableRuntimePath(input)).toBe(expected);
+	});
+
+	it.each([
+		// file:// URLs from disconnected.html fallback — the original bug.
+		"/Users/someone/main/kanban-desktop/packages/desktop/out/mac-arm64/Kanban.app/Contents/Resources/app.asar/dist/disconnected.html",
+		"/Users/johnchoi1/Library/whatever.html",
+		"/private/var/folders/x/y/z/Kanban.app/Contents/disconnected.html",
+		"/tmp/disconnected.html",
+		"/home/user/kanban/disconnected.html",
+		"/var/folders/abc/disconnected.html",
+		"/opt/kanban/disconnected.html",
+		"/Applications/Kanban.app/Contents/Resources/disconnected.html",
+		// Any .html pathname — the runtime SPA never exposes those.
+		"/index.html",
+		"/some/deep/page.html",
+		// Degenerate inputs.
+		"/",
+		"",
+		"relative/path",
+	])("rejects %s", (input) => {
+		expect(isPersistableRuntimePath(input)).toBe(false);
+	});
+});
+
+describe("loadAllWindowStates heals stale file:// lastViewedPath", () => {
+	it("drops a disconnected.html lastViewedPath from existing on-disk state", () => {
+		// This mirrors the exact shape written by an older build when the
+		// window had been flipped to the local disconnected.html fallback
+		// and then the app was quit. On the next launch, without this
+		// validation, the window would navigate to
+		// http://127.0.0.1:3484/Users/.../disconnected.html → 404.
+		const raw = [
+			{
+				x: 100,
+				y: 200,
+				width: 1400,
+				height: 900,
+				isMaximized: false,
+				projectId: null,
+				lastViewedPath:
+					"/Users/alice/main/kanban-desktop/packages/desktop/out/mac-arm64/Kanban.app/Contents/Resources/app.asar/dist/disconnected.html",
+			},
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded).toHaveLength(1);
+		expect(loaded[0].lastViewedPath).toBeUndefined();
+	});
+
+	it("preserves a legitimate lastViewedPath like /<projectId>", () => {
+		const raw = [
+			{
+				x: 0,
+				y: 0,
+				width: 800,
+				height: 600,
+				isMaximized: false,
+				projectId: "proj-a",
+				lastViewedPath: "/proj-a/tasks/task-1",
+			},
+		];
+		writeFileSync(resolveMultiWindowStatePath(tmpDir), JSON.stringify(raw), "utf-8");
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded[0].lastViewedPath).toBe("/proj-a/tasks/task-1");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractPersistablePath — URL-to-pathname helper shared by window-registry's
+// state-save path and app-menu's File → New Window handler.
+//
+// The key defensive case: when a window shows the local `disconnected.html`
+// fallback, its URL is a `file://` URL whose pathname looks like
+// `/Users/.../disconnected.html`. Replaying that pathname against the
+// runtime origin would strand the window on a 404.
+// ---------------------------------------------------------------------------
+
+describe("extractPersistablePath", () => {
+	// ── Happy path ────────────────────────────────────────────────────
+
+	it("returns the pathname for a normal http runtime URL", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/my-project")).toBe(
+			"/my-project",
+		);
+	});
+
+	it("returns the pathname for a normal https runtime URL", () => {
+		expect(extractPersistablePath("https://example.com/project/task-42")).toBe(
+			"/project/task-42",
+		);
+	});
+
+	it("preserves multi-segment pathnames", () => {
+		expect(
+			extractPersistablePath("http://localhost:3484/team/alpha/task/123"),
+		).toBe("/team/alpha/task/123");
+	});
+
+	// ── Guards against the disconnected.html footgun ──────────────────
+
+	it("returns null for a file:// URL pointing at a disconnected.html fallback", () => {
+		const url =
+			"file:///Users/dev/Library/Application%20Support/Kanban/disconnected.html";
+		expect(extractPersistablePath(url)).toBeNull();
+	});
+
+	it("returns null for a file:// URL pointing at a /home/ path (Linux)", () => {
+		const url = "file:///home/dev/.config/Kanban/disconnected.html";
+		expect(extractPersistablePath(url)).toBeNull();
+	});
+
+	it("returns null for any file:// URL regardless of path", () => {
+		expect(extractPersistablePath("file:///tmp/something")).toBeNull();
+	});
+
+	// ── Other defensive cases ─────────────────────────────────────────
+
+	it("returns null for the root pathname (no useful route to inherit)", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/")).toBeNull();
+	});
+
+	it("returns null for about:blank", () => {
+		expect(extractPersistablePath("about:blank")).toBeNull();
+	});
+
+	it("returns null for a pathname ending in .html", () => {
+		expect(
+			extractPersistablePath("http://127.0.0.1:3484/foo.html"),
+		).toBeNull();
+	});
+
+	it("returns null for a malformed URL", () => {
+		expect(extractPersistablePath("not a url")).toBeNull();
+	});
+
+	it("returns null for undefined input", () => {
+		expect(extractPersistablePath(undefined)).toBeNull();
+	});
+
+	it("returns null for null input", () => {
+		expect(extractPersistablePath(null)).toBeNull();
+	});
+
+	it("returns null for empty string input", () => {
+		expect(extractPersistablePath("")).toBeNull();
+	});
+
+	// ── Query strings and fragments are ignored (not part of pathname) ──
+
+	it("strips query strings (not part of the pathname)", () => {
+		expect(
+			extractPersistablePath("http://127.0.0.1:3484/project?foo=bar"),
+		).toBe("/project");
+	});
+
+	it("strips fragments (not part of the pathname)", () => {
+		expect(extractPersistablePath("http://127.0.0.1:3484/project#top")).toBe(
+			"/project",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// clampBoundsToDisplays — protects against off-screen window placement after
+// a saved-on-secondary-monitor disconnects.
+// ---------------------------------------------------------------------------
+
+describe("clampBoundsToDisplays", () => {
+	const PRIMARY = { workArea: { x: 0, y: 0, width: 1920, height: 1080 } };
+	const SECONDARY_RIGHT = {
+		workArea: { x: 1920, y: 0, width: 2560, height: 1440 },
+	};
+	// macOS-style negative-x display layout — common when a laptop docks
+	// to the left of an external display.
+	const SECONDARY_LEFT = {
+		workArea: { x: -1920, y: 0, width: 1920, height: 1080 },
+	};
+
+	const baseState: PersistedWindowState = {
+		x: undefined,
+		y: undefined,
+		width: 1400,
+		height: 900,
+		isMaximized: false,
+		projectId: null,
+	};
+
+	it("returns state unchanged when x/y are undefined", () => {
+		const out = clampBoundsToDisplays(baseState, [PRIMARY]);
+		expect(out).toBe(baseState);
+	});
+
+	it("returns state unchanged when bounds fall on the primary display", () => {
+		const state = { ...baseState, x: 100, y: 200 };
+		const out = clampBoundsToDisplays(state, [PRIMARY]);
+		expect(out).toEqual(state);
+	});
+
+	it("returns state unchanged when bounds fall on a secondary display", () => {
+		const state = { ...baseState, x: 2200, y: 100 };
+		const out = clampBoundsToDisplays(state, [PRIMARY, SECONDARY_RIGHT]);
+		expect(out).toEqual(state);
+	});
+
+	it("clears x/y when bounds fall on a now-disconnected display", () => {
+		// Saved on a secondary display that has since been unplugged.
+		const state = { ...baseState, x: 2200, y: 100 };
+		const out = clampBoundsToDisplays(state, [PRIMARY]);
+		expect(out.x).toBeUndefined();
+		expect(out.y).toBeUndefined();
+		// Width/height/other fields preserved — we only drop the position.
+		expect(out.width).toBe(1400);
+		expect(out.height).toBe(900);
+	});
+
+	it("clears x/y for negative-coordinate off-screen positions", () => {
+		// Saved on a left-of-primary display that's no longer attached.
+		const state = { ...baseState, x: -500, y: 100 };
+		const out = clampBoundsToDisplays(state, [PRIMARY]);
+		expect(out.x).toBeUndefined();
+		expect(out.y).toBeUndefined();
+	});
+
+	it("preserves negative coordinates when the matching display IS attached", () => {
+		const state = { ...baseState, x: -500, y: 100 };
+		const out = clampBoundsToDisplays(state, [PRIMARY, SECONDARY_LEFT]);
+		expect(out.x).toBe(-500);
+		expect(out.y).toBe(100);
+	});
+
+	it("returns state unchanged when displays array is empty (no info to clamp against)", () => {
+		// Defensive — Electron's screen API should never return an empty
+		// list, but if it ever does we'd rather honour the saved bounds
+		// than blow them away on every launch.
+		const state = { ...baseState, x: 100, y: 200 };
+		const out = clampBoundsToDisplays(state, []);
+		expect(out).toEqual(state);
+	});
+
+	it("treats the workArea right/bottom edges as exclusive (1920 is not on a 0..1920 display)", () => {
+		// Standard half-open rect semantics — the bottom-right corner of
+		// a 1920×1080 primary belongs to the next display, not this one.
+		const state = { ...baseState, x: 1920, y: 0 };
+		const out = clampBoundsToDisplays(state, [PRIMARY]);
+		expect(out.x).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Atomic save — writeFileSync directly to the canonical path is vulnerable
+// to crash-mid-write corruption. Verify that saveAllWindowStates writes via
+// a sibling tmp file then renames into place.
+// ---------------------------------------------------------------------------
+
+describe("saveAllWindowStates atomic write", () => {
+	it("does not leave a .tmp file behind after a successful save", () => {
+		saveAllWindowStates(tmpDir, SAMPLE_PERSISTED_STATES);
+		const finalPath = resolveMultiWindowStatePath(tmpDir);
+		expect(existsSync(finalPath)).toBe(true);
+		expect(existsSync(`${finalPath}.tmp`)).toBe(false);
+	});
+
+	it("preserves the previous state file if a sibling .tmp existed from a prior failed write", () => {
+		// Pre-seed the canonical file, then drop a stale .tmp alongside it
+		// (simulating a previous run that crashed between writeFileSync and
+		// renameSync). The next save must still produce a valid canonical
+		// file.
+		saveAllWindowStates(tmpDir, SAMPLE_PERSISTED_STATES);
+		const finalPath = resolveMultiWindowStatePath(tmpDir);
+		writeFileSync(`${finalPath}.tmp`, "STALE GARBAGE", "utf-8");
+
+		const newStates: PersistedWindowState[] = [
+			{ x: 1, y: 2, width: 100, height: 200, isMaximized: false, projectId: "p" },
+		];
+		saveAllWindowStates(tmpDir, newStates);
+
+		// Canonical file reflects the latest write — not the stale tmp.
+		expect(loadAllWindowStates(tmpDir)).toEqual(newStates);
+		// .tmp is consumed by the rename, so it must no longer exist.
+		expect(existsSync(`${finalPath}.tmp`)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Restored window count cap — bounds the blast radius of a hand-edited or
+// corrupted state file with absurd entry counts.
+// ---------------------------------------------------------------------------
+
+describe("loadAllWindowStates respects MAX_RESTORED_WINDOWS", () => {
+	it("caps the number of restored entries", () => {
+		const overSize = MAX_RESTORED_WINDOWS + 25;
+		const raw = Array.from({ length: overSize }, (_, i) => ({
+			x: i,
+			y: i,
+			width: 800,
+			height: 600,
+			isMaximized: false,
+			projectId: `proj-${i}`,
+		}));
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		const loaded = loadAllWindowStates(tmpDir);
+		expect(loaded.length).toBe(MAX_RESTORED_WINDOWS);
+		// First entries kept, later entries dropped — implementation
+		// detail, but locking it in keeps the cap behaviour predictable.
+		expect(loaded[0].projectId).toBe("proj-0");
+		expect(loaded[loaded.length - 1].projectId).toBe(
+			`proj-${MAX_RESTORED_WINDOWS - 1}`,
+		);
+	});
+
+	it("returns all entries when count is below the cap", () => {
+		const raw = Array.from({ length: 5 }, (_, i) => ({
+			x: i,
+			y: i,
+			width: 800,
+			height: 600,
+			isMaximized: false,
+			projectId: `proj-${i}`,
+		}));
+		writeFileSync(
+			resolveMultiWindowStatePath(tmpDir),
+			JSON.stringify(raw),
+			"utf-8",
+		);
+		expect(loadAllWindowStates(tmpDir).length).toBe(5);
+	});
+});
+
+

--- a/packages/desktop/test/window-state.test.ts
+++ b/packages/desktop/test/window-state.test.ts
@@ -587,5 +587,3 @@ describe("loadAllWindowStates respects MAX_RESTORED_WINDOWS", () => {
 		expect(loadAllWindowStates(tmpDir).length).toBe(5);
 	});
 });
-
-


### PR DESCRIPTION
Window creation, state persistence, and multi-window tracking layer.

**Split from original PR #372** - Part 1 of 3

**Window state persistence** (window-state.ts)
- Per-window bounds, last viewed path, display affinity
- Saved to userData on close, restored on next launch

**Multi-window tracking** (window-registry.ts)
- Centralized registry for all BrowserWindow instances
- Focus tracking, lifecycle events
- Batch operations (loadUrlInAllWindows, saveAllStates)

**Window factory** (window-factory.ts)
- Creates BrowserWindows from persisted state or defaults
- Handles disconnected screen transitions
- Security boundary via will-navigate origin checks

**Files:** 7 new files, 1770 lines
**Stack:** PR #371 → **#372a** → #372b → #372c → #373