### PR TITLE
Add LiteLLM model refresh action

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -21,6 +21,7 @@ import type {
 	RuntimeClineReasoningEffort,
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
+import { createKanbanClineLogger } from "./cline-runtime-logger";
 import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
@@ -58,8 +59,16 @@ const MANAGED_PROVIDER_ENV_KEYS: Record<ManagedClineOauthProviderId, readonly st
 const CLINE_REMOTE_CONFIG_SCHEMA = z.object({
 	kanbanEnabled: z.boolean().optional(),
 });
+const LITELLM_MODELS_RESPONSE_SCHEMA = z.object({
+	data: z.array(z.object({ id: z.string().optional(), model_name: z.string().optional() }).passthrough()).optional(),
+});
+const LITELLM_MODEL_LIST_PATHNAMES = ["/models", "/model/info"] as const;
+const LITELLM_MODEL_LIST_TIMEOUT_MS = 2_500;
+const LOGGER = createKanbanClineLogger({ component: "cline-provider-service" });
 
 type ClineRemoteConfig = z.infer<typeof CLINE_REMOTE_CONFIG_SCHEMA>;
+type LiteLlmModelListPathname = (typeof LITELLM_MODEL_LIST_PATHNAMES)[number];
+type LiteLlmModelListItem = NonNullable<z.infer<typeof LITELLM_MODELS_RESPONSE_SCHEMA>["data"]>[number];
 type SdkReasoningEffort = NonNullable<NonNullable<SdkProviderSettings["reasoning"]>["effort"]>;
 
 export interface ResolvedClineLaunchConfig {
@@ -225,6 +234,83 @@ function toRuntimeProviderModel(model: RuntimeClineProviderModel): RuntimeClineP
 		supportsAttachments: model.supportsAttachments || undefined,
 		supportsReasoningEffort: model.supportsReasoningEffort || undefined,
 	};
+}
+
+function logLiteLlmModelListWarning(message: string, metadata?: Record<string, unknown>): void {
+	LOGGER.log(message, {
+		severity: "warn",
+		providerId: "litellm",
+		...(metadata ?? {}),
+	});
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+	return Object.keys(headers).some((key) => key.toLowerCase() === "authorization");
+}
+
+function resolveLiteLlmModelListHeaders(settings: SdkProviderSettings): Record<string, string> {
+	const headers = { ...(settings.headers ?? {}) };
+	const apiKey = resolveVisibleApiKey(settings);
+	if (apiKey && !hasAuthorizationHeader(headers)) {
+		headers.Authorization = `Bearer ${apiKey}`;
+	}
+	return headers;
+}
+
+function resolveLiteLlmModelListItemId(item: LiteLlmModelListItem, pathname: LiteLlmModelListPathname): string {
+	const modelId = pathname === "/model/info" ? (item.model_name ?? item.id) : item.id;
+	return modelId?.trim() ?? "";
+}
+
+async function fetchLiteLlmBaseUrlModels(settings: SdkProviderSettings | null): Promise<RuntimeClineProviderModel[]> {
+	const baseUrl = settings?.baseUrl?.trim() ?? "";
+	if (!settings || (settings.provider?.trim().toLowerCase() ?? "") !== "litellm" || !baseUrl) {
+		return [];
+	}
+
+	const headers = resolveLiteLlmModelListHeaders(settings);
+	const timeoutMs =
+		typeof settings.timeout === "number" && settings.timeout > 0
+			? Math.min(settings.timeout, LITELLM_MODEL_LIST_TIMEOUT_MS)
+			: LITELLM_MODEL_LIST_TIMEOUT_MS;
+	const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+	for (const pathname of LITELLM_MODEL_LIST_PATHNAMES) {
+		const url = `${normalizedBaseUrl}${pathname}`;
+		try {
+			const response = await globalThis.fetch(url, {
+				method: "GET",
+				headers,
+				signal: AbortSignal.timeout(timeoutMs),
+			});
+			if (!response.ok) {
+				logLiteLlmModelListWarning("LiteLLM model list request returned an unsuccessful response.", {
+					url,
+					status: response.status,
+				});
+				continue;
+			}
+
+			const parsed = LITELLM_MODELS_RESPONSE_SCHEMA.safeParse((await response.json()) as unknown);
+			if (!parsed.success) {
+				logLiteLlmModelListWarning("LiteLLM model list request returned an unexpected response.", { url });
+				continue;
+			}
+
+			const modelIds =
+				parsed.data.data
+					?.map((item) => resolveLiteLlmModelListItemId(item, pathname))
+					.filter((modelId) => modelId.length > 0) ?? [];
+			if (modelIds.length > 0) {
+				return [...new Set(modelIds)].map((id) => ({ id, name: id }));
+			}
+		} catch (error) {
+			logLiteLlmModelListWarning("LiteLLM model list request failed.", {
+				url,
+				errorMessage: toErrorMessage(error),
+			});
+		}
+	}
+	return [];
 }
 
 function createEmptyProviderSettingsSummary(): RuntimeClineProviderSettings {
@@ -786,13 +872,21 @@ export function createClineProviderService() {
 
 		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
 			const normalizedProviderId = providerId.trim().toLowerCase();
-			const providerModels =
+			let providerModels =
 				normalizedProviderId.length > 0
 					? await listSdkProviderModels(normalizedProviderId)
 							.then((sdkModels) => sdkModels.map((model) => toRuntimeProviderModel(model)))
 							.then((sdkModels) => sdkModels.sort((left, right) => left.name.localeCompare(right.name)))
 							.catch(() => [])
 					: [];
+			if (normalizedProviderId === "litellm") {
+				const liteLlmModels = await fetchLiteLlmBaseUrlModels(getSdkProviderSettings(normalizedProviderId));
+				const existingModelIds = new Set(providerModels.map((model) => model.id));
+				providerModels = [
+					...providerModels,
+					...liteLlmModels.filter((model) => !existingModelIds.has(model.id)),
+				].sort((left, right) => left.name.localeCompare(right.name));
+			}
 
 			if (providerModels.length > 0) {
 				return {

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clineAccountMocks = vi.hoisted(() => ({
 	fetchMe: vi.fn(),
@@ -37,6 +37,7 @@ vi.mock("@clinebot/core", () => ({
 	loginOcaOAuth: vi.fn(),
 	loginOpenAICodex: vi.fn(),
 	resolveDefaultMcpSettingsPath: vi.fn(),
+	resolveClineDataDir: vi.fn(() => "/tmp/cline"),
 	loadMcpSettingsFile: vi.fn(),
 	ClineAccountService: class {
 		constructor(options: { apiBaseUrl: string; getAuthToken: () => Promise<string | undefined | null> }) {
@@ -104,6 +105,8 @@ function setSelectedProviderSettings(
 		model?: string;
 		baseUrl?: string;
 		apiKey?: string;
+		headers?: Record<string, string>;
+		timeout?: number;
 		auth?: {
 			accessToken?: string;
 			refreshToken?: string;
@@ -117,6 +120,112 @@ function setSelectedProviderSettings(
 		settings && settings.provider === providerId ? settings : undefined,
 	);
 }
+
+describe("getProviderModels", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setSelectedProviderSettings({
+			provider: "litellm",
+			model: "gpt-5.4",
+			baseUrl: "http://127.0.0.1:4000/v1",
+		});
+		localProviderMocks.getLocalProviderModels.mockResolvedValue({
+			providerId: "litellm",
+			models: [{ id: "gpt-5.4", name: "gpt-5.4" }],
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("loads keyless LiteLLM model aliases from the saved Base URL models endpoint", async () => {
+		const fetchMock = vi.fn<typeof fetch>(async () => {
+			return new Response(
+				JSON.stringify({
+					data: [{ id: "litellm-test-alpha" }, { id: "litellm-test-beta" }, { id: "litellm-test-gamma" }],
+				}),
+				{ status: 200 },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await createClineProviderService().getProviderModels("litellm");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:4000/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: {},
+				signal: expect.any(AbortSignal),
+			}),
+		);
+		expect(result.models.map((model) => model.id)).toEqual([
+			"gpt-5.4",
+			"litellm-test-alpha",
+			"litellm-test-beta",
+			"litellm-test-gamma",
+		]);
+	});
+
+	it("uses LiteLLM model_name values from the model info endpoint", async () => {
+		const fetchMock = vi.fn<typeof fetch>(async (input) => {
+			const url = input.toString();
+			if (url.endsWith("/models")) {
+				return new Response(JSON.stringify({ data: [] }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ data: [{ id: "internal-id", model_name: "litellm-test-alias" }] }), {
+				status: 200,
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await createClineProviderService().getProviderModels("litellm");
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"http://127.0.0.1:4000/v1/model/info",
+			expect.objectContaining({
+				method: "GET",
+				headers: {},
+				signal: expect.any(AbortSignal),
+			}),
+		);
+		expect(result.models.map((model) => model.id)).toEqual(["gpt-5.4", "litellm-test-alias"]);
+	});
+
+	it("passes configured LiteLLM headers and a bounded timeout signal to model list requests", async () => {
+		setSelectedProviderSettings({
+			provider: "litellm",
+			model: "gpt-5.4",
+			baseUrl: "http://127.0.0.1:4000/v1",
+			apiKey: "sk-test",
+			headers: { "X-Proxy-Token": "proxy-token" },
+			timeout: 30_000,
+		});
+		const fetchMock = vi.fn<typeof fetch>(async () => {
+			return new Response(JSON.stringify({ data: [{ id: "litellm-test-alpha" }] }), { status: 200 });
+		});
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+		vi.stubGlobal("fetch", fetchMock);
+
+		await createClineProviderService().getProviderModels("litellm");
+
+		expect(timeoutSpy).toHaveBeenCalledWith(2_500);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://127.0.0.1:4000/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: {
+					Authorization: "Bearer sk-test",
+					"X-Proxy-Token": "proxy-token",
+				},
+				signal: expect.any(AbortSignal),
+			}),
+		);
+		timeoutSpy.mockRestore();
+	});
+});
 
 describe("getClineAccountBalance", () => {
 	beforeEach(() => {

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -28,6 +28,7 @@ const oauthMocks = vi.hoisted(() => ({
 	loginOcaOAuth: vi.fn(),
 	loginOpenAICodex: vi.fn(),
 	resolveDefaultMcpSettingsPath: vi.fn(),
+	resolveClineDataDir: vi.fn(() => "/tmp/cline"),
 	loadMcpSettingsFile: vi.fn(),
 	saveProviderSettings: vi.fn(),
 	getProviderSettings: vi.fn(),
@@ -79,6 +80,7 @@ vi.mock("@clinebot/core", () => ({
 	loginOcaOAuth: oauthMocks.loginOcaOAuth,
 	loginOpenAICodex: oauthMocks.loginOpenAICodex,
 	resolveDefaultMcpSettingsPath: oauthMocks.resolveDefaultMcpSettingsPath,
+	resolveClineDataDir: oauthMocks.resolveClineDataDir,
 	loadMcpSettingsFile: oauthMocks.loadMcpSettingsFile,
 	ClineAccountService: class {
 		constructor(options: { apiBaseUrl: string; getAuthToken: () => Promise<string | undefined | null> }) {

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -1,5 +1,5 @@
 import * as RadixCheckbox from "@radix-ui/react-checkbox";
-import { Check, Copy, ExternalLink, Pencil, Plus, X } from "lucide-react";
+import { Check, Copy, ExternalLink, Pencil, Plus, RefreshCw, X } from "lucide-react";
 import { type ReactElement, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -14,6 +14,7 @@ import {
 } from "@/components/shared/cline-add-provider-dialog";
 import { Button } from "@/components/ui/button";
 import { NativeSelect } from "@/components/ui/native-select";
+import { Tooltip } from "@/components/ui/tooltip";
 import type {
 	AddClineProviderInput,
 	UpdateClineProviderInput,
@@ -262,6 +263,17 @@ export function ClineSetupSection({
 		setIsDeviceCodeCopied(false);
 		onError?.(null);
 		copyDeviceCode(code);
+	};
+
+	const handleRefreshProviderModels = () => {
+		void (async () => {
+			onError?.(null);
+			const result = await controller.refreshProviderModels();
+			if (!result.ok) {
+				onError?.(result.message ?? "Failed to refresh Cline models.");
+				return;
+			}
+		})();
 	};
 
 	return (
@@ -556,7 +568,30 @@ export function ClineSetupSection({
 					style={{ gridTemplateColumns: controller.selectedModelSupportsReasoningEffort ? "1fr 1fr" : "1fr" }}
 				>
 					<div className="min-w-0">
-						<p className="text-text-secondary text-[12px] mt-0 mb-1">Model ID</p>
+						<div className="mb-1 flex items-center justify-between gap-2">
+							<p className="text-text-secondary text-[12px] m-0">Model ID</p>
+							{shouldShowBaseUrlField ? (
+								<Tooltip side="bottom" content="Save settings and refresh models">
+									<Button
+										variant="ghost"
+										size="sm"
+										icon={
+											<RefreshCw
+												size={14}
+												className={controller.isLoadingProviderModels ? "animate-spin" : undefined}
+											/>
+										}
+										aria-label="Save settings and refresh models"
+										disabled={
+											controlsDisabled ||
+											controller.isLoadingProviderModels ||
+											controller.providerId.trim().length === 0
+										}
+										onClick={handleRefreshProviderModels}
+									/>
+								</Tooltip>
+							) : null}
+						</div>
 						<SearchSelectDropdown
 							options={clineModelOptions}
 							selectedValue={controller.modelId}

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx
@@ -3,7 +3,12 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useRuntimeSettingsClineController } from "@/hooks/use-runtime-settings-cline-controller";
-import type { RuntimeClineReasoningEffort, RuntimeConfigResponse, RuntimeTaskClineSettings } from "@/runtime/types";
+import type {
+	RuntimeClineProviderModel,
+	RuntimeClineReasoningEffort,
+	RuntimeConfigResponse,
+	RuntimeTaskClineSettings,
+} from "@/runtime/types";
 
 const fetchClineProviderCatalogMock = vi.hoisted(() => vi.fn());
 const fetchClineProviderModelsMock = vi.hoisted(() => vi.fn());
@@ -52,6 +57,7 @@ interface HookSnapshot {
 	saveProviderSettings: (
 		overrides?: Parameters<ReturnType<typeof useRuntimeSettingsClineController>["saveProviderSettings"]>[0],
 	) => Promise<{ ok: boolean; message?: string }>;
+	refreshProviderModels: () => Promise<{ ok: boolean; message?: string }>;
 	addCustomProvider: (
 		input: Parameters<ReturnType<typeof useRuntimeSettingsClineController>["addCustomProvider"]>[0],
 	) => Promise<{ ok: boolean; message?: string }>;
@@ -119,6 +125,20 @@ async function flushAsyncWork(): Promise<void> {
 	await Promise.resolve();
 }
 
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+} {
+	let resolve: (value: T) => void = () => {};
+	let reject: (reason?: unknown) => void = () => {};
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
 function HookHarness({
 	open,
 	workspaceId,
@@ -173,6 +193,7 @@ function HookHarness({
 				state.setReasoningEffort(value as RuntimeClineReasoningEffort | "");
 			},
 			saveProviderSettings: state.saveProviderSettings,
+			refreshProviderModels: state.refreshProviderModels,
 			addCustomProvider: state.addCustomProvider,
 			runOauthLogin: state.runOauthLogin,
 		});
@@ -746,6 +767,173 @@ describe("useRuntimeSettingsClineController", () => {
 			baseUrl: "https://openrouter.ai/api/v1",
 			reasoningEffort: null,
 		});
+	});
+
+	it("saves base URL provider settings before refreshing models", async () => {
+		const config = createRuntimeConfigResponse({
+			providerId: "litellm",
+			oauthProvider: null,
+			modelId: "gpt-5.4",
+			baseUrl: null,
+			apiKeyConfigured: false,
+		});
+		let latestSnapshot: HookSnapshot | null = null;
+		fetchClineProviderCatalogMock.mockResolvedValue([
+			{
+				id: "litellm",
+				name: "LiteLLM",
+				oauthSupported: false,
+				enabled: true,
+				defaultModelId: "gpt-5.4",
+				baseUrl: "http://localhost:4000/v1",
+				supportsBaseUrl: true,
+			},
+		]);
+		fetchClineProviderModelsMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+			{
+				id: "private-proxy-model",
+				name: "private-proxy-model",
+				supportsReasoningEffort: true,
+			},
+		]);
+		saveClineProviderSettingsMock.mockResolvedValue({
+			providerId: "litellm",
+			modelId: "gpt-5.4",
+			baseUrl: "http://127.0.0.1:4010/v1",
+			reasoningEffort: null,
+			apiKeyConfigured: true,
+			oauthProvider: null,
+			oauthAccessTokenConfigured: false,
+			oauthRefreshTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					open={true}
+					workspaceId="workspace-1"
+					selectedAgentId="cline"
+					config={config}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			await flushAsyncWork();
+		});
+
+		expect(requireSnapshot(latestSnapshot).baseUrl).toBe("http://localhost:4000/v1");
+		expect(requireSnapshot(latestSnapshot).providerModelIds).toEqual([]);
+
+		await act(async () => {
+			requireSnapshot(latestSnapshot).setBaseUrl("http://127.0.0.1:4010/v1");
+			requireSnapshot(latestSnapshot).setApiKey("test-key-catalog");
+			await flushAsyncWork();
+		});
+
+		expect(requireSnapshot(latestSnapshot).hasUnsavedChanges).toBe(true);
+
+		await act(async () => {
+			expect(await requireSnapshot(latestSnapshot).refreshProviderModels()).toEqual({ ok: true });
+			await flushAsyncWork();
+		});
+
+		expect(saveClineProviderSettingsMock).toHaveBeenCalledWith("workspace-1", {
+			providerId: "litellm",
+			modelId: "gpt-5.4",
+			apiKey: "test-key-catalog",
+			baseUrl: "http://127.0.0.1:4010/v1",
+			reasoningEffort: null,
+		});
+		expect(fetchClineProviderModelsMock).toHaveBeenLastCalledWith("workspace-1", "litellm");
+		expect(requireSnapshot(latestSnapshot).providerModelIds).toEqual(["private-proxy-model"]);
+		expect(requireSnapshot(latestSnapshot).hasUnsavedChanges).toBe(false);
+	});
+
+	it("keeps refreshed provider models when the initial model load resolves later", async () => {
+		const config = createRuntimeConfigResponse({
+			providerId: "litellm",
+			oauthProvider: null,
+			modelId: "gpt-5.4",
+			baseUrl: "http://localhost:4000/v1",
+			apiKeyConfigured: false,
+		});
+		const initialModels = createDeferred<RuntimeClineProviderModel[]>();
+		let latestSnapshot: HookSnapshot | null = null;
+		fetchClineProviderCatalogMock.mockResolvedValue([
+			{
+				id: "litellm",
+				name: "LiteLLM",
+				oauthSupported: false,
+				enabled: true,
+				defaultModelId: "gpt-5.4",
+				baseUrl: "http://localhost:4000/v1",
+				supportsBaseUrl: true,
+			},
+		]);
+		fetchClineProviderModelsMock.mockReturnValueOnce(initialModels.promise).mockResolvedValueOnce([
+			{
+				id: "fresh-proxy-model",
+				name: "fresh-proxy-model",
+			},
+		]);
+		saveClineProviderSettingsMock.mockResolvedValue({
+			providerId: "litellm",
+			modelId: "gpt-5.4",
+			baseUrl: "http://127.0.0.1:4010/v1",
+			reasoningEffort: null,
+			apiKeyConfigured: false,
+			oauthProvider: null,
+			oauthAccessTokenConfigured: false,
+			oauthRefreshTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					open={true}
+					workspaceId="workspace-1"
+					selectedAgentId="cline"
+					config={config}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			requireSnapshot(latestSnapshot).setBaseUrl("http://127.0.0.1:4010/v1");
+			await flushAsyncWork();
+		});
+
+		await act(async () => {
+			expect(await requireSnapshot(latestSnapshot).refreshProviderModels()).toEqual({ ok: true });
+			await flushAsyncWork();
+		});
+
+		expect(requireSnapshot(latestSnapshot).providerModelIds).toEqual(["fresh-proxy-model"]);
+
+		await act(async () => {
+			initialModels.resolve([
+				{
+					id: "stale-proxy-model",
+					name: "stale-proxy-model",
+				},
+			]);
+			await flushAsyncWork();
+		});
+
+		expect(requireSnapshot(latestSnapshot).providerModelIds).toEqual(["fresh-proxy-model"]);
 	});
 
 	it("adds a custom provider and refreshes catalog and models", async () => {

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
@@ -1,7 +1,7 @@
 // Owns the Cline-specific settings state machine inside the settings dialog.
 // It loads provider data, drives model selection, saves settings, and runs
 // OAuth login flows so the dialog component can stay presentation-focused.
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getRuntimeClineProviderSettings } from "@/runtime/native-agent";
 import {
 	addClineProvider,
@@ -136,6 +136,7 @@ export interface UseRuntimeSettingsClineControllerResult {
 	selectedModelSupportsReasoningEffort: boolean;
 	hasUnsavedChanges: boolean;
 	saveProviderSettings: (overrides?: SaveProviderSettingsOverrides) => Promise<SaveResult>;
+	refreshProviderModels: () => Promise<SaveResult>;
 	addCustomProvider: (input: AddClineProviderInput) => Promise<SaveResult>;
 	updateCustomProvider: (input: UpdateClineProviderInput) => Promise<SaveResult>;
 	runOauthLogin: () => Promise<SaveResult>;
@@ -221,6 +222,7 @@ export function useRuntimeSettingsClineController(
 	const [providerModels, setProviderModels] = useState<RuntimeClineProviderModel[]>([]);
 	const [isLoadingProviderCatalog, setIsLoadingProviderCatalog] = useState(false);
 	const [isLoadingProviderModels, setIsLoadingProviderModels] = useState(false);
+	const providerModelsRequestIdRef = useRef(0);
 	const [isRunningOauthLogin, setIsRunningOauthLogin] = useState(false);
 	const [deviceAuthInfo, setDeviceAuthInfo] = useState<{
 		userCode: string;
@@ -442,41 +444,52 @@ export function useRuntimeSettingsClineController(
 		setBaseUrl(normalizeBaseUrlForProvider(providerId, defaultBaseUrl));
 	}, [baseUrl, open, providerCatalog, providerId, selectedAgentId]);
 
+	const nextProviderModelsRequestId = useCallback((): number => {
+		providerModelsRequestIdRef.current += 1;
+		return providerModelsRequestIdRef.current;
+	}, []);
+
+	const loadProviderModelsForProvider = useCallback(
+		async (nextProviderId: string, requestId = nextProviderModelsRequestId()): Promise<void> => {
+			setIsLoadingProviderModels(true);
+			try {
+				const nextModels = await fetchClineProviderModels(workspaceId, nextProviderId);
+				if (providerModelsRequestIdRef.current === requestId) {
+					setProviderModels(nextModels);
+				}
+			} catch (error) {
+				if (providerModelsRequestIdRef.current === requestId) {
+					setProviderModels([]);
+				}
+				throw error;
+			} finally {
+				if (providerModelsRequestIdRef.current === requestId) {
+					setIsLoadingProviderModels(false);
+				}
+			}
+		},
+		[nextProviderModelsRequestId, workspaceId],
+	);
+
 	useEffect(() => {
 		if (!open || selectedAgentId !== "cline") {
+			nextProviderModelsRequestId();
 			setProviderModels([]);
 			setIsLoadingProviderModels(false);
 			return;
 		}
 		const trimmedProviderId = providerId.trim();
 		if (trimmedProviderId.length === 0) {
+			nextProviderModelsRequestId();
 			setProviderModels([]);
 			setIsLoadingProviderModels(false);
 			return;
 		}
-		let cancelled = false;
-		setIsLoadingProviderModels(true);
-		void fetchClineProviderModels(workspaceId, trimmedProviderId)
-			.then((nextModels) => {
-				if (cancelled) {
-					return;
-				}
-				setProviderModels(nextModels);
-			})
-			.catch(() => {
-				if (!cancelled) {
-					setProviderModels([]);
-				}
-			})
-			.finally(() => {
-				if (!cancelled) {
-					setIsLoadingProviderModels(false);
-				}
-			});
+		void loadProviderModelsForProvider(trimmedProviderId).catch(() => {});
 		return () => {
-			cancelled = true;
+			nextProviderModelsRequestId();
 		};
-	}, [open, providerId, selectedAgentId, workspaceId]);
+	}, [loadProviderModelsForProvider, nextProviderModelsRequestId, open, providerId, selectedAgentId]);
 
 	const saveProviderSettingsDraft = useCallback(
 		async (overrides?: SaveProviderSettingsOverrides): Promise<SaveResult> => {
@@ -581,6 +594,48 @@ export function useRuntimeSettingsClineController(
 		],
 	);
 
+	const refreshProviderModels = useCallback(async (): Promise<SaveResult> => {
+		const trimmedProviderId = providerId.trim();
+		if (trimmedProviderId.length === 0) {
+			return {
+				ok: false,
+				message: "Choose a Cline provider before refreshing models.",
+			};
+		}
+
+		setIsLoadingProviderModels(true);
+		const requestId = nextProviderModelsRequestId();
+		try {
+			const saveResult = await saveProviderSettingsDraft({
+				providerId: trimmedProviderId,
+				modelId: modelId.trim() || null,
+				baseUrl: baseUrl.trim() || null,
+			});
+			if (!saveResult.ok) {
+				return saveResult;
+			}
+
+			await loadProviderModelsForProvider(trimmedProviderId, requestId);
+			return { ok: true };
+		} catch (error) {
+			return {
+				ok: false,
+				message: error instanceof Error ? error.message : String(error),
+			};
+		} finally {
+			if (providerModelsRequestIdRef.current === requestId) {
+				setIsLoadingProviderModels(false);
+			}
+		}
+	}, [
+		baseUrl,
+		loadProviderModelsForProvider,
+		modelId,
+		nextProviderModelsRequestId,
+		providerId,
+		saveProviderSettingsDraft,
+	]);
+
 	const addCustomProvider = useCallback(
 		async (input: AddClineProviderInput): Promise<SaveResult> => {
 			try {
@@ -600,12 +655,7 @@ export function useRuntimeSettingsClineController(
 					setIsLoadingProviderCatalog(false);
 				}
 
-				setIsLoadingProviderModels(true);
-				try {
-					setProviderModels(await fetchClineProviderModels(workspaceId, nextProviderId));
-				} finally {
-					setIsLoadingProviderModels(false);
-				}
+				await loadProviderModelsForProvider(nextProviderId);
 
 				return { ok: true };
 			} catch (error) {
@@ -615,7 +665,7 @@ export function useRuntimeSettingsClineController(
 				};
 			}
 		},
-		[workspaceId],
+		[loadProviderModelsForProvider, workspaceId],
 	);
 
 	const runOauthLogin = useCallback(async (): Promise<SaveResult> => {
@@ -690,12 +740,7 @@ export function useRuntimeSettingsClineController(
 					setIsLoadingProviderCatalog(false);
 				}
 
-				setIsLoadingProviderModels(true);
-				try {
-					setProviderModels(await fetchClineProviderModels(workspaceId, nextProviderId));
-				} finally {
-					setIsLoadingProviderModels(false);
-				}
+				await loadProviderModelsForProvider(nextProviderId);
 
 				return { ok: true };
 			} catch (error) {
@@ -705,7 +750,7 @@ export function useRuntimeSettingsClineController(
 				};
 			}
 		},
-		[baseUrl, modelId, workspaceId],
+		[baseUrl, loadProviderModelsForProvider, modelId, workspaceId],
 	);
 
 	return {
@@ -756,6 +801,7 @@ export function useRuntimeSettingsClineController(
 		selectedModelSupportsReasoningEffort,
 		hasUnsavedChanges,
 		saveProviderSettings: saveProviderSettingsDraft,
+		refreshProviderModels,
 		addCustomProvider,
 		updateCustomProvider,
 		runOauthLogin,


### PR DESCRIPTION
## Motivation
LiteLLM and other Base URL-backed providers get their model list from saved SDK provider settings. Before this change, editing the Base URL in Kanban settings and immediately refreshing models still used the previous saved settings, so the user had to save, reopen settings, and only then see aliases from the new LiteLLM URL.

The refresh action now saves the current draft provider settings first, then asks the runtime for models. That keeps the SDK-backed provider store, Kanban UI state, and keyless LiteLLM `/v1/models` discovery pointed at the same URL during the refresh.

## Summary
- add a small refresh action for Base URL-backed Cline providers so settings are saved before fetching provider models
- refresh provider models after saving the current LiteLLM/custom provider base URL and API key draft values
- keep the settings dialog on Cline after refreshing models instead of resetting to the saved default agent
- add a compact LiteLLM keyless Base URL discovery fallback so local proxies exposing `/v1/models` show their model aliases even when no API key is configured
- bound the LiteLLM model-list probe to 2.5s, preserve configured request headers/global fetch behavior, and parse `/model/info` aliases from `model_name`
- guard provider-model loads with a latest-request id so an older initial load cannot overwrite models returned by a newer refresh

## Verification
- verified `http://127.0.0.1:4000/v1/models` returns `litellm-test-alpha`, `litellm-test-beta`, and `litellm-test-gamma`
- verified Kanban runtime returns `gpt-5.4` plus those three LiteLLM aliases for `getClineProviderModels({ providerId: "litellm" })` with `apiKeyConfigured: false`
- `npx @biomejs/biome check src/cline-sdk/cline-provider-service.ts test/runtime/cline-sdk/account-balance.test.ts test/runtime/trpc/runtime-api.test.ts web-ui/src/components/shared/cline-setup-section.tsx web-ui/src/hooks/use-runtime-settings-cline-controller.ts web-ui/src/hooks/use-runtime-settings-cline-controller.test.tsx`
- `npx vitest run test/runtime/cline-sdk/account-balance.test.ts`
- `npm --prefix web-ui run test -- src/hooks/use-runtime-settings-cline-controller.test.tsx`
- `npm run typecheck`
- `npm run test:fast`
- `npm run web:build`
- `npm --prefix packages/desktop run typecheck`
- `npm --prefix packages/desktop test`
- pre-commit: Biome, root typecheck, `npm run test:fast`