### PR TITLE
fix: use Codex hooks for task transitions

### DIFF
--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -531,6 +531,29 @@ function mapGeminiHookEvent(eventName: string): RuntimeHookEvent | null {
 	return null;
 }
 
+async function runCodexHookSubcommand(
+	event: RuntimeHookEvent,
+	options: HookCommandMetadataOptionValues,
+	payloadArg: string | undefined,
+): Promise<void> {
+	let payload = "";
+	try {
+		payload = await readStdinText();
+	} catch {
+		payload = "";
+	}
+
+	process.stdout.write("{}\n");
+
+	try {
+		const parsedArgs = parseHooksIngestArgs(event, options, payloadArg, payload);
+		const codexEnrichedArgs = await enrichCodexReviewMetadata(parsedArgs, process.cwd());
+		await ingestHookEvent(codexEnrichedArgs);
+	} catch {
+		// Best effort only.
+	}
+}
+
 async function runGeminiHookSubcommand(): Promise<void> {
 	let payload = "";
 	try {
@@ -569,31 +592,7 @@ async function runGeminiHookSubcommand(): Promise<void> {
 }
 
 export function buildCodexWrapperChildArgs(agentArgs: string[]): string[] {
-	const childArgs = [...agentArgs];
-	const hasNotifyOverride = childArgs.some((arg, index) => {
-		if (arg === "-c" || arg === "--config") {
-			const next = childArgs[index + 1];
-			return typeof next === "string" && next.startsWith("notify=");
-		}
-		return arg.startsWith("-cnotify=") || arg.startsWith("--config=notify=");
-	});
-	if (hasNotifyOverride) {
-		return childArgs;
-	}
-	// Session log formats can change across Codex versions. Always wire legacy notify
-	// so task completion still transitions to review when watcher parsing misses events.
-	const reviewNotifyCommandParts = buildKanbanCommandParts([
-		"hooks",
-		"notify",
-		"--event",
-		"to_review",
-		"--source",
-		"codex",
-	]);
-	const notifyConfig = `notify=${JSON.stringify(reviewNotifyCommandParts)}`;
-	childArgs.unshift(notifyConfig);
-	childArgs.unshift("-c");
-	return childArgs;
+	return [...agentArgs];
 }
 
 export function buildCodexWrapperSpawn(
@@ -786,6 +785,26 @@ export function registerHooksCommand(program: Command): void {
 		.action(async () => {
 			await runGeminiHookSubcommand();
 		});
+
+	hooks
+		.command("codex-hook [payload]")
+		.description("Codex hook entrypoint.")
+		.requiredOption("--event <event>", "Event: to_review | to_in_progress | activity.", parseHookEvent)
+		.option("--source <source>", "Hook source.")
+		.option("--activity-text <text>", "Activity summary text.")
+		.option("--tool-name <name>", "Tool name.")
+		.option("--final-message <message>", "Final message.")
+		.option("--hook-event-name <name>", "Original hook event name.")
+		.option("--notification-type <type>", "Notification type.")
+		.option("--metadata-base64 <base64>", "Base64-encoded JSON metadata payload.")
+		.action(
+			async (
+				payload: string | undefined,
+				options: HookCommandMetadataOptionValues & { event: RuntimeHookEvent },
+			) => {
+				await runCodexHookSubcommand(options.event, options, payload);
+			},
+		);
 
 	hooks
 		.command("codex-wrapper [agentArgs...]")

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -14,6 +14,7 @@ import { quoteShellArg } from "../core/shell";
 import { lockedFileSystem } from "../fs/locked-file-system";
 import { resolveHomeAgentAppendSystemPrompt } from "../prompts/append-system-prompt";
 import { getRuntimeHomePath } from "../state/workspace-state";
+import { configureCodexHooks, hasCodexConfigOverride } from "./codex-hook-config";
 import { createHookRuntimeEnv } from "./hook-runtime-context";
 import {
 	getOpenCodeAuthPathCandidates,
@@ -120,24 +121,6 @@ function hasCliOption(args: string[], optionName: string): boolean {
 	for (let i = 0; i < args.length; i += 1) {
 		const arg = args[i];
 		if (arg === optionName || arg.startsWith(`${optionName}=`)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-function hasCodexConfigOverride(args: string[], key: string): boolean {
-	for (let i = 0; i < args.length; i += 1) {
-		const arg = args[i];
-		if (arg === "-c" || arg === "--config") {
-			const next = args[i + 1];
-			if (typeof next === "string" && next.startsWith(`${key}=`)) {
-				return true;
-			}
-			i += 1;
-			continue;
-		}
-		if (arg.startsWith(`-c${key}=`) || arg.startsWith(`--config=${key}=`)) {
 			return true;
 		}
 	}
@@ -752,7 +735,7 @@ const codexAdapter: AgentSessionAdapter = {
 	async prepare(input) {
 		const codexArgs = [...input.args];
 		const env: Record<string, string | undefined> = {};
-		let binary = input.binary;
+		const binary = input.binary;
 		let deferredStartupInput: string | undefined;
 		const appendedSystemPrompt = resolveHomeAgentAppendSystemPrompt(input.taskId);
 
@@ -779,6 +762,7 @@ const codexAdapter: AgentSessionAdapter = {
 
 		const hooks = resolveHookContext(input);
 		if (hooks) {
+			configureCodexHooks(codexArgs);
 			Object.assign(
 				env,
 				createHookRuntimeEnv({
@@ -797,18 +781,9 @@ const codexAdapter: AgentSessionAdapter = {
 		}
 
 		if (hooks) {
-			const wrapperParts = buildHooksCommandParts([
-				"codex-wrapper",
-				"--real-binary",
-				input.binary ?? "codex",
-				"--",
-				...codexArgs,
-			]);
-			binary = wrapperParts[0];
-			const args = wrapperParts.slice(1);
 			return {
 				binary,
-				args,
+				args: codexArgs,
 				env,
 				deferredStartupInput,
 				detectOutputTransition: codexPromptDetector,

--- a/src/terminal/codex-hook-config.ts
+++ b/src/terminal/codex-hook-config.ts
@@ -1,0 +1,58 @@
+import type { RuntimeHookEvent } from "../core/api-contract";
+import { buildKanbanCommandParts } from "../core/kanban-command";
+import { quoteShellArg } from "../core/shell";
+
+const CODEX_HOOK_TIMEOUT_SECONDS = 5;
+
+export function hasCodexConfigOverride(args: string[], key: string): boolean {
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === "-c" || arg === "--config") {
+			const next = args[i + 1];
+			if (typeof next === "string" && next.startsWith(`${key}=`)) {
+				return true;
+			}
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith(`-c${key}=`) || arg.startsWith(`--config=${key}=`)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function addCodexConfigOverride(args: string[], key: string, value: string): void {
+	if (hasCodexConfigOverride(args, key)) {
+		return;
+	}
+	args.push("-c", `${key}=${value}`);
+}
+
+function buildCodexHookCommand(event: RuntimeHookEvent): string {
+	return buildKanbanCommandParts(["hooks", "codex-hook", "--event", event, "--source", "codex"])
+		.map(quoteShellArg)
+		.join(" ");
+}
+
+function buildCodexHookConfigValue(command: string, matcher?: string): string {
+	const matcherConfig = matcher ? `matcher=${JSON.stringify(matcher)},` : "";
+	return `[{${matcherConfig}hooks=[{type="command",command=${JSON.stringify(command)},timeout=${CODEX_HOOK_TIMEOUT_SECONDS}}]}]`;
+}
+
+export function configureCodexHooks(args: string[]): void {
+	const inProgressHookConfig = buildCodexHookConfigValue(buildCodexHookCommand("to_in_progress"));
+	const reviewHookConfig = buildCodexHookConfigValue(buildCodexHookCommand("to_review"));
+	const activityHookConfig = buildCodexHookConfigValue(buildCodexHookCommand("activity"), "*");
+
+	addCodexConfigOverride(args, "features.codex_hooks", "true");
+	addCodexConfigOverride(args, "hooks.UserPromptSubmit", inProgressHookConfig);
+	addCodexConfigOverride(args, "hooks.Stop", reviewHookConfig);
+	addCodexConfigOverride(
+		args,
+		"hooks.PermissionRequest",
+		buildCodexHookConfigValue(buildCodexHookCommand("to_review"), "*"),
+	);
+	addCodexConfigOverride(args, "hooks.PreToolUse", activityHookConfig);
+	addCodexConfigOverride(args, "hooks.PostToolUse", activityHookConfig);
+}

--- a/test/runtime/hooks-codex-wrapper.test.ts
+++ b/test/runtime/hooks-codex-wrapper.test.ts
@@ -3,17 +3,13 @@ import { describe, expect, it } from "vitest";
 import { buildCodexWrapperChildArgs, buildCodexWrapperSpawn } from "../../src/commands/hooks";
 
 describe("buildCodexWrapperChildArgs", () => {
-	it("injects notify config", () => {
+	it("does not inject legacy notify config", () => {
 		const args = buildCodexWrapperChildArgs(["exec", "fix the bug"]);
 
-		expect(args[0]).toBe("-c");
-		expect(args[1]).toContain("notify=");
-		expect(args[1]).toContain("hooks");
-		expect(args[1]).toContain("to_review");
-		expect(args.slice(2)).toEqual(["exec", "fix the bug"]);
+		expect(args).toEqual(["exec", "fix the bug"]);
 	});
 
-	it("does not override an explicit notify config", () => {
+	it("preserves an explicit notify config without adding another one", () => {
 		expect(buildCodexWrapperChildArgs(["-c", 'notify=["echo","custom"]', "exec", "fix the bug"])).toEqual([
 			"-c",
 			'notify=["echo","custom"]',
@@ -35,14 +31,12 @@ describe("buildCodexWrapperChildArgs", () => {
 		expect(launch.args[3]).toContain("exec");
 	});
 
-	it("does not wrap cmd itself on Windows and still applies notify fallback args", () => {
+	it("does not wrap cmd itself on Windows", () => {
 		const launch = buildCodexWrapperSpawn("cmd.exe", ["/c", "echo hi"], "win32", {
 			ComSpec: "C:\\Windows\\System32\\cmd.exe",
 		});
 
 		expect(launch.binary).toBe("cmd.exe");
-		expect(launch.args[0]).toBe("-c");
-		expect(launch.args[1]).toContain("notify=");
-		expect(launch.args.slice(2)).toEqual(["/c", "echo hi"]);
+		expect(launch.args).toEqual(["/c", "echo hi"]);
 	});
 });

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -81,7 +81,7 @@ afterEach(() => {
 });
 
 describe("prepareAgentLaunch hook strategies", () => {
-	it("routes codex through hooks codex-wrapper command", async () => {
+	it("configures Codex hooks without legacy notify", async () => {
 		setupTempHome();
 		const launch = await prepareAgentLaunch({
 			taskId: "task-1",
@@ -97,11 +97,15 @@ describe("prepareAgentLaunch hook strategies", () => {
 		expect(launch.env.KANBAN_HOOK_WORKSPACE_ID).toBe("workspace-1");
 
 		const launchCommand = [launch.binary ?? "", ...launch.args].join(" ");
-		expect(launchCommand).toContain("hooks");
-		expect(launchCommand).toContain("codex-wrapper");
-		expect(launchCommand).toContain("--real-binary");
 		expect(launchCommand).toContain("codex");
-		expect(launchCommand).toContain("--");
+		expect(launchCommand).toContain("codex-hook");
+		expect(launchCommand).toContain("hooks.UserPromptSubmit");
+		expect(launchCommand).toContain("hooks.Stop");
+		expect(launchCommand).toContain("hooks.PermissionRequest");
+		expect(launchCommand).toContain("features.codex_hooks=true");
+		expect(launchCommand).toContain("timeout=5");
+		expect(launchCommand).not.toContain("codex-wrapper");
+		expect(launchCommand).not.toContain("notify=");
 
 		const wrapperPath = join(homedir(), ".cline", "kanban", "hooks", "codex", "codex-wrapper.mjs");
 		expect(existsSync(wrapperPath)).toBe(false);


### PR DESCRIPTION
## Problem

Codex task transitions were still wired through the legacy Codex `notify` config. That fallback ran Kanban as `hooks notify --event to_review --source codex`, so any Codex notify invocation was treated as a completed task. With newer Codex behavior, that could surface in two bad ways:

- Hook subprocesses could hang when Codex left stdin open for the command process.
- Cards could jump back to review while the agent was still working because the legacy notify path always meant `to_review`.

Kanban already has a richer hook ingest path used by other agents, and Codex now exposes first-class hooks behind `features.codex_hooks`. The older `notify=...` fallback is no longer the right integration point for active Codex sessions.

## Approach

This switches Kanban-launched Codex sessions to Codex's new hook configuration model.

The Codex adapter now injects dynamic `-c hooks.*=...` config values instead of wrapping Codex with `hooks codex-wrapper` and adding `notify=...`. The configured hooks map Codex lifecycle events into Kanban transitions:

- `UserPromptSubmit` sends `to_in_progress`.
- `Stop` sends `to_review`.
- `PermissionRequest` sends `to_review`.
- `PreToolUse` and `PostToolUse` send `activity`.

A new `hooks codex-hook` subcommand handles Codex hook stdin payloads, writes `{}` for Codex compatibility, and best-effort ingests the event into the Kanban runtime. It reuses the existing hook metadata normalization and Codex final-message enrichment logic.

The legacy `buildCodexWrapperChildArgs` helper no longer injects `notify=...`. The wrapper command still exists for compatibility with older call sites, but it no longer adds the problematic notify config.

Codex-specific hook config construction is isolated in `src/terminal/codex-hook-config.ts`, so `agent-session-adapters.ts` stays focused on launch flow.

## Debugging notes

The original leak was not caused by tRPC itself. The hanging processes were stuck before runtime ingest when hook command stdin did not reach EOF. The old native Codex `notify` fallback made this much easier to trigger because Kanban was launching a full `hooks notify` process for every Codex notify event.

The premature review transition was the stronger signal that the integration point was wrong: the command was hard-coded to `--event to_review`, so if Codex invoked notify for a non-terminal reason, Kanban could not distinguish it from actual task completion.

Using Codex hooks gives Kanban explicit event names and lets us map only `Stop` to review.

## Tests

- `npx @biomejs/biome check src/terminal/codex-hook-config.ts src/terminal/agent-session-adapters.ts src/commands/hooks.ts test/runtime/hooks-codex-wrapper.test.ts test/runtime/terminal/agent-session-adapters.test.ts`
- `npm run typecheck`
- `npx vitest run test/runtime/hooks-codex-wrapper.test.ts test/runtime/terminal/agent-session-adapters.test.ts`
- Precommit also ran `npm run test:fast`: 53 files passed, 540 tests passed.
