### PR TITLE
Add "Dev (full stack)" kanban shortcut

### DIFF
--- a/.cline/kanban/config.json
+++ b/.cline/kanban/config.json
@@ -4,6 +4,11 @@
       "label": "Run",
       "command": "npm run dogfood",
       "icon": "play"
+    },
+    {
+      "label": "Dev (full stack)",
+      "command": "node scripts/dev-full.mjs",
+      "icon": "play"
     }
   ]
 }


### PR DESCRIPTION
Adds a kanban sidebar shortcut that runs `scripts/dev-full.mjs` — the hot-reloading runtime + Vite web UI dev stack on auto-selected free ports.

## Why

The existing `Run` shortcut maps to `npm run dogfood` (production-style). There was no one-click equivalent for the dev stack, which is the more common workflow while iterating on the app.

## Naming

Reuses terminology already in the codebase:
- `scripts/dev-full.mjs`'s own docstring calls itself "Dev (Full Stack)"
- The matching npm script is `dev:full`

The `Run` vs `Dev` distinction makes the purpose obvious at a glance.

## Change

One-line addition to `.cline/kanban/config.json`:

```json
{
  "label": "Dev (full stack)",
  "command": "node scripts/dev-full.mjs",
  "icon": "play"
}
```