### PR TITLE
feat: block sending images when selected model lacks vision support

### DIFF
--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -232,15 +232,12 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						const providerModels = await clineProviderService
 							.getProviderModels(clineLaunchConfig.providerId)
 							.catch(() => ({ models: [] }));
-						const selectedModel = providerModels.models.find(
-							(model) => model.id === clineLaunchConfig.modelId,
-						);
+						const selectedModel = providerModels.models.find((model) => model.id === clineLaunchConfig.modelId);
 						if (selectedModel?.supportsVision === false) {
 							return {
 								ok: false,
 								summary: null,
-								error:
-									"The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to start this task.",
+								error: "The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to start this task.",
 							};
 						}
 					}
@@ -616,6 +613,29 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						message: null,
 					};
 				}
+				const chatHasImages = Boolean(body.images && body.images.length > 0);
+				if (chatHasImages) {
+					try {
+						const clineLaunchConfig = await clineProviderService.resolveLaunchConfig();
+						if (clineLaunchConfig.modelId) {
+							const providerModels = await clineProviderService
+								.getProviderModels(clineLaunchConfig.providerId)
+								.catch(() => ({ models: [] }));
+							const selectedModel = providerModels.models.find(
+								(model) => model.id === clineLaunchConfig.modelId,
+							);
+							if (selectedModel?.supportsVision === false) {
+								return {
+									ok: false,
+									summary: null,
+									error: "The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to send this message.",
+								};
+							}
+						}
+					} catch {
+						// Provider lookup failed — skip validation, let the SDK handle it.
+					}
+				}
 				const requestedMode = body.mode;
 				let summary = await clineTaskSessionService.sendTaskSessionInput(
 					body.taskId,
@@ -643,23 +663,6 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						}
 					} else {
 						const clineLaunchConfig = await clineProviderService.resolveLaunchConfig();
-						const chatHasImages = Boolean(body.images && body.images.length > 0);
-						if (chatHasImages && clineLaunchConfig.modelId) {
-							const providerModels = await clineProviderService
-								.getProviderModels(clineLaunchConfig.providerId)
-								.catch(() => ({ models: [] }));
-							const selectedModel = providerModels.models.find(
-								(model) => model.id === clineLaunchConfig.modelId,
-							);
-							if (selectedModel?.supportsVision === false) {
-								return {
-									ok: false,
-									summary: null,
-									error:
-										"The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to send this message.",
-								};
-							}
-						}
 						summary = await clineTaskSessionService.startTaskSession({
 							taskId: body.taskId,
 							cwd: workspaceScope.workspacePath,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -227,6 +227,23 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 								}
 							: {}),
 					});
