### PR TITLE
fix: auto load latest model catalog on startup

### DIFF
--- a/src/cline-sdk/cline-session-runtime.ts
+++ b/src/cline-sdk/cline-session-runtime.ts
@@ -22,6 +22,12 @@ import {
 } from "./sdk-runtime-boundary";
 
 const DEFAULT_CLINE_MAX_CONSECUTIVE_MISTAKES = 6;
+const CLINE_MODEL_CATALOG_DEFAULTS = {
+	loadLatestOnInit: true,
+	loadPrivateOnAuth: true,
+	failOnError: false,
+} as const;
+
 interface ClineSessionHostBoundary {
 	start(input: ClineSdkStartSessionInput): Promise<{ sessionId: string; result?: unknown }>;
 	send(input: Parameters<ClineSdkSessionHost["send"]>[0]): Promise<unknown>;
@@ -231,9 +237,10 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 				initialMessages: request.initialMessages,
 				interactive: true,
 				userImages: toSdkUserImages(request.images),
-				localRuntime: request.userInstructionWatcher
-					? { userInstructionWatcher: request.userInstructionWatcher }
-					: undefined,
+				localRuntime: {
+					modelCatalogDefaults: CLINE_MODEL_CATALOG_DEFAULTS,
+					...(request.userInstructionWatcher ? { userInstructionWatcher: request.userInstructionWatcher } : {}),
+				},
 				requestToolApproval: request.requestToolApproval,
 			});
 		} catch (error) {

--- a/test/runtime/cline-sdk/cline-session-runtime.test.ts
+++ b/test/runtime/cline-sdk/cline-session-runtime.test.ts
@@ -113,6 +113,13 @@ describe("InMemoryClineSessionRuntime", () => {
 						}),
 					]),
 				}),
+				localRuntime: expect.objectContaining({
+					modelCatalogDefaults: {
+						loadLatestOnInit: true,
+						loadPrivateOnAuth: true,
+						failOnError: false,
+					},
+				}),
 			}),
 		);
 	});

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -467,9 +467,7 @@ export function BoardCard({
 		return parts.length > 0 ? parts.join(" · ") : null;
 	}, [agentOverrideLabel, modelOverrideLabel]);
 
-	const activeDescriptionDisplay = isDescriptionExpanded
-		? descriptionDisplay.expanded
-		: descriptionDisplay.collapsed;
+	const activeDescriptionDisplay = isDescriptionExpanded ? descriptionDisplay.expanded : descriptionDisplay.collapsed;
 
 	return (
 		<Draggable draggableId={card.id} index={index} isDragDisabled={false}>
@@ -688,9 +686,7 @@ export function BoardCard({
 														setIsDescriptionExpanded(!isDescriptionExpanded);
 													}}
 												>
-													{isDescriptionExpanded
-														? DESCRIPTION_COLLAPSE_LABEL
-														: DESCRIPTION_EXPAND_LABEL}
+													{isDescriptionExpanded ? DESCRIPTION_COLLAPSE_LABEL : DESCRIPTION_EXPAND_LABEL}
 												</button>
 											</>
 										) : isDescriptionExpanded && descriptionDisplay.collapsed.isTruncated ? (


### PR DESCRIPTION
Configure Kanban-started Cline sessions to load the latest public model catalog on init, load private models after auth, and avoid failing startup when catalog loading errors occur.

Also updates the session runtime test to assert the local runtime catalog defaults are passed to the SDK host.