### PR TITLE
llama.cpp context overflow response fix

### DIFF
--- a/src/cline-sdk/cline-context-overflow-compaction.ts
+++ b/src/cline-sdk/cline-context-overflow-compaction.ts
@@ -30,6 +30,8 @@ const CONTEXT_OVERFLOW_ERROR_PATTERNS = [
 	/reduce.*length.*messages.*completion/i,
 	/tokens?\s*>\s*[\d,]+\s*(maximum|limit)/i,
 	/input tokens?.*(exceed|exceeds).*(limit|maximum|context)/i,
+	/available context size/i,
+	/exceeds?\s*the available context size/i,
 ];
 const CONTEXT_COMPACTION_PREVIEW_CHARS = 300;
 


### PR DESCRIPTION
fix(cline-sdk): added 2 additional entries to CONTEXT_OVERFLOW_ERROR_PATTERNS to handle llama.cpp context overflow response patterns

fixes #504 