+					const hasImages = Boolean(body.images && body.images.length > 0);
+					if (hasImages && clineLaunchConfig.modelId) {
+						const providerModels = await clineProviderService
+							.getProviderModels(clineLaunchConfig.providerId)
+							.catch(() => ({ models: [] }));
+						const selectedModel = providerModels.models.find(
+							(model) => model.id === clineLaunchConfig.modelId,
+						);
+						if (selectedModel?.supportsVision === false) {
+							return {
+								ok: false,
+								summary: null,
+								error:
+									"The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to start this task.",
+							};
+						}
+					}
 					const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 					const resolvedClineTitle = resolveTaskTitle(body.taskTitle?.trim(), body.prompt);
 					const summary = await clineTaskSessionService.startTaskSession({
@@ -626,6 +643,23 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						}
 					} else {
 						const clineLaunchConfig = await clineProviderService.resolveLaunchConfig();
+						const chatHasImages = Boolean(body.images && body.images.length > 0);
+						if (chatHasImages && clineLaunchConfig.modelId) {
+							const providerModels = await clineProviderService
+								.getProviderModels(clineLaunchConfig.providerId)
+								.catch(() => ({ models: [] }));
+							const selectedModel = providerModels.models.find(
+								(model) => model.id === clineLaunchConfig.modelId,
+							);
+							if (selectedModel?.supportsVision === false) {
+								return {
+									ok: false,
+									summary: null,
+									error:
+										"The selected Cline model does not support image input. Switch to a vision-capable model or remove the images to send this message.",
+								};
+							}
+						}
 						summary = await clineTaskSessionService.startTaskSession({
 							taskId: body.taskId,
 							cwd: workspaceScope.workspacePath,

--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
@@ -219,7 +219,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 		const panelError = composerError ?? error;
 		const attachmentWarningMessage =
 			draftImages.length > 0 && selectedModel?.supportsVision === false
-				? "The selected Cline model may not accept image input. Choose a vision-capable model to use these images."
+				? "The selected model does not support image input. Switch to a vision-capable model or remove the images to send."
 				: null;
 
 		const isPinnedToBottom = useCallback((container: HTMLDivElement): boolean => {

--- a/web-ui/src/components/detail-panels/cline-chat-composer.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-composer.tsx
@@ -113,7 +113,7 @@ export function ClineChatComposer({
 	const [slashSuggestions, setSlashSuggestions] = useState<ClineComposerCompletionSuggestion[]>([]);
 	const [isMentionSearchLoading, setIsMentionSearchLoading] = useState(false);
 	const [isSlashSearchLoading, setIsSlashSearchLoading] = useState(false);
-	const canSubmit = canSend && !isModelSaving && (draft.trim().length > 0 || images.length > 0);
+	const canSubmit = canSend && !isModelSaving && !attachmentWarningMessage && (draft.trim().length > 0 || images.length > 0);
 
 	const activeToken = useMemo(() => detectActiveClineComposerToken(draft, cursorIndex), [cursorIndex, draft]);
 	const completionSuggestions = useMemo(() => {

--- a/web-ui/src/components/task-create-dialog.tsx
+++ b/web-ui/src/components/task-create-dialog.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as RadixSwitch from "@radix-ui/react-switch";
 
 import {
+	AlertTriangle,
 	ArrowBigUp,
 	ArrowLeft,
 	Check,
@@ -201,6 +202,20 @@ export function TaskCreateDialog({
 	const effectivePrimaryStartAction =
 		onCreateStartAndOpen || primaryStartAction === "start" ? primaryStartAction : DEFAULT_PRIMARY_START_ACTION;
 	const secondaryStartAction = effectivePrimaryStartAction === "start" ? "start_and_open" : "start";
+
+	const effectiveAgentIdForImages = agentId ?? defaultAgentId ?? null;
+	const effectiveModelIdForImages = clineSettings?.modelId ?? effectiveDefaultModelId ?? "";
+	const selectedClineModel = useMemo(
+		() =>
+			effectiveModelIdForImages
+				? providerModels.find((model) => model.id === effectiveModelIdForImages) ?? null
+				: null,
+		[effectiveModelIdForImages, providerModels],
+	);
+	const imagesBlockedByModel =
+		images.length > 0 &&
+		effectiveAgentIdForImages === "cline" &&
+		selectedClineModel?.supportsVision === false;
 
 	// Reset state when dialog closes
 	useEffect(() => {
@@ -598,6 +613,15 @@ export function TaskCreateDialog({
 				</div>
 			</DialogBody>
 			<DialogFooter>
+				{imagesBlockedByModel ? (
+					<div className="mb-2 flex items-start gap-1.5 text-xs text-status-orange">
+						<AlertTriangle size={14} className="mt-0.5 shrink-0" />
+						<p className="m-0 min-w-0">
+							The selected Cline model does not support image input. Switch to a vision-capable model in Override
+							Agent Settings or remove the images to continue.
+						</p>
+					</div>
+				) : null}
 				<label
 					htmlFor={createMoreId}
 					className="mr-auto flex items-center gap-2 text-[12px] text-text-primary cursor-pointer select-none"
@@ -614,7 +638,7 @@ export function TaskCreateDialog({
 				</label>
 				{mode === "single" ? (
 					<>
-						<Button size="sm" onClick={handleCreateSingle} disabled={!prompt.trim() || !branchRef}>
+						<Button size="sm" onClick={handleCreateSingle} disabled={!prompt.trim() || !branchRef || imagesBlockedByModel}>
 							<span className="inline-flex items-center">
 								Create
 								<ButtonShortcut />
@@ -627,7 +651,7 @@ export function TaskCreateDialog({
 										variant="primary"
 										size="sm"
 										onClick={() => handleRunSingleStartAction(primaryStartAction)}
-										disabled={!prompt.trim() || !branchRef}
+										disabled={!prompt.trim() || !branchRef || imagesBlockedByModel}
 										className={onCreateStartAndOpen ? "rounded-r-none" : undefined}
 									>
 										<span className="inline-flex items-center">
@@ -640,7 +664,7 @@ export function TaskCreateDialog({
 											<Button
 												variant="primary"
 												size="sm"
-												disabled={!prompt.trim() || !branchRef}
+												disabled={!prompt.trim() || !branchRef || imagesBlockedByModel}
 												className="rounded-l-none border-l border-white/20 px-1"
 												aria-label="More start options"
 											>

--- a/web-ui/src/components/task-create-dialog.tsx
+++ b/web-ui/src/components/task-create-dialog.tsx
@@ -203,19 +203,17 @@ export function TaskCreateDialog({
 		onCreateStartAndOpen || primaryStartAction === "start" ? primaryStartAction : DEFAULT_PRIMARY_START_ACTION;
 	const secondaryStartAction = effectivePrimaryStartAction === "start" ? "start_and_open" : "start";
 
-	const effectiveAgentIdForImages = agentId ?? defaultAgentId ?? null;
+	const effectiveAgentIdForImages = (agentId || defaultAgentId) ?? null;
 	const effectiveModelIdForImages = clineSettings?.modelId ?? effectiveDefaultModelId ?? "";
 	const selectedClineModel = useMemo(
 		() =>
 			effectiveModelIdForImages
-				? providerModels.find((model) => model.id === effectiveModelIdForImages) ?? null
+				? (providerModels.find((model) => model.id === effectiveModelIdForImages) ?? null)
 				: null,
 		[effectiveModelIdForImages, providerModels],
 	);
 	const imagesBlockedByModel =
-		images.length > 0 &&
-		effectiveAgentIdForImages === "cline" &&
-		selectedClineModel?.supportsVision === false;
+		images.length > 0 && effectiveAgentIdForImages === "cline" && selectedClineModel?.supportsVision === false;
 
 	// Reset state when dialog closes
 	useEffect(() => {
@@ -638,7 +636,11 @@ export function TaskCreateDialog({
 				</label>
 				{mode === "single" ? (
 					<>
-						<Button size="sm" onClick={handleCreateSingle} disabled={!prompt.trim() || !branchRef || imagesBlockedByModel}>
+						<Button
+							size="sm"
+							onClick={handleCreateSingle}
+							disabled={!prompt.trim() || !branchRef || imagesBlockedByModel}
+						>
 							<span className="inline-flex items-center">
 								Create
 								<ButtonShortcut />


### PR DESCRIPTION
## Problem

When a user pastes a screenshot in the Cline chat composer or attaches images to a new task, and the selected Cline model does not support vision (`supportsVision === false`), only a non-blocking warning was shown. The send/start button remained enabled, allowing the user to proceed. This caused model errors and broken, unusable tasks.

**Reported in:**
- Fixes #307 — *Kanban failed to recognise the attached screenshot*
- Closes #413 — *Cline Kanban doesn't see attached files*

## Solution

When images are present and the effective Cline model has `supportsVision === false`, sending is now **blocked** with a clear error message. The send/start button is disabled.

### Changes

| File | Change |
|------|--------|
| `web-ui/.../cline-chat-composer.tsx` | `canSubmit` now also checks `!attachmentWarningMessage` — disables send button + Enter key when images are incompatible |
| `web-ui/.../cline-agent-chat-panel.tsx` | Strengthened warning message from "may not accept" to "does not support" |
| `web-ui/.../task-create-dialog.tsx` | Added vision support check: disables Create / Start / Start & Open buttons and shows an orange error banner when images are attached to a non-vision Cline model |
| `src/trpc/runtime-api.ts` | Server-side safety net: validates model vision support before `startTaskSession` and before `sendTaskChatMessage` (home agent path) — returns an error if the model lacks vision support |

### Design decisions

- **Only blocks when capability is explicitly `false`**: If `supportsVision` is `undefined` (e.g. custom providers that can't persist capabilities, see #395), we do NOT block. This avoids breaking users whose providers have unknown capabilities.
- **Only applies to the Cline agent**: Non-Cline agents (Claude Code, Codex, Gemini, etc.) convert images to file path references in the prompt text, so the vision check is not applicable.
- **Frontend + backend**: The UI blocks are the primary defense. The backend validation in `runtime-api.ts` catches edge cases where the frontend check is bypassed. Both use `.catch(() => ({ models: [] }))` so a network error during model lookup never blocks legitimate requests.

## Related issues / PRs

| Ref | Status | Relationship |
|-----|--------|-------------|
| #307 | open | **Fixes** — screenshots unrecognised by non-vision models |
| #413 | closed | **Closes** — attached files not seen |
| #395 | open | **Mitigates** — only blocks on explicit `false`, safe for undefined capabilities |
| PR #35 | merged | **Builds on** — added the initial warning, this PR adds blocking |
| #156 | closed | **Relates** — original feature request for image attachments |

## Testing

### What was tested
- Manual code review and logic verification of all 4 files
- Node.js syntax check on `runtime-api.ts` (passed)
- Full diff review for correctness

### What was NOT tested
- `npm run check` (lint + typecheck + tests) — `npm install` 
- Manual browser testing — `npm run web:dev` (did not start due to missing `web-ui/node_modules`)
- `npm run build` 

### How to test manually

**Prerequisites:** `npm install` (root) + `npm install` (web-ui) must complete.

**Scenario 1 — Chat composer blocking:**
1. Start Kanban, open a project, create a task with the **Cline** agent, start it
2. In the chat composer model picker, select a model that does NOT support vision
3. Paste a screenshot (Ctrl+V / Cmd+V)
4. **Expected:** Orange error banner appears, send button is disabled, Enter does nothing
5. Remove images → send button re-enables
6. Switch to a vision-capable model → warning disappears, sending works with images

**Scenario 2 — Task creation blocking:**
1. Open "New task" dialog, expand "Override Agent Settings", select Cline
2. Select a non-vision model, paste a screenshot
3. **Expected:** Orange error banner above buttons, Create/Start disabled
4. Remove images → buttons re-enable

**Scenario 3 — Non-Cline agents unaffected:**
1. New task with images, agent is Claude Code/Codex/etc (not Cline)
2. **Expected:** No blocking — check only applies to Cline agent

**Scenario 4 — Unknown capability (safe):**
1. Use a custom provider where `supportsVision` is undefined
2. Paste images → **Expected:** No blocking (only blocks on explicit `false`)