### PR TITLE
fix: skip binary workspace diff contents

### DIFF
--- a/src/workspace/get-workspace-changes.ts
+++ b/src/workspace/get-workspace-changes.ts
@@ -38,6 +38,7 @@ interface ChangesFromRefInput {
 interface DiffStat {
 	additions: number;
 	deletions: number;
+	isBinary: boolean;
 }
 
 interface FileFingerprint {
@@ -192,13 +193,13 @@ async function readWorkingTreeFile(repoRoot: string, path: string): Promise<stri
 
 function fallbackStats(oldText: string | null, newText: string | null): DiffStat {
 	if (oldText == null && newText == null) {
-		return { additions: 0, deletions: 0 };
+		return { additions: 0, deletions: 0, isBinary: false };
 	}
 	if (oldText == null) {
-		return { additions: toLineCount(newText ?? ""), deletions: 0 };
+		return { additions: toLineCount(newText ?? ""), deletions: 0, isBinary: false };
 	}
 	if (newText == null) {
-		return { additions: 0, deletions: toLineCount(oldText) };
+		return { additions: 0, deletions: toLineCount(oldText), isBinary: false };
 	}
 
 	const oldLines = toLineCount(oldText);
@@ -206,26 +207,39 @@ function fallbackStats(oldText: string | null, newText: string | null): DiffStat
 	return {
 		additions: Math.max(newLines - oldLines, 0),
 		deletions: Math.max(oldLines - newLines, 0),
+		isBinary: false,
+	};
+}
+
+function parseDiffStatOutput(output: string): DiffStat | null {
+	const firstLine = output
+		.split("\n")
+		.map((line) => line.trim())
+		.find(Boolean);
+	if (!firstLine) {
+		return null;
+	}
+	const [addedRaw, deletedRaw] = firstLine.split("\t");
+	if (addedRaw === "-" && deletedRaw === "-") {
+		return {
+			additions: 0,
+			deletions: 0,
+			isBinary: true,
+		};
+	}
+	const additions = Number.parseInt(addedRaw ?? "", 10);
+	const deletions = Number.parseInt(deletedRaw ?? "", 10);
+	return {
+		additions: Number.isFinite(additions) ? additions : 0,
+		deletions: Number.isFinite(deletions) ? deletions : 0,
+		isBinary: false,
 	};
 }
 
 async function readDiffStat(repoRoot: string, path: string): Promise<DiffStat | null> {
 	try {
 		const output = await getGitStdout(["diff", "--numstat", "HEAD", "--", path], repoRoot);
-		const firstLine = output
-			.split("\n")
-			.map((line) => line.trim())
-			.find(Boolean);
-		if (!firstLine) {
-			return null;
-		}
-		const [addedRaw, deletedRaw] = firstLine.split("\t");
-		const additions = Number.parseInt(addedRaw ?? "", 10);
-		const deletions = Number.parseInt(deletedRaw ?? "", 10);
-		return {
-			additions: Number.isFinite(additions) ? additions : 0,
-			deletions: Number.isFinite(deletions) ? deletions : 0,
-		};
+		return parseDiffStatOutput(output);
 	} catch {
 		return null;
 	}
@@ -239,20 +253,7 @@ async function readDiffStatBetweenRefs(
 ): Promise<DiffStat | null> {
 	try {
 		const output = await getGitStdout(["diff", "--numstat", fromRef, toRef, "--", path], repoRoot);
-		const firstLine = output
-			.split("\n")
-			.map((line) => line.trim())
-			.find(Boolean);
-		if (!firstLine) {
-			return null;
-		}
-		const [addedRaw, deletedRaw] = firstLine.split("\t");
-		const additions = Number.parseInt(addedRaw ?? "", 10);
-		const deletions = Number.parseInt(deletedRaw ?? "", 10);
-		return {
-			additions: Number.isFinite(additions) ? additions : 0,
-			deletions: Number.isFinite(deletions) ? deletions : 0,
-		};
+		return parseDiffStatOutput(output);
 	} catch {
 		return null;
 	}
@@ -261,20 +262,7 @@ async function readDiffStatBetweenRefs(
 async function readDiffStatFromRef(repoRoot: string, fromRef: string, path: string): Promise<DiffStat | null> {
 	try {
 		const output = await getGitStdout(["diff", "--numstat", fromRef, "--", path], repoRoot);
-		const firstLine = output
-			.split("\n")
-			.map((line) => line.trim())
-			.find(Boolean);
-		if (!firstLine) {
-			return null;
-		}
-		const [addedRaw, deletedRaw] = firstLine.split("\t");
-		const additions = Number.parseInt(addedRaw ?? "", 10);
-		const deletions = Number.parseInt(deletedRaw ?? "", 10);
-		return {
-			additions: Number.isFinite(additions) ? additions : 0,
-			deletions: Number.isFinite(deletions) ? deletions : 0,
-		};
+		return parseDiffStatOutput(output);
 	} catch {
 		return null;
 	}
@@ -282,13 +270,17 @@ async function readDiffStatFromRef(repoRoot: string, fromRef: string, path: stri
 
 async function buildFileChange(repoRoot: string, entry: NameStatusEntry): Promise<RuntimeWorkspaceFileChange> {
 	const basePath = entry.previousPath ?? entry.path;
+	const diffStat = entry.status === "untracked" ? null : await readDiffStat(repoRoot, entry.path);
 	const oldText =
-		entry.status === "added" || entry.status === "untracked" ? null : await readHeadFile(repoRoot, basePath);
-	const newText = entry.status === "deleted" ? null : await readWorkingTreeFile(repoRoot, entry.path);
+		entry.status === "added" || entry.status === "untracked" || diffStat?.isBinary
+			? null
+			: await readHeadFile(repoRoot, basePath);
+	const newText =
+		entry.status === "deleted" || diffStat?.isBinary ? null : await readWorkingTreeFile(repoRoot, entry.path);
 	const stats =
 		entry.status === "untracked"
 			? { additions: toLineCount(newText ?? ""), deletions: 0 }
-			: ((await readDiffStat(repoRoot, entry.path)) ?? fallbackStats(oldText, newText));
+			: (diffStat ?? fallbackStats(oldText, newText));
 
 	return {
 		path: entry.path,
@@ -308,10 +300,12 @@ async function buildFileChangeBetweenRefs(
 	toRef: string,
 ): Promise<RuntimeWorkspaceFileChange> {
 	const basePath = entry.previousPath ?? entry.path;
-	const oldText = entry.status === "added" ? null : await readFileAtRef(repoRoot, fromRef, basePath);
-	const newText = entry.status === "deleted" ? null : await readFileAtRef(repoRoot, toRef, entry.path);
-	const stats =
-		(await readDiffStatBetweenRefs(repoRoot, fromRef, toRef, entry.path)) ?? fallbackStats(oldText, newText);
+	const diffStat = await readDiffStatBetweenRefs(repoRoot, fromRef, toRef, entry.path);
+	const oldText =
+		entry.status === "added" || diffStat?.isBinary ? null : await readFileAtRef(repoRoot, fromRef, basePath);
+	const newText =
+		entry.status === "deleted" || diffStat?.isBinary ? null : await readFileAtRef(repoRoot, toRef, entry.path);
+	const stats = diffStat ?? fallbackStats(oldText, newText);
 
 	return {
 		path: entry.path,
@@ -330,15 +324,17 @@ async function buildFileChangeFromRef(
 	fromRef: string,
 ): Promise<RuntimeWorkspaceFileChange> {
 	const basePath = entry.previousPath ?? entry.path;
+	const diffStat = entry.status === "untracked" ? null : await readDiffStatFromRef(repoRoot, fromRef, entry.path);
 	const oldText =
-		entry.status === "added" || entry.status === "untracked"
+		entry.status === "added" || entry.status === "untracked" || diffStat?.isBinary
 			? null
 			: await readFileAtRef(repoRoot, fromRef, basePath);
-	const newText = entry.status === "deleted" ? null : await readWorkingTreeFile(repoRoot, entry.path);
+	const newText =
+		entry.status === "deleted" || diffStat?.isBinary ? null : await readWorkingTreeFile(repoRoot, entry.path);
 	const stats =
 		entry.status === "untracked"
 			? { additions: toLineCount(newText ?? ""), deletions: 0 }
-			: ((await readDiffStatFromRef(repoRoot, fromRef, entry.path)) ?? fallbackStats(oldText, newText));
+			: (diffStat ?? fallbackStats(oldText, newText));
 
 	return {
 		path: entry.path,

--- a/test/runtime/get-workspace-changes.test.ts
+++ b/test/runtime/get-workspace-changes.test.ts
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, open, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getWorkspaceChanges, getWorkspaceChangesBetweenRefs } from "../../src/workspace/get-workspace-changes";
+
+const execFileAsync = promisify(execFile);
+const FIFTY_MIB = 50 * 1024 * 1024;
+
+async function runGit(repoRoot: string, args: string[]): Promise<string> {
+	const { stdout } = await execFileAsync("git", ["-c", "core.quotepath=false", ...args], {
+		cwd: repoRoot,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			GIT_CONFIG_GLOBAL: "/dev/null",
+			GIT_CONFIG_NOSYSTEM: "1",
+		},
+	});
+	return stdout.trim();
+}
+
+async function commitAll(repoRoot: string, message: string): Promise<string> {
+	await runGit(repoRoot, ["add", "."]);
+	await runGit(repoRoot, ["commit", "-m", message]);
+	return await runGit(repoRoot, ["rev-parse", "HEAD"]);
+}
+
+async function createSparseFile(path: string, size: number): Promise<void> {
+	const handle = await open(path, "w");
+	try {
+		await handle.truncate(size);
+	} finally {
+		await handle.close();
+	}
+}
+
+describe("getWorkspaceChanges", () => {
+	let repoRoot: string;
+
+	beforeEach(async () => {
+		repoRoot = await mkdtemp(join(tmpdir(), "kanban-workspace-changes-"));
+		await runGit(repoRoot, ["init"]);
+		await runGit(repoRoot, ["config", "user.email", "test@example.com"]);
+		await runGit(repoRoot, ["config", "user.name", "Test User"]);
+	});
+
+	afterEach(async () => {
+		await rm(repoRoot, { recursive: true, force: true });
+	});
+
+	it("skips a 50 MiB working tree binary without loading file text", async () => {
+		const filePath = join(repoRoot, "large.bin");
+		await writeFile(filePath, "initial\n");
+		await commitAll(repoRoot, "Initial commit");
+
+		await createSparseFile(filePath, FIFTY_MIB);
+
+		const response = await getWorkspaceChanges(repoRoot);
+		const file = response.files.find((entry) => entry.path === "large.bin");
+
+		expect(file).toBeDefined();
+		expect(file?.status).toBe("modified");
+		expect(file?.oldText).toBeNull();
+		expect(file?.newText).toBeNull();
+	});
+
+	it("skips a 50 MiB historical binary before reading it from git", async () => {
+		const filePath = join(repoRoot, "large.bin");
+		await writeFile(filePath, "initial\n");
+		const smallRef = await commitAll(repoRoot, "Initial commit");
+
+		await createSparseFile(filePath, FIFTY_MIB);
+		const largeRef = await commitAll(repoRoot, "Large binary commit");
+
+		const response = await getWorkspaceChangesBetweenRefs({
+			cwd: repoRoot,
+			fromRef: smallRef,
+			toRef: largeRef,
+		});
+		const file = response.files.find((entry) => entry.path === "large.bin");
+
+		expect(file).toBeDefined();
+		expect(file?.status).toBe("modified");
+		expect(file?.oldText).toBeNull();
+		expect(file?.newText).toBeNull();
+	});
+});

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.test.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.test.tsx
@@ -265,6 +265,7 @@ describe("DiffViewerPanel", () => {
 
 		expect(container.textContent).toContain("assets/logo.png");
 		expect(container.textContent).toContain("Binary");
+		expect(container.textContent).toContain("Binary file not shown.");
 		expect(container.querySelector(".kb-diff-row")).toBeNull();
 	});
 

--- a/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
+++ b/web-ui/src/components/detail-panels/diff-viewer-panel.tsx
@@ -889,7 +889,17 @@ export function DiffViewerPanel({
 										>
 											{group.entries.map((entry) => (
 												<div key={entry.id} className="kb-diff-entry">
-													{entry.isBinary ? null : viewMode === "split" ? (
+													{entry.isBinary ? (
+														<div
+															style={{
+																padding: "12px",
+																fontSize: 12,
+																color: "var(--color-text-tertiary)",
+															}}
+														>
+															Binary file not shown.
+														</div>
+													) : viewMode === "split" ? (
 														<SplitDiff
 															path={group.path}
 															oldText={entry.oldText}

--- a/web-ui/src/components/git-history/git-commit-diff-panel.test.tsx
+++ b/web-ui/src/components/git-history/git-commit-diff-panel.test.tsx
@@ -134,7 +134,7 @@ describe("GitCommitDiffPanel", () => {
 		expect(scrollContainer.scrollTop).toBe(547);
 	});
 
-	it("shows only the file header for binary paths", async () => {
+	it("shows a binary not shown message for binary paths", async () => {
 		const diffSource: GitCommitDiffSource = {
 			type: "commit",
 			files: [
@@ -162,6 +162,7 @@ describe("GitCommitDiffPanel", () => {
 
 		expect(container.textContent).toContain("assets/logo.png");
 		expect(container.textContent).toContain("Binary");
+		expect(container.textContent).toContain("Binary file not shown.");
 		expect(container.textContent).not.toContain("No textual diff available.");
 		expect(container.querySelector(".kb-diff-row")).toBeNull();
 	});

--- a/web-ui/src/components/git-history/git-commit-diff-panel.tsx
+++ b/web-ui/src/components/git-history/git-commit-diff-panel.tsx
@@ -412,9 +412,19 @@ export function GitCommitDiffPanel({
 													Renamed from <code className="font-mono">{commitFile.previousPath}</code>
 												</div>
 											) : null}
-											{!isBinaryFile && rows.length > 0 ? (
+											{isBinaryFile ? (
+												<div
+													style={{
+														padding: "12px",
+														fontSize: 12,
+														color: "var(--color-text-tertiary)",
+													}}
+												>
+													Binary file not shown.
+												</div>
+											) : rows.length > 0 ? (
 												<ReadOnlyUnifiedDiff rows={rows} path={path} />
-											) : !isBinaryFile ? (
+											) : (
 												<div
 													style={{
 														padding: "12px",
@@ -424,7 +434,7 @@ export function GitCommitDiffPanel({
 												>
 													No textual diff available.
 												</div>
-											) : null}
+											)}
 										</div>
 									</div>
 								) : null}


### PR DESCRIPTION
# Problem

Kanban could crash or hang when the workspace changes view included large binary files. The concrete reproduction came from a Cline web worktree where Git reported several tracked mp4 files as modified. The previous workspace changes loader treated every changed file as text and read both sides of the diff into memory before returning the response.

That is unsafe for repositories with large committed assets. A changed mp4, webm, png, or other binary can be tens of megabytes, and reading it through UTF-8 text paths can allocate large strings, churn the workspace changes cache, and eventually drive the Node process into an out of memory crash.

# Technical approach

The fix keeps the API shape unchanged and uses information Kanban was already asking Git for. `git diff --numstat` reports binary files with `-` for both additions and deletions. The workspace changes loader now parses that output into a shared `DiffStat` shape with an `isBinary` flag.

Each workspace file-change builder now reads numstat before loading file contents. If Git marks the file as binary, Kanban skips both the old-side read and the working-tree read, returning `oldText: null` and `newText: null`. This prevents binary bytes from entering the response payload or the workspace changes cache.

This applies to all three workspace changes paths:

```ts
getWorkspaceChanges
getWorkspaceChangesBetweenRefs
getWorkspaceChangesFromRef
```

The UI already detected binary-looking paths and avoided rendering diff rows for them. I added a small expanded-body message so users can tell the file was intentionally omitted instead of seeing an empty diff panel:

```text
Binary file not shown.
```

<img width="709" height="520" alt="image" src="https://github.com/user-attachments/assets/d47f7a58-93ed-447d-a9f1-490b25de8efb" />


# Debugging notes

The original suspicion was that `cline-web` was simply large, but plain Git commands were fast. The expensive part was Kanban reading changed binary file contents as text after Git reported them in the diff.

A specific task worktree showed these files as modified:

```text
public/assets/videos/plan-act-4k.mp4
public/assets/videos/refactor-web-1080p.mp4
public/assets/videos/understand-codebase-4k.mp4
```

Git reported them as binary in numstat:

```text
-	-	public/assets/videos/plan-act-4k.mp4
```

That is the exact signal this PR now uses to avoid content reads.

There was also a repo-level reason those mp4s showed as modified in the task worktree: `cline-web` has LFS attributes for mp4 files, but those committed blobs appear to still be full mp4 blobs rather than LFS pointer blobs. Git therefore reports a binary diff even when the working-tree files are not something Kanban changed. This PR does not try to fix that repository state. It makes Kanban robust when Git reports binary changes.

# Decisions

I intentionally kept this narrower than a broader file-size cap or API change. A size cap would also protect against very large text files, but it requires new response semantics and more UI states. The immediate failure mode was binary assets, and Git already provides a reliable signal for those through numstat.

The response contract remains unchanged. Binary files continue to appear in the file list, but their text fields stay null and the UI explains why no diff rows are shown.

# Testing

Ran these focused checks before pushing:

```sh
npm test -- test/runtime/get-workspace-changes.test.ts test/runtime/git-utils.test.ts
npm --prefix web-ui run test -- src/components/git-history/git-commit-diff-panel.test.tsx src/components/detail-panels/diff-viewer-panel.test.tsx
npm run typecheck
npm --prefix web-ui run typecheck
```

The precommit hook also passed:

```text
54 test files passed
548 tests passed
```

# Follow-up

A separate improvement could add a file-size cap for very large text files. I would keep that separate because it changes behavior beyond the binary OOM case and likely deserves explicit UI wording for oversized text previews.