### PR TITLE
Hide provider edit for built-in Cline providers

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -747,6 +747,7 @@ export function createClineProviderService() {
 							id: provider.id,
 							name: provider.name,
 							oauthSupported: (provider.capabilities ?? []).includes("oauth"),
+							custom: provider.custom,
 							enabled:
 								selectedProviderId.length > 0 ? selectedProviderId === provider.id : provider.id === "cline",
 							defaultModelId: provider.defaultModelId ?? null,

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -62,6 +62,7 @@ export interface SdkProviderCatalogItem {
 	baseUrl?: string;
 	env?: string[];
 	capabilities?: string[];
+	custom?: boolean;
 }
 
 export interface SdkProviderModel {
@@ -305,7 +306,11 @@ export async function completeClineDeviceAuth(input: {
 }
 
 export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]> {
-	return await ClineCore.Llms.getAllProviders();
+	const customProviderIds = await readCustomProviderIds();
+	return (await ClineCore.Llms.getAllProviders()).map((provider: SdkProviderCatalogItem) => ({
+		...provider,
+		custom: customProviderIds.has(provider.id.trim().toLowerCase()),
+	}));
 }
 
 export async function listSdkProviderModels(providerId: string): Promise<SdkProviderModel[]> {
@@ -337,6 +342,11 @@ async function readModelsRegistry(): Promise<LocalModelsFile> {
 		// Fall through.
 	}
 	return { version: 1, providers: {} };
+}
+
+async function readCustomProviderIds(): Promise<Set<string>> {
+	const state = await readModelsRegistry();
+	return new Set(Object.keys(state.providers).map((providerId) => providerId.trim().toLowerCase()));
 }
 
 async function writeModelsRegistry(state: LocalModelsFile): Promise<void> {

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -673,6 +673,7 @@ export const runtimeClineProviderCatalogItemSchema = z.object({
 	baseUrl: z.string().nullable(),
 	supportsBaseUrl: z.boolean(),
 	env: z.array(z.string()).optional(),
+	custom: z.boolean().optional(),
 });
 export type RuntimeClineProviderCatalogItem = z.infer<typeof runtimeClineProviderCatalogItemSchema>;
 

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -1,0 +1,153 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClineSetupSection } from "@/components/shared/cline-setup-section";
+import type { UseRuntimeSettingsClineControllerResult } from "@/hooks/use-runtime-settings-cline-controller";
+import type { RuntimeClineProviderCatalogItem } from "@/runtime/types";
+
+vi.mock("@/runtime/runtime-config-query", () => ({
+	openFileOnHost: vi.fn(),
+}));
+
+function findButtonByText(container: ParentNode, text: string): HTMLButtonElement | null {
+	return (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === text) ??
+		null) as HTMLButtonElement | null;
+}
+
+function createProvider(overrides: Partial<RuntimeClineProviderCatalogItem> = {}): RuntimeClineProviderCatalogItem {
+	return {
+		id: "litellm",
+		name: "LiteLLM",
+		oauthSupported: false,
+		enabled: true,
+		defaultModelId: "gpt-5.4",
+		baseUrl: "http://localhost:4000/v1",
+		supportsBaseUrl: true,
+		...overrides,
+	};
+}
+
+function createController(provider: RuntimeClineProviderCatalogItem): UseRuntimeSettingsClineControllerResult {
+	const providerId = provider.id;
+	return {
+		currentProviderSettings: {
+			providerId,
+			modelId: provider.defaultModelId,
+			baseUrl: provider.baseUrl,
+			reasoningEffort: null,
+			apiKeyConfigured: false,
+			oauthProvider: null,
+			oauthAccessTokenConfigured: false,
+			oauthRefreshTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		},
+		providerId,
+		setProviderId: vi.fn(),
+		modelId: provider.defaultModelId ?? "",
+		setModelId: vi.fn(),
+		apiKey: "",
+		setApiKey: vi.fn(),
+		baseUrl: provider.baseUrl ?? "",
+		setBaseUrl: vi.fn(),
+		region: "",
+		setRegion: vi.fn(),
+		reasoningEffort: "",
+		setReasoningEffort: vi.fn(),
+		awsAccessKey: "",
+		setAwsAccessKey: vi.fn(),
+		awsSecretKey: "",
+		setAwsSecretKey: vi.fn(),
+		awsSessionToken: "",
+		setAwsSessionToken: vi.fn(),
+		awsRegion: "",
+		setAwsRegion: vi.fn(),
+		awsProfile: "",
+		setAwsProfile: vi.fn(),
+		awsAuthentication: "",
+		setAwsAuthentication: vi.fn(),
+		awsEndpoint: "",
+		setAwsEndpoint: vi.fn(),
+		gcpProjectId: "",
+		setGcpProjectId: vi.fn(),
+		gcpRegion: "",
+		setGcpRegion: vi.fn(),
+		providerCatalog: [provider],
+		providerModels: [{ id: provider.defaultModelId ?? "gpt-5.4", name: provider.defaultModelId ?? "gpt-5.4" }],
+		isLoadingProviderCatalog: false,
+		isLoadingProviderModels: false,
+		isRunningOauthLogin: false,
+		deviceAuthInfo: null,
+		normalizedProviderId: providerId,
+		managedOauthProvider: null,
+		isOauthProviderSelected: false,
+		apiKeyConfigured: false,
+		oauthConfigured: false,
+		oauthAccountId: "",
+		oauthExpiresAt: "",
+		selectedModelSupportsReasoningEffort: false,
+		hasUnsavedChanges: false,
+		saveProviderSettings: vi.fn(async () => ({ ok: true })),
+		addCustomProvider: vi.fn(async () => ({ ok: true })),
+		updateCustomProvider: vi.fn(async () => ({ ok: true })),
+		runOauthLogin: vi.fn(async () => ({ ok: true })),
+	};
+}
+
+describe("ClineSetupSection", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let previousActEnvironment: boolean | undefined;
+
+	beforeEach(() => {
+		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		document.body.innerHTML = "";
+		if (previousActEnvironment === undefined) {
+			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+		} else {
+			(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+				previousActEnvironment;
+		}
+	});
+
+	it("does not show custom-provider edit controls for built-in providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(createProvider({ custom: false }))}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeNull();
+	});
+
+	it("shows custom-provider edit controls for local custom providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(createProvider({ id: "my-provider", name: "My Provider", custom: true }))}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeInstanceOf(HTMLButtonElement);
+	});
+});

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -150,7 +150,10 @@ export function ClineSetupSection({
 		() => clineProviderOptions.find((option) => option.value === controller.providerId) ?? null,
 		[clineProviderOptions, controller.providerId],
 	);
-	const canEditSelectedProvider = controller.providerId.trim().length > 0 && !controller.isOauthProviderSelected;
+	const canEditSelectedProvider =
+		controller.providerId.trim().length > 0 &&
+		!controller.isOauthProviderSelected &&
+		selectedProvider?.custom === true;
 	const selectedProviderEditInitialValues = useMemo((): ClineProviderDialogInitialValues | null => {
 		if (!canEditSelectedProvider) {
 			return null;


### PR DESCRIPTION
## Summary
- mark SDK catalog entries that come from the local custom provider registry
- show the OpenAI-compatible provider edit modal only for local custom providers
- add a focused setup-section regression test for built-in vs custom providers

## Root cause
Kanban showed the custom-provider edit modal for every non-OAuth provider. Built-in providers like LiteLLM then called the custom-provider update path, which correctly failed because `litellm` is not in the local custom provider registry.

## Validation
- npm --prefix web-ui run test -- src/components/shared/cline-setup-section.test.tsx
- npm --prefix web-ui run typecheck
- npm --prefix web-ui run build
- in-app browser verification on patched Vite UI: LiteLLM still shows normal API key/base URL/model settings, and no custom-provider Edit button is present

Note: root `npm run typecheck` could not be validated in this temporary clean worktree because I reused dependency folders from another checkout and the installed `@clinebot/core` version does not match this branch's lockfile.