### PR TITLE
Support local overrides for editable Cline providers

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -757,6 +757,8 @@ export function createClineProviderService() {
 							env: provider.env,
 							capabilities: provider.capabilities,
 							modelsSourceUrl: provider.modelsSourceUrl?.trim() || null,
+							headers: provider.headers,
+							timeoutMs: provider.timeoutMs,
 						}))
 						.sort((left, right) => {
 							if (left.id === "cline") {

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -747,12 +747,16 @@ export function createClineProviderService() {
 							id: provider.id,
 							name: provider.name,
 							oauthSupported: (provider.capabilities ?? []).includes("oauth"),
+							custom: provider.custom,
+							client: provider.client,
 							enabled:
 								selectedProviderId.length > 0 ? selectedProviderId === provider.id : provider.id === "cline",
 							defaultModelId: provider.defaultModelId ?? null,
 							baseUrl: provider.baseUrl?.trim() || null,
 							supportsBaseUrl: (provider.baseUrl?.trim().length ?? 0) > 0,
 							env: provider.env,
+							capabilities: provider.capabilities,
+							modelsSourceUrl: provider.modelsSourceUrl?.trim() || null,
 						}))
 						.sort((left, right) => {
 							if (left.id === "cline") {

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -64,6 +64,8 @@ export interface SdkProviderCatalogItem {
 	capabilities?: string[];
 	client?: string;
 	modelsSourceUrl?: string;
+	headers?: Record<string, string>;
+	timeoutMs?: number;
 	custom?: boolean;
 }
 
@@ -341,11 +343,17 @@ export async function completeClineDeviceAuth(input: {
 
 export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]> {
 	const localModels = await readModelsRegistry();
-	return (await ClineCore.Llms.getAllProviders()).map((provider: SdkProviderCatalogItem) => ({
-		...provider,
-		custom: Boolean(localModels.providers[provider.id.trim().toLowerCase()]),
-		modelsSourceUrl: localModels.providers[provider.id.trim().toLowerCase()]?.provider.modelsSourceUrl,
-	}));
+	return (await ClineCore.Llms.getAllProviders()).map((provider: SdkProviderCatalogItem) => {
+		const providerId = provider.id.trim().toLowerCase();
+		const providerSettings = providerManager.getProviderSettings(providerId);
+		return {
+			...provider,
+			custom: Boolean(localModels.providers[providerId]),
+			modelsSourceUrl: localModels.providers[providerId]?.provider.modelsSourceUrl,
+			headers: providerSettings?.headers,
+			timeoutMs: providerSettings?.timeout,
+		};
+	});
 }
 
 export async function listSdkProviderModels(providerId: string): Promise<SdkProviderModel[]> {

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -350,8 +350,8 @@ export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]
 		return {
 			...provider,
 			custom: Boolean(localProvider),
-			capabilities: localProvider?.capabilities ?? provider.capabilities,
-			modelsSourceUrl: localProvider?.modelsSourceUrl,
+			capabilities: localProvider ? localProvider.capabilities : provider.capabilities,
+			modelsSourceUrl: localProvider ? localProvider.modelsSourceUrl : provider.modelsSourceUrl,
 			headers: providerSettings?.headers,
 			timeoutMs: providerSettings?.timeout,
 		};
@@ -410,11 +410,6 @@ function toCustomProviderCapabilities(
 		CUSTOM_PROVIDER_CAPABILITIES.has(value as SdkCustomProviderCapability),
 	);
 	return capabilities && capabilities.length > 0 ? [...new Set(capabilities)] : undefined;
-}
-
-function isMissingLocalProviderError(error: unknown, providerId: string): boolean {
-	const message = error instanceof Error ? error.message : String(error);
-	return message === `provider "${providerId}" does not exist`;
 }
 
 function titleCaseProviderId(providerId: string): string {
@@ -544,26 +539,26 @@ export async function updateSdkCustomProvider(input: UpdateSdkCustomProviderInpu
 	).updateLocalProvider;
 	if (updateLocalProvider) {
 		const providerId = normalizeProviderId(input.providerId);
+		const previousModelsState = await readModelsRegistry();
+		const hasLocalProvider = Boolean(previousModelsState.providers[providerId]);
+		const shouldSeedLocalOverride = !hasLocalProvider && Boolean(await getOverrideableBuiltInProvider(providerId));
+		const previousSettingsState = shouldSeedLocalOverride ? providerManager.read() : null;
+		if (shouldSeedLocalOverride) {
+			await seedLocalProviderOverride(input);
+		}
 		try {
 			await updateLocalProvider(providerManager, input);
 			return;
 		} catch (error) {
-			if (!isMissingLocalProviderError(error, providerId) || !(await getOverrideableBuiltInProvider(providerId))) {
-				throw error;
-			}
-			const previousModelsState = await readModelsRegistry();
-			const previousSettingsState = providerManager.read();
-			await seedLocalProviderOverride(input);
-			try {
-				await updateLocalProvider(providerManager, input);
-			} catch (updateError) {
+			if (shouldSeedLocalOverride) {
 				await writeModelsRegistry(previousModelsState);
-				providerManager.write(previousSettingsState);
+				if (previousSettingsState) {
+					providerManager.write(previousSettingsState);
+				}
 				ClineCore.Llms.unregisterProvider(providerId);
-				throw updateError;
 			}
+			throw error;
 		}
-		return;
 	}
 
 	const providerId = normalizeProviderId(input.providerId);

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -345,11 +345,13 @@ export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]
 	const localModels = await readModelsRegistry();
 	return (await ClineCore.Llms.getAllProviders()).map((provider: SdkProviderCatalogItem) => {
 		const providerId = provider.id.trim().toLowerCase();
+		const localProvider = localModels.providers[providerId]?.provider;
 		const providerSettings = providerManager.getProviderSettings(providerId);
 		return {
 			...provider,
-			custom: Boolean(localModels.providers[providerId]),
-			modelsSourceUrl: localModels.providers[providerId]?.provider.modelsSourceUrl,
+			custom: Boolean(localProvider),
+			capabilities: localProvider?.capabilities ?? provider.capabilities,
+			modelsSourceUrl: localProvider?.modelsSourceUrl,
 			headers: providerSettings?.headers,
 			timeoutMs: providerSettings?.timeout,
 		};

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -2,7 +2,7 @@
 // The rest of Kanban should talk to the SDK through local service modules so
 // auth, catalog, and provider-settings behavior stay behind one boundary.
 
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import * as ClineCore from "@clinebot/core";
 import {
@@ -62,6 +62,9 @@ export interface SdkProviderCatalogItem {
 	baseUrl?: string;
 	env?: string[];
 	capabilities?: string[];
+	client?: string;
+	modelsSourceUrl?: string;
+	custom?: boolean;
 }
 
 export interface SdkProviderModel {
@@ -125,10 +128,42 @@ type LocalModelsFile = {
 				capabilities?: SdkCustomProviderCapability[];
 				modelsSourceUrl?: string;
 			};
-			models: Record<string, { id: string; name: string }>;
+			models: Record<
+				string,
+				{
+					id: string;
+					name: string;
+					supportsVision?: boolean;
+					supportsAttachments?: boolean;
+					supportsReasoning?: boolean;
+				}
+			>;
 		}
 	>;
 };
+
+type UpdateLocalProviderRequest = {
+	providerId: string;
+	name?: string;
+	baseUrl?: string;
+	apiKey?: string | null;
+	headers?: Record<string, string> | null;
+	timeoutMs?: number | null;
+	models?: string[];
+	defaultModelId?: string | null;
+	modelsSourceUrl?: string | null;
+	capabilities?: SdkCustomProviderCapability[];
+};
+
+const MANAGED_OAUTH_PROVIDER_IDS = new Set<string>(["cline", "oca", "openai-codex"]);
+const OPENAI_COMPATIBLE_CLIENT = "openai-compatible";
+const CUSTOM_PROVIDER_CAPABILITIES = new Set<SdkCustomProviderCapability>([
+	"streaming",
+	"tools",
+	"reasoning",
+	"vision",
+	"prompt-cache",
+]);
 
 export type SdkMcpTool = Tool;
 
@@ -305,7 +340,12 @@ export async function completeClineDeviceAuth(input: {
 }
 
 export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]> {
-	return await ClineCore.Llms.getAllProviders();
+	const localModels = await readModelsRegistry();
+	return (await ClineCore.Llms.getAllProviders()).map((provider: SdkProviderCatalogItem) => ({
+		...provider,
+		custom: Boolean(localModels.providers[provider.id.trim().toLowerCase()]),
+		modelsSourceUrl: localModels.providers[provider.id.trim().toLowerCase()]?.provider.modelsSourceUrl,
+	}));
 }
 
 export async function listSdkProviderModels(providerId: string): Promise<SdkProviderModel[]> {
@@ -340,7 +380,131 @@ async function readModelsRegistry(): Promise<LocalModelsFile> {
 }
 
 async function writeModelsRegistry(state: LocalModelsFile): Promise<void> {
-	await writeFile(resolveModelsPath(), `${JSON.stringify(state, null, 2)}\n`, "utf8");
+	const modelsPath = resolveModelsPath();
+	await mkdir(dirname(modelsPath), { recursive: true });
+	await writeFile(modelsPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function normalizeProviderId(providerId: string): string {
+	return providerId.trim().toLowerCase();
+}
+
+function uniqueTrimmed(values: readonly string[] | undefined): string[] {
+	return [...new Set((values ?? []).map((value) => value.trim()).filter((value) => value.length > 0))];
+}
+
+function toCustomProviderCapabilities(
+	values: readonly string[] | null | undefined,
+): SdkCustomProviderCapability[] | undefined {
+	const capabilities = values?.filter((value): value is SdkCustomProviderCapability =>
+		CUSTOM_PROVIDER_CAPABILITIES.has(value as SdkCustomProviderCapability),
+	);
+	return capabilities && capabilities.length > 0 ? [...new Set(capabilities)] : undefined;
+}
+
+function isMissingLocalProviderError(error: unknown, providerId: string): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message === `provider "${providerId}" does not exist`;
+}
+
+function titleCaseProviderId(providerId: string): string {
+	return providerId
+		.split(/[-_]/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+async function getOverrideableBuiltInProvider(providerId: string): Promise<SdkProviderCatalogItem | null> {
+	if (MANAGED_OAUTH_PROVIDER_IDS.has(providerId)) {
+		return null;
+	}
+	const provider = (await ClineCore.Llms.getProvider(providerId)) as SdkProviderCatalogItem | undefined;
+	if (!provider || provider.client !== OPENAI_COMPATIBLE_CLIENT) {
+		return null;
+	}
+	if ((provider.capabilities ?? []).includes("oauth")) {
+		return null;
+	}
+	return provider;
+}
+
+async function readRegisteredProviderModels(
+	providerId: string,
+): Promise<Record<string, { id?: string; name?: string }>> {
+	return (await ClineCore.Llms.getModelsForProvider(providerId)) as Record<string, { id?: string; name?: string }>;
+}
+
+async function resolveSeedModelIds(input: UpdateSdkCustomProviderInput, providerId: string): Promise<string[]> {
+	const explicitModels = uniqueTrimmed(input.models);
+	if (explicitModels.length > 0) {
+		return explicitModels;
+	}
+
+	const registeredModels = await readRegisteredProviderModels(providerId).catch(
+		(): Record<string, { id?: string; name?: string }> => ({}),
+	);
+	const registeredModelIds = uniqueTrimmed(Object.keys(registeredModels));
+	if (registeredModelIds.length > 0) {
+		return registeredModelIds;
+	}
+
+	return [];
+}
+
+async function seedLocalProviderOverride(input: UpdateSdkCustomProviderInput): Promise<void> {
+	const providerId = normalizeProviderId(input.providerId);
+	const state = await readModelsRegistry();
+	if (state.providers[providerId]) {
+		return;
+	}
+
+	const provider = await getOverrideableBuiltInProvider(providerId);
+	if (!provider) {
+		throw new Error(`provider "${providerId}" does not exist`);
+	}
+
+	const resolvedModelIds = await resolveSeedModelIds(input, providerId);
+	const fallbackDefaultModelId = input.defaultModelId?.trim() || provider.defaultModelId?.trim() || "";
+	const modelIds =
+		resolvedModelIds.length > 0 ? resolvedModelIds : fallbackDefaultModelId ? [fallbackDefaultModelId] : [];
+	const defaultModelId =
+		(input.defaultModelId?.trim() && modelIds.includes(input.defaultModelId.trim())
+			? input.defaultModelId.trim()
+			: provider.defaultModelId?.trim() && modelIds.includes(provider.defaultModelId.trim())
+				? provider.defaultModelId.trim()
+				: modelIds[0]) ?? "";
+	if (!defaultModelId) {
+		throw new Error("at least one model is required");
+	}
+
+	const registeredModels = await readRegisteredProviderModels(providerId).catch(
+		(): Record<string, { id?: string; name?: string }> => ({}),
+	);
+	const baseUrl = input.baseUrl?.trim() || provider.baseUrl?.trim() || "";
+	if (!baseUrl) {
+		throw new Error("baseUrl is required");
+	}
+
+	state.providers[providerId] = {
+		provider: {
+			name: input.name?.trim() || provider.name || titleCaseProviderId(providerId),
+			baseUrl,
+			defaultModelId,
+			capabilities: input.capabilities ?? toCustomProviderCapabilities(provider.capabilities),
+			modelsSourceUrl: input.modelsSourceUrl?.trim() || undefined,
+		},
+		models: Object.fromEntries(
+			modelIds.map((modelId) => [
+				modelId,
+				{
+					id: modelId,
+					name: registeredModels[modelId]?.name?.trim() || modelId,
+				},
+			]),
+		),
+	};
+	await writeModelsRegistry(state);
 }
 
 export async function addSdkCustomProvider(input: AddSdkCustomProviderInput): Promise<void> {
@@ -364,27 +528,35 @@ export async function updateSdkCustomProvider(input: UpdateSdkCustomProviderInpu
 		ClineCore as {
 			updateLocalProvider?: (
 				manager: ProviderSettingsManager,
-				request: {
-					providerId: string;
-					name?: string;
-					baseUrl?: string;
-					apiKey?: string | null;
-					headers?: Record<string, string> | null;
-					timeoutMs?: number | null;
-					models?: string[];
-					defaultModelId?: string | null;
-					modelsSourceUrl?: string | null;
-					capabilities?: SdkCustomProviderCapability[];
-				},
+				request: UpdateLocalProviderRequest,
 			) => Promise<unknown>;
 		}
 	).updateLocalProvider;
 	if (updateLocalProvider) {
-		await updateLocalProvider(providerManager, input);
+		const providerId = normalizeProviderId(input.providerId);
+		try {
+			await updateLocalProvider(providerManager, input);
+			return;
+		} catch (error) {
+			if (!isMissingLocalProviderError(error, providerId) || !(await getOverrideableBuiltInProvider(providerId))) {
+				throw error;
+			}
+			const previousModelsState = await readModelsRegistry();
+			const previousSettingsState = providerManager.read();
+			await seedLocalProviderOverride(input);
+			try {
+				await updateLocalProvider(providerManager, input);
+			} catch (updateError) {
+				await writeModelsRegistry(previousModelsState);
+				providerManager.write(previousSettingsState);
+				ClineCore.Llms.unregisterProvider(providerId);
+				throw updateError;
+			}
+		}
 		return;
 	}
 
-	const providerId = input.providerId.trim().toLowerCase();
+	const providerId = normalizeProviderId(input.providerId);
 	const state = await readModelsRegistry();
 	const existing = state.providers[providerId];
 	if (!existing) {
@@ -396,9 +568,7 @@ export async function updateSdkCustomProvider(input: UpdateSdkCustomProviderInpu
 
 	const models =
 		input.models?.map((model) => model.trim()).filter((model) => model.length > 0) ??
-		Object.keys(existing.models)
-			.map((model) => model.trim())
-			.filter((model) => model.length > 0);
+		uniqueTrimmed(Object.keys(existing.models));
 	if (models.length === 0) {
 		throw new Error("at least one model is required");
 	}

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -677,6 +677,8 @@ export const runtimeClineProviderCatalogItemSchema = z.object({
 	client: z.string().optional(),
 	capabilities: z.array(z.string()).optional(),
 	modelsSourceUrl: z.string().nullable().optional(),
+	headers: z.record(z.string(), z.string()).optional(),
+	timeoutMs: z.number().int().positive().optional(),
 });
 export type RuntimeClineProviderCatalogItem = z.infer<typeof runtimeClineProviderCatalogItemSchema>;
 

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -673,6 +673,10 @@ export const runtimeClineProviderCatalogItemSchema = z.object({
 	baseUrl: z.string().nullable(),
 	supportsBaseUrl: z.boolean(),
 	env: z.array(z.string()).optional(),
+	custom: z.boolean().optional(),
+	client: z.string().optional(),
+	capabilities: z.array(z.string()).optional(),
+	modelsSourceUrl: z.string().nullable().optional(),
 });
 export type RuntimeClineProviderCatalogItem = z.infer<typeof runtimeClineProviderCatalogItemSchema>;
 

--- a/web-ui/src/components/shared/cline-add-provider-dialog.test.tsx
+++ b/web-ui/src/components/shared/cline-add-provider-dialog.test.tsx
@@ -200,4 +200,28 @@ describe("ClineAddProviderDialog", () => {
 			}),
 		);
 	});
+
+	it("does not replace explicit empty edit capabilities with add-mode defaults", async () => {
+		await act(async () => {
+			root.render(
+				<ClineAddProviderDialog
+					open={true}
+					onOpenChange={() => {}}
+					existingProviderIds={["litellm"]}
+					mode="edit"
+					initialValues={{
+						providerId: "litellm",
+						name: "LiteLLM",
+						baseUrl: "http://localhost:4000/v1",
+						models: ["gpt-5.4"],
+						capabilities: [],
+					}}
+					onSubmit={async () => ({ ok: true })}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "streaming")?.getAttribute("aria-pressed")).toBe("false");
+		expect(findButtonByText(document.body, "tools")?.getAttribute("aria-pressed")).toBe("false");
+	});
 });

--- a/web-ui/src/components/shared/cline-add-provider-dialog.tsx
+++ b/web-ui/src/components/shared/cline-add-provider-dialog.tsx
@@ -74,7 +74,7 @@ function createInitialFormState(initialValues?: ClineProviderDialogInitialValues
 		defaultModelId: initialValues?.defaultModelId?.trim() || initialModels[0] || "",
 		timeoutMs: initialValues?.timeoutMs ? String(initialValues.timeoutMs) : "",
 		headers: initialHeaders,
-		capabilities: initialValues?.capabilities?.length ? initialValues.capabilities : ["streaming", "tools"],
+		capabilities: initialValues?.capabilities !== undefined ? initialValues.capabilities : ["streaming", "tools"],
 	};
 }
 

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -1,8 +1,9 @@
-import { act } from "react";
+import { act, type ComponentProps, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ClineSetupSection } from "@/components/shared/cline-setup-section";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { UseRuntimeSettingsClineControllerResult } from "@/hooks/use-runtime-settings-cline-controller";
 import type { RuntimeClineProviderCatalogItem } from "@/runtime/types";
 
@@ -13,6 +14,14 @@ vi.mock("@/runtime/runtime-config-query", () => ({
 function findButtonByText(container: ParentNode, text: string): HTMLButtonElement | null {
 	return (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === text) ??
 		null) as HTMLButtonElement | null;
+}
+
+function ClineSetupSectionTestHarness(props: ComponentProps<typeof ClineSetupSection>): ReactElement {
+	return (
+		<TooltipProvider>
+			<ClineSetupSection {...props} />
+		</TooltipProvider>
+	);
 }
 
 function createProvider(overrides: Partial<RuntimeClineProviderCatalogItem> = {}): RuntimeClineProviderCatalogItem {
@@ -136,7 +145,7 @@ describe("ClineSetupSection", () => {
 	it("shows edit controls for OpenAI-compatible built-in providers", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(createProvider({ custom: false }))}
 					controlsDisabled={false}
 					showMcpSettings={false}
@@ -150,7 +159,7 @@ describe("ClineSetupSection", () => {
 	it("does not show edit controls for non-OpenAI-compatible built-in providers", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(
 						createProvider({ id: "anthropic", name: "Anthropic", client: "anthropic", custom: false }),
 					)}
@@ -166,7 +175,7 @@ describe("ClineSetupSection", () => {
 	it("does not show edit controls for managed OAuth providers", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(createProvider({ id: "cline", name: "Cline", custom: false }), {
 						normalizedProviderId: "cline",
 						managedOauthProvider: "cline",
@@ -184,7 +193,7 @@ describe("ClineSetupSection", () => {
 	it("shows custom-provider edit controls for local custom providers", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(createProvider({ id: "my-provider", name: "My Provider", custom: true }))}
 					controlsDisabled={false}
 					showMcpSettings={false}
@@ -198,7 +207,7 @@ describe("ClineSetupSection", () => {
 	it("preloads saved advanced settings in the edit dialog", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(
 						createProvider({
 							custom: true,
@@ -233,7 +242,7 @@ describe("ClineSetupSection", () => {
 	it("preloads saved capability overrides in the edit dialog", async () => {
 		await act(async () => {
 			root.render(
-				<ClineSetupSection
+				<ClineSetupSectionTestHarness
 					controller={createController(
 						createProvider({
 							custom: true,

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -1,0 +1,193 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClineSetupSection } from "@/components/shared/cline-setup-section";
+import type { UseRuntimeSettingsClineControllerResult } from "@/hooks/use-runtime-settings-cline-controller";
+import type { RuntimeClineProviderCatalogItem } from "@/runtime/types";
+
+vi.mock("@/runtime/runtime-config-query", () => ({
+	openFileOnHost: vi.fn(),
+}));
+
+function findButtonByText(container: ParentNode, text: string): HTMLButtonElement | null {
+	return (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === text) ??
+		null) as HTMLButtonElement | null;
+}
+
+function createProvider(overrides: Partial<RuntimeClineProviderCatalogItem> = {}): RuntimeClineProviderCatalogItem {
+	return {
+		id: "litellm",
+		name: "LiteLLM",
+		oauthSupported: false,
+		enabled: true,
+		defaultModelId: "gpt-5.4",
+		baseUrl: "http://localhost:4000/v1",
+		supportsBaseUrl: true,
+		client: "openai-compatible",
+		capabilities: ["prompt-cache"],
+		...overrides,
+	};
+}
+
+function createController(
+	provider: RuntimeClineProviderCatalogItem,
+	overrides: Partial<UseRuntimeSettingsClineControllerResult> = {},
+): UseRuntimeSettingsClineControllerResult {
+	const providerId = provider.id;
+	return {
+		currentProviderSettings: {
+			providerId,
+			modelId: provider.defaultModelId,
+			baseUrl: provider.baseUrl,
+			reasoningEffort: null,
+			apiKeyConfigured: false,
+			oauthProvider: null,
+			oauthAccessTokenConfigured: false,
+			oauthRefreshTokenConfigured: false,
+			oauthAccountId: null,
+			oauthExpiresAt: null,
+		},
+		providerId,
+		setProviderId: vi.fn(),
+		modelId: provider.defaultModelId ?? "",
+		setModelId: vi.fn(),
+		apiKey: "",
+		setApiKey: vi.fn(),
+		baseUrl: provider.baseUrl ?? "",
+		setBaseUrl: vi.fn(),
+		region: "",
+		setRegion: vi.fn(),
+		reasoningEffort: "",
+		setReasoningEffort: vi.fn(),
+		awsAccessKey: "",
+		setAwsAccessKey: vi.fn(),
+		awsSecretKey: "",
+		setAwsSecretKey: vi.fn(),
+		awsSessionToken: "",
+		setAwsSessionToken: vi.fn(),
+		awsRegion: "",
+		setAwsRegion: vi.fn(),
+		awsProfile: "",
+		setAwsProfile: vi.fn(),
+		awsAuthentication: "",
+		setAwsAuthentication: vi.fn(),
+		awsEndpoint: "",
+		setAwsEndpoint: vi.fn(),
+		gcpProjectId: "",
+		setGcpProjectId: vi.fn(),
+		gcpRegion: "",
+		setGcpRegion: vi.fn(),
+		providerCatalog: [provider],
+		providerModels: [{ id: provider.defaultModelId ?? "gpt-5.4", name: provider.defaultModelId ?? "gpt-5.4" }],
+		isLoadingProviderCatalog: false,
+		isLoadingProviderModels: false,
+		isRunningOauthLogin: false,
+		deviceAuthInfo: null,
+		normalizedProviderId: providerId,
+		managedOauthProvider: null,
+		isOauthProviderSelected: false,
+		apiKeyConfigured: false,
+		oauthConfigured: false,
+		oauthAccountId: "",
+		oauthExpiresAt: "",
+		selectedModelSupportsReasoningEffort: false,
+		hasUnsavedChanges: false,
+		saveProviderSettings: vi.fn(async () => ({ ok: true })),
+		addCustomProvider: vi.fn(async () => ({ ok: true })),
+		updateCustomProvider: vi.fn(async () => ({ ok: true })),
+		runOauthLogin: vi.fn(async () => ({ ok: true })),
+		...overrides,
+	};
+}
+
+describe("ClineSetupSection", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let previousActEnvironment: boolean | undefined;
+
+	beforeEach(() => {
+		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		document.body.innerHTML = "";
+		if (previousActEnvironment === undefined) {
+			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+		} else {
+			(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+				previousActEnvironment;
+		}
+	});
+
+	it("shows edit controls for OpenAI-compatible built-in providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(createProvider({ custom: false }))}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeInstanceOf(HTMLButtonElement);
+	});
+
+	it("does not show edit controls for non-OpenAI-compatible built-in providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(
+						createProvider({ id: "anthropic", name: "Anthropic", client: "anthropic", custom: false }),
+					)}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeNull();
+	});
+
+	it("does not show edit controls for managed OAuth providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(createProvider({ id: "cline", name: "Cline", custom: false }), {
+						normalizedProviderId: "cline",
+						managedOauthProvider: "cline",
+						isOauthProviderSelected: true,
+					})}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeNull();
+	});
+
+	it("shows custom-provider edit controls for local custom providers", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(createProvider({ id: "my-provider", name: "My Provider", custom: true }))}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		expect(findButtonByText(document.body, "Edit")).toBeInstanceOf(HTMLButtonElement);
+	});
+});

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -225,4 +225,33 @@ describe("ClineSetupSection", () => {
 			"test-value",
 		);
 	});
+
+	it("preloads saved capability overrides in the edit dialog", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(
+						createProvider({
+							custom: true,
+							capabilities: ["vision", "reasoning"],
+						}),
+					)}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		const editButton = findButtonByText(document.body, "Edit");
+		expect(editButton).toBeInstanceOf(HTMLButtonElement);
+
+		await act(async () => {
+			editButton?.click();
+		});
+
+		expect(findButtonByText(document.body, "vision")?.getAttribute("aria-pressed")).toBe("true");
+		expect(findButtonByText(document.body, "reasoning")?.getAttribute("aria-pressed")).toBe("true");
+		expect(findButtonByText(document.body, "streaming")?.getAttribute("aria-pressed")).toBe("false");
+		expect(findButtonByText(document.body, "tools")?.getAttribute("aria-pressed")).toBe("false");
+	});
 });

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -35,6 +35,9 @@ function createController(
 	overrides: Partial<UseRuntimeSettingsClineControllerResult> = {},
 ): UseRuntimeSettingsClineControllerResult {
 	const providerId = provider.id;
+	const currentMainControllerMethods = {
+		refreshProviderModels: vi.fn(async () => ({ ok: true })),
+	};
 	return {
 		currentProviderSettings: {
 			providerId,
@@ -94,6 +97,7 @@ function createController(
 		selectedModelSupportsReasoningEffort: false,
 		hasUnsavedChanges: false,
 		saveProviderSettings: vi.fn(async () => ({ ok: true })),
+		...currentMainControllerMethods,
 		addCustomProvider: vi.fn(async () => ({ ok: true })),
 		updateCustomProvider: vi.fn(async () => ({ ok: true })),
 		runOauthLogin: vi.fn(async () => ({ ok: true })),

--- a/web-ui/src/components/shared/cline-setup-section.test.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.test.tsx
@@ -190,4 +190,39 @@ describe("ClineSetupSection", () => {
 
 		expect(findButtonByText(document.body, "Edit")).toBeInstanceOf(HTMLButtonElement);
 	});
+
+	it("preloads saved advanced settings in the edit dialog", async () => {
+		await act(async () => {
+			root.render(
+				<ClineSetupSection
+					controller={createController(
+						createProvider({
+							custom: true,
+							headers: {
+								"X-Test-Header": "test-value",
+							},
+							timeoutMs: 45123,
+						}),
+					)}
+					controlsDisabled={false}
+					showMcpSettings={false}
+				/>,
+			);
+		});
+
+		const editButton = findButtonByText(document.body, "Edit");
+		expect(editButton).toBeInstanceOf(HTMLButtonElement);
+
+		await act(async () => {
+			editButton?.click();
+		});
+
+		expect(document.body.querySelector<HTMLInputElement>('input[placeholder="30000"]')?.value).toBe("45123");
+		expect(document.body.querySelector<HTMLInputElement>('input[placeholder="Header name"]')?.value).toBe(
+			"X-Test-Header",
+		);
+		expect(document.body.querySelector<HTMLInputElement>('input[placeholder="Header value"]')?.value).toBe(
+			"test-value",
+		);
+	});
 });

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -21,9 +21,21 @@ import type {
 } from "@/hooks/use-runtime-settings-cline-controller";
 import type { UseRuntimeSettingsClineMcpControllerResult } from "@/hooks/use-runtime-settings-cline-mcp-controller";
 import { openFileOnHost } from "@/runtime/runtime-config-query";
-import type { RuntimeClineMcpServer, RuntimeClineReasoningEffort } from "@/runtime/types";
+import type {
+	RuntimeClineMcpServer,
+	RuntimeClineProviderCapability,
+	RuntimeClineReasoningEffort,
+} from "@/runtime/types";
 import { formatPathForDisplay } from "@/utils/path-display";
 import { useCopyToClipboard } from "@/utils/react-use";
+
+const EDITABLE_PROVIDER_CAPABILITIES = new Set<RuntimeClineProviderCapability>([
+	"streaming",
+	"tools",
+	"reasoning",
+	"vision",
+	"prompt-cache",
+]);
 
 function formatExpiry(value: string): string {
 	const trimmed = value.trim();
@@ -46,6 +58,15 @@ function formatExpiry(value: string): string {
 	}
 
 	return trimmed;
+}
+
+function normalizeProviderCapabilities(
+	values: readonly string[] | undefined,
+): RuntimeClineProviderCapability[] | undefined {
+	const capabilities = values?.filter((value): value is RuntimeClineProviderCapability =>
+		EDITABLE_PROVIDER_CAPABILITIES.has(value as RuntimeClineProviderCapability),
+	);
+	return capabilities && capabilities.length > 0 ? capabilities : undefined;
 }
 
 export function ClineSetupSection({
@@ -150,7 +171,10 @@ export function ClineSetupSection({
 		() => clineProviderOptions.find((option) => option.value === controller.providerId) ?? null,
 		[clineProviderOptions, controller.providerId],
 	);
-	const canEditSelectedProvider = controller.providerId.trim().length > 0 && !controller.isOauthProviderSelected;
+	const canEditSelectedProvider =
+		controller.providerId.trim().length > 0 &&
+		!controller.isOauthProviderSelected &&
+		(selectedProvider?.custom === true || selectedProvider?.client === "openai-compatible");
 	const selectedProviderEditInitialValues = useMemo((): ClineProviderDialogInitialValues | null => {
 		if (!canEditSelectedProvider) {
 			return null;
@@ -164,8 +188,10 @@ export function ClineSetupSection({
 			providerId: selectedProvider?.id ?? fallbackProviderId,
 			name: selectedProvider?.name ?? fallbackProviderName,
 			baseUrl: controller.baseUrl.trim() || selectedProvider?.baseUrl?.trim() || "",
+			modelsSourceUrl: selectedProvider?.modelsSourceUrl?.trim() || "",
 			models: normalizedModelIds,
 			defaultModelId: controller.modelId.trim() || selectedProvider?.defaultModelId?.trim() || "",
+			capabilities: normalizeProviderCapabilities(selectedProvider?.capabilities),
 		};
 	}, [
 		canEditSelectedProvider,

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -191,6 +191,8 @@ export function ClineSetupSection({
 			modelsSourceUrl: selectedProvider?.modelsSourceUrl?.trim() || "",
 			models: normalizedModelIds,
 			defaultModelId: controller.modelId.trim() || selectedProvider?.defaultModelId?.trim() || "",
+			timeoutMs: selectedProvider?.timeoutMs ?? null,
+			headers: selectedProvider?.headers,
 			capabilities: normalizeProviderCapabilities(selectedProvider?.capabilities),
 		};
 	}, [

--- a/web-ui/src/components/shared/cline-setup-section.tsx
+++ b/web-ui/src/components/shared/cline-setup-section.tsx
@@ -63,10 +63,13 @@ function formatExpiry(value: string): string {
 function normalizeProviderCapabilities(
 	values: readonly string[] | undefined,
 ): RuntimeClineProviderCapability[] | undefined {
+	if (values === undefined) {
+		return undefined;
+	}
 	const capabilities = values?.filter((value): value is RuntimeClineProviderCapability =>
 		EDITABLE_PROVIDER_CAPABILITIES.has(value as RuntimeClineProviderCapability),
 	);
-	return capabilities && capabilities.length > 0 ? capabilities : undefined;
+	return capabilities ?? [];
 }
 
 export function ClineSetupSection({


### PR DESCRIPTION
## Summary

Fixes editing built-in OpenAI-compatible Cline providers such as LiteLLM from the provider edit modal.

The modal previously routed every edit through `updateCustomProvider`, but SDK `updateLocalProvider` only updates providers that already exist in the local `models.json` registry. Built-in providers like `litellm` exist in the SDK catalog, not in that local registry, so saving the edit surfaced `provider "litellm" does not exist`.

This PR makes first edit of an eligible built-in provider create a local override for the same provider ID before calling the SDK update path, so the SDK still owns model source fetching, settings persistence, and provider registration without depending on SDK error message text. It also makes the modal reload saved local override fields, including capabilities, instead of falling back to SDK catalog defaults.

## Changes

- Expose provider `client`, capabilities, local/custom status, `modelsSourceUrl`, timeout, and custom headers through the runtime provider catalog.
- Show the provider Edit button for non-OAuth OpenAI-compatible providers, including LiteLLM, while keeping managed OAuth providers like Cline out of this PR.
- Seed a local provider registry entry before SDK update when an eligible OpenAI-compatible built-in has no local entry yet.
- Roll back the seeded local override if the SDK update fails after seeding.
- Preserve SDK catalog `modelsSourceUrl` values when no local override exists, while allowing local overrides to clear or replace that field.
- Ensure the local models registry directory exists before writing `models.json`.
- Preload saved modal fields when reopening the edit modal so model source URL, timeout, custom headers, and capabilities round-trip correctly.
- Preserve explicit empty capability overrides instead of replacing them with add-provider defaults.
- Add focused UI tests for editable provider visibility and saved modal field reload behavior.

## Validation

- `npm --prefix web-ui test -- cline-add-provider-dialog.test.tsx cline-setup-section.test.tsx`
- `npm --prefix web-ui run typecheck`
- `npm --prefix web-ui run build`
- `git diff --check`

Manual UI test:

- Ran patched full stack app with isolated `CLINE_DATA_DIR`.
- Opened Settings → Cline provider settings.
- Selected LiteLLM and confirmed the Edit button appears.
- Opened the edit modal, changed provider fields, clicked Update provider.
- Confirmed the modal closed without `provider "litellm" does not exist` or `ENOENT` errors.
- Reopened Edit and confirmed saved timeout/custom header values reloaded into the modal.
- Toggled `vision`, clicked Update provider, reopened Edit, and confirmed `vision` stayed selected.
- Toggled `vision` back off, clicked Update provider, reopened Edit, and confirmed all capability toggles stayed off.

Note: root `npm run typecheck` is currently blocked in this local dependency setup by existing `@clinebot/core` export mismatches unrelated to this PR.
