### PR TITLE
fix(terminal): preserve viewport across output and restore

### DIFF
--- a/web-ui/src/terminal/persistent-terminal-manager.test.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TerminalWriteData = string | Uint8Array;
+type TerminalWriteCallback = () => void;
+
+interface MockTerminalOptions {
+	cols?: number;
+	rows?: number;
+}
+
+interface MockTerminalBuffer {
+	active: {
+		baseY: number;
+		viewportY: number;
+	};
+}
+
+interface MockAddon {
+	dispose?: () => void;
+}
+
+type MockKeyEventHandler = (event: KeyboardEvent) => boolean;
+
+const terminalMocks = vi.hoisted(() => {
+	class MockTerminal {
+		readonly buffer: MockTerminalBuffer = {
+			active: {
+				baseY: 0,
+				viewportY: 0,
+			},
+		};
+		readonly unicode = {
+			activeVersion: "",
+		};
+		cols: number;
+		rows: number;
+		onWrite: ((data: TerminalWriteData) => void) | null = null;
+		options: { theme?: Record<string, string> } = {};
+		customKeyEventHandler: MockKeyEventHandler | null = null;
+		readonly attachCustomKeyEventHandler = vi.fn((handler: MockKeyEventHandler) => {
+			this.customKeyEventHandler = handler;
+		});
+		readonly clear = vi.fn();
+		readonly dispose = vi.fn();
+		readonly focus = vi.fn();
+		readonly getSelection = vi.fn(() => "");
+		readonly hasSelection = vi.fn(() => false);
+		readonly input = vi.fn();
+		readonly loadAddon = vi.fn((_addon: MockAddon) => {});
+		readonly onBinary = vi.fn();
+		readonly onData = vi.fn();
+		readonly open = vi.fn();
+		deferWriteCallback = false;
+		pendingWriteCallback: TerminalWriteCallback | null = null;
+		readonly paste = vi.fn();
+		readonly reset = vi.fn(() => {
+			this.buffer.active.baseY = 0;
+			this.buffer.active.viewportY = 0;
+		});
+		readonly resize = vi.fn((cols: number, rows: number) => {
+			this.cols = cols;
+			this.rows = rows;
+		});
+		readonly scrollToBottom = vi.fn(() => {
+			this.buffer.active.viewportY = this.buffer.active.baseY;
+		});
+		readonly scrollToLine = vi.fn((line: number) => {
+			this.buffer.active.viewportY = line;
+		});
+		readonly write = vi.fn((data: TerminalWriteData, callback?: TerminalWriteCallback) => {
+			this.onWrite?.(data);
+			if (this.deferWriteCallback) {
+				this.pendingWriteCallback = callback ?? null;
+				return;
+			}
+			callback?.();
+		});
+
+		constructor(options: MockTerminalOptions) {
+			this.cols = options.cols ?? 0;
+			this.rows = options.rows ?? 0;
+			instances.push(this);
+		}
+
+		flushPendingWrite(): void {
+			const callback = this.pendingWriteCallback;
+			this.pendingWriteCallback = null;
+			callback?.();
+		}
+	}
+
+	const instances: MockTerminal[] = [];
+	return {
+		instances,
+		MockTerminal,
+	};
+});
+
+const fitAddonMocks = vi.hoisted(() => {
+	class MockFitAddon {
+		onFit: (() => void) | null = null;
+		readonly fit = vi.fn(() => {
+			this.onFit?.();
+		});
+	}
+
+	const instances: MockFitAddon[] = [];
+	const FitAddon = class extends MockFitAddon {
+		constructor() {
+			super();
+			instances.push(this);
+		}
+	};
+
+	return {
+		FitAddon,
+		instances,
+	};
+});
+
+const addonMocks = vi.hoisted(() => {
+	class MockWebglAddon {
+		readonly dispose = vi.fn();
+		readonly onContextLoss = vi.fn();
+	}
+
+	return {
+		ClipboardAddon: class {},
+		Unicode11Addon: class {},
+		WebLinksAddon: class {},
+		WebglAddon: MockWebglAddon,
+	};
+});
+
+const geometryMocks = vi.hoisted(() => ({
+	clearTerminalGeometry: vi.fn(),
+	reportTerminalGeometry: vi.fn(),
+}));
+
+const trpcMocks = vi.hoisted(() => ({
+	getRuntimeTrpcClient: vi.fn(() => ({
+		runtime: {
+			stopTaskSession: {
+				mutate: vi.fn(async () => {}),
+			},
+		},
+	})),
+}));
+
+interface MockMessageEvent {
+	data: string | ArrayBuffer | Blob;
+}
+
+type MockMessageListener = (event: MockMessageEvent) => void;
+
+class MockWebSocket {
+	static readonly CLOSED = 3;
+	static readonly OPEN = 1;
+
+	binaryType: BinaryType = "blob";
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MockMessageEvent) => void) | null = null;
+	onopen: ((event: Event) => void) | null = null;
+	readyState = MockWebSocket.OPEN;
+	readonly send = vi.fn();
+	private readonly messageListeners = new Set<MockMessageListener>();
+
+	constructor(readonly url: string) {
+		webSocketInstances.push(this);
+	}
+
+	addEventListener(type: "message", listener: MockMessageListener): void {
+		if (type === "message") {
+			this.messageListeners.add(listener);
+		}
+	}
+
+	close(): void {
+		this.readyState = MockWebSocket.CLOSED;
+		this.onclose?.(new CloseEvent("close"));
+	}
+
+	emitMessage(data: string | ArrayBuffer | Blob): void {
+		const event = { data };
+		for (const listener of this.messageListeners) {
+			listener(event);
+		}
+		this.onmessage?.(event);
+	}
+}
+
+class MockResizeObserver implements ResizeObserver {
+	readonly root = null;
+	readonly rootMargin = "";
+	readonly thresholds = [];
+
+	constructor(readonly callback: ResizeObserverCallback) {}
+
+	disconnect(): void {}
+
+	observe(_target: Element): void {}
+
+	takeRecords(): ResizeObserverEntry[] {
+		return [];
+	}
+
+	unobserve(_target: Element): void {}
+}
+
+const webSocketInstances: MockWebSocket[] = [];
+
+vi.mock("@xterm/xterm", () => ({
+	Terminal: terminalMocks.MockTerminal,
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+	FitAddon: fitAddonMocks.FitAddon,
+}));
+
+vi.mock("@xterm/addon-clipboard", () => ({
+	ClipboardAddon: addonMocks.ClipboardAddon,
+}));
+
+vi.mock("@xterm/addon-unicode11", () => ({
+	Unicode11Addon: addonMocks.Unicode11Addon,
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+	WebLinksAddon: addonMocks.WebLinksAddon,
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+	WebglAddon: addonMocks.WebglAddon,
+}));
+
+vi.mock("@/runtime/trpc-client", () => ({
+	getRuntimeTrpcClient: trpcMocks.getRuntimeTrpcClient,
+}));
+
+vi.mock("@/terminal/terminal-geometry-registry", () => ({
+	clearTerminalGeometry: geometryMocks.clearTerminalGeometry,
+	reportTerminalGeometry: geometryMocks.reportTerminalGeometry,
+}));
+
+import {
+	disposeAllPersistentTerminalsForWorkspace,
+	ensurePersistentTerminal,
+} from "@/terminal/persistent-terminal-manager";
+
+function createTerminal() {
+	return ensurePersistentTerminal({
+		cursorColor: "#ffffff",
+		taskId: "task-1",
+		terminalBackgroundColor: "#000000",
+		workspaceId: "workspace-1",
+	});
+}
+
+function getMockTerminal() {
+	const terminal = terminalMocks.instances[0];
+	if (!terminal) {
+		throw new Error("Expected a terminal instance.");
+	}
+	return terminal;
+}
+
+function getFitAddon() {
+	const fitAddon = fitAddonMocks.instances[0];
+	if (!fitAddon) {
+		throw new Error("Expected a fit addon instance.");
+	}
+	return fitAddon;
+}
+
+function getHostElement() {
+	const hostElement = getMockTerminal().open.mock.calls[0]?.[0];
+	if (!(hostElement instanceof HTMLDivElement)) {
+		throw new Error("Expected terminal host element.");
+	}
+	return hostElement;
+}
+
+function getSocket(path: "control" | "io") {
+	const socket = webSocketInstances.find((candidate) => candidate.url.includes(`/api/terminal/${path}`));
+	if (!socket) {
+		throw new Error(`Expected ${path} socket.`);
+	}
+	return socket;
+}
+
+describe("persistent terminal viewport preservation", () => {
+	let previousResizeObserver: typeof globalThis.ResizeObserver | undefined;
+	let previousWebSocket: typeof globalThis.WebSocket | undefined;
+	let requestAnimationFrameSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		previousResizeObserver = globalThis.ResizeObserver;
+		previousWebSocket = globalThis.WebSocket;
+		terminalMocks.instances.length = 0;
+		fitAddonMocks.instances.length = 0;
+		webSocketInstances.length = 0;
+		geometryMocks.clearTerminalGeometry.mockClear();
+		geometryMocks.reportTerminalGeometry.mockClear();
+		requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+			callback(0);
+			return 0;
+		});
+		Object.defineProperty(globalThis, "ResizeObserver", {
+			configurable: true,
+			value: MockResizeObserver,
+			writable: true,
+		});
+		Object.defineProperty(globalThis, "WebSocket", {
+			configurable: true,
+			value: MockWebSocket,
+			writable: true,
+		});
+	});
+
+	afterEach(() => {
+		disposeAllPersistentTerminalsForWorkspace("workspace-1");
+		requestAnimationFrameSpy.mockRestore();
+		if (previousResizeObserver) {
+			Object.defineProperty(globalThis, "ResizeObserver", {
+				configurable: true,
+				value: previousResizeObserver,
+				writable: true,
+			});
+		} else {
+			delete (globalThis as Partial<typeof globalThis>).ResizeObserver;
+		}
+		if (previousWebSocket) {
+			Object.defineProperty(globalThis, "WebSocket", {
+				configurable: true,
+				value: previousWebSocket,
+				writable: true,
+			});
+		} else {
+			delete (globalThis as Partial<typeof globalThis>).WebSocket;
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("preserves a scrolled-back viewport after terminal output", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.buffer.active.viewportY = 24;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 101;
+		};
+
+		getSocket("io").emitMessage("agent output");
+
+		await vi.waitFor(() => {
+			expect(terminal.write).toHaveBeenCalledWith("agent output", expect.any(Function));
+		});
+		expect(terminal.scrollToLine).toHaveBeenCalledWith(24);
+		expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+	});
+
+	it("does not restore a stale output viewport after the user scrolls during an async write", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.deferWriteCallback = true;
+		terminal.buffer.active.viewportY = 24;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 101;
+		};
+
+		getSocket("io").emitMessage("agent output");
+
+		await vi.waitFor(() => {
+			expect(terminal.write).toHaveBeenCalledWith("agent output", expect.any(Function));
+		});
+		getHostElement().dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+		terminal.buffer.active.viewportY = 55;
+		terminal.flushPendingWrite();
+
+		await vi.waitFor(() => {
+			expect(terminal.pendingWriteCallback).toBeNull();
+		});
+		expect(terminal.scrollToLine).not.toHaveBeenCalled();
+		expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+		expect(terminal.buffer.active.viewportY).toBe(55);
+	});
+
+	it("does not restore a stale output viewport after user input scrolls to bottom during an async write", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.deferWriteCallback = true;
+		terminal.buffer.active.viewportY = 24;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 101;
+		};
+
+		getSocket("io").emitMessage("agent output");
+
+		await vi.waitFor(() => {
+			expect(terminal.write).toHaveBeenCalledWith("agent output", expect.any(Function));
+		});
+		const handled = terminal.customKeyEventHandler?.(new KeyboardEvent("keydown", { key: "a" }));
+		terminal.buffer.active.viewportY = 101;
+		terminal.flushPendingWrite();
+
+		await vi.waitFor(() => {
+			expect(terminal.pendingWriteCallback).toBeNull();
+		});
+		expect(handled).toBe(true);
+		expect(terminal.scrollToLine).not.toHaveBeenCalled();
+		expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+		expect(terminal.buffer.active.viewportY).toBe(101);
+	});
+
+	it("keeps the terminal pinned to bottom after terminal output", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.buffer.active.viewportY = 100;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 101;
+		};
+
+		getSocket("io").emitMessage("agent output");
+
+		await vi.waitFor(() => {
+			expect(terminal.write).toHaveBeenCalled();
+		});
+		expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+		expect(terminal.scrollToLine).not.toHaveBeenCalled();
+	});
+
+	it("preserves a scrolled-back viewport after restore replay", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.buffer.active.viewportY = 24;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 90;
+		};
+
+		getSocket("control").emitMessage(
+			JSON.stringify({
+				cols: 120,
+				rows: 40,
+				snapshot: "restored terminal snapshot",
+				type: "restore",
+			}),
+		);
+
+		await vi.waitFor(() => {
+			expect(terminal.scrollToLine).toHaveBeenCalledWith(24);
+		});
+		expect(terminal.reset).toHaveBeenCalledTimes(1);
+		expect(terminal.resize).toHaveBeenCalledWith(120, 40);
+		expect(terminal.write).toHaveBeenCalledWith("restored terminal snapshot", expect.any(Function));
+	});
+
+	it("does not restore a stale restore viewport after the user scrolls during replay", async () => {
+		createTerminal();
+		const terminal = getMockTerminal();
+		terminal.deferWriteCallback = true;
+		terminal.buffer.active.viewportY = 24;
+		terminal.buffer.active.baseY = 100;
+		terminal.onWrite = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 90;
+		};
+
+		getSocket("control").emitMessage(
+			JSON.stringify({
+				cols: 120,
+				rows: 40,
+				snapshot: "restored terminal snapshot",
+				type: "restore",
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(terminal.write).toHaveBeenCalledWith("restored terminal snapshot", expect.any(Function));
+		});
+		getHostElement().dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+		terminal.buffer.active.viewportY = 55;
+		terminal.flushPendingWrite();
+
+		await vi.waitFor(() => {
+			expect(terminal.pendingWriteCallback).toBeNull();
+		});
+		expect(terminal.scrollToLine).not.toHaveBeenCalled();
+		expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+		expect(terminal.buffer.active.viewportY).toBe(55);
+	});
+
+	it("clamps a scrolled-back viewport after fit reduces the buffer", async () => {
+		const persistentTerminal = createTerminal();
+		const terminal = getMockTerminal();
+		const fitAddon = getFitAddon();
+		const container = document.createElement("div");
+		terminal.buffer.active.viewportY = 80;
+		terminal.buffer.active.baseY = 100;
+		fitAddon.onFit = () => {
+			terminal.buffer.active.viewportY = 0;
+			terminal.buffer.active.baseY = 40;
+		};
+
+		persistentTerminal.mount(
+			container,
+			{
+				cursorColor: "#ffffff",
+				terminalBackgroundColor: "#000000",
+			},
+			{},
+		);
+
+		await vi.waitFor(() => {
+			expect(fitAddon.fit).toHaveBeenCalled();
+		});
+		expect(terminal.scrollToLine).toHaveBeenCalledWith(40);
+	});
+});

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -49,6 +49,12 @@ interface EnsurePersistentTerminalInput extends PersistentTerminalAppearance {
 	workspaceId: string;
 }
 
+interface TerminalViewportSnapshot {
+	userInteractionSequence: number;
+	viewportY: number;
+	wasAtBottom: boolean;
+}
+
 function generateTerminalClientId(): string {
 	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
 		return crypto.randomUUID();
@@ -161,6 +167,7 @@ class PersistentTerminal {
 	private restoreCompleted = false;
 	private outputTextDecoder = new TextDecoder();
 	private terminalWriteQueue: Promise<void> = Promise.resolve();
+	private userViewportInteractionSequence = 0;
 	private disposed = false;
 
 	constructor(
@@ -204,7 +211,16 @@ class PersistentTerminal {
 			}
 			this.sendIoData(bytes);
 		});
+		this.hostElement.addEventListener("wheel", this.trackUserViewportInteraction, { capture: true, passive: true });
+		this.hostElement.addEventListener("touchmove", this.trackUserViewportInteraction, {
+			capture: true,
+			passive: true,
+		});
+		this.hostElement.addEventListener("pointerdown", this.trackScrollbarViewportInteraction, { capture: true });
 		this.terminal.attachCustomKeyEventHandler((event) => {
+			if (event.type === "keydown") {
+				this.trackUserViewportInteraction();
+			}
 			if (event.key === "Enter" && event.shiftKey) {
 				if (event.type === "keydown") {
 					this.terminal.input(SHIFT_ENTER_SEQUENCE);
@@ -232,6 +248,19 @@ class PersistentTerminal {
 
 		this.ensureConnected();
 	}
+
+	private readonly trackUserViewportInteraction = (): void => {
+		this.userViewportInteractionSequence += 1;
+	};
+
+	private readonly trackScrollbarViewportInteraction = (event: PointerEvent): void => {
+		if (!(event.target instanceof Element)) {
+			return;
+		}
+		if (event.target.closest(".xterm-viewport")) {
+			this.trackUserViewportInteraction();
+		}
+	};
 
 	private notifyLastError(): void {
 		for (const subscriber of this.subscribers) {
@@ -279,10 +308,12 @@ class PersistentTerminal {
 		options: {
 			ackBytes?: number;
 			notifyText?: string | null;
+			preserveViewport?: boolean;
 		} = {},
 	): Promise<void> {
 		const ackBytes = options.ackBytes ?? 0;
 		const notifyText = options.notifyText ?? null;
+		const preserveViewport = options.preserveViewport ?? true;
 		this.terminalWriteQueue = this.terminalWriteQueue
 			.catch(() => undefined)
 			.then(
@@ -292,7 +323,11 @@ class PersistentTerminal {
 							resolve();
 							return;
 						}
+						const viewportSnapshot = preserveViewport ? this.captureViewport() : null;
 						this.terminal.write(data, () => {
+							if (viewportSnapshot) {
+								this.restoreViewport(viewportSnapshot);
+							}
 							if (notifyText) {
 								this.notifyOutputText(notifyText);
 							}
@@ -309,27 +344,51 @@ class PersistentTerminal {
 		return this.terminalWriteQueue;
 	}
 
+	private captureViewport(): TerminalViewportSnapshot {
+		const { baseY, viewportY } = this.terminal.buffer.active;
+		return {
+			userInteractionSequence: this.userViewportInteractionSequence,
+			viewportY,
+			wasAtBottom: viewportY >= baseY,
+		};
+	}
+
+	private restoreViewport(snapshot: TerminalViewportSnapshot): void {
+		if (snapshot.userInteractionSequence !== this.userViewportInteractionSequence) {
+			return;
+		}
+		if (snapshot.wasAtBottom) {
+			this.terminal.scrollToBottom();
+			return;
+		}
+		const targetViewportY = Math.min(Math.max(snapshot.viewportY, 0), this.terminal.buffer.active.baseY);
+		this.terminal.scrollToLine(targetViewportY);
+	}
+
 	private async applyRestore(
 		snapshot: string,
 		cols: number | null | undefined,
 		rows: number | null | undefined,
 	): Promise<void> {
 		await this.terminalWriteQueue.catch(() => undefined);
+		const viewportSnapshot = this.captureViewport();
 		this.terminal.reset();
 		if (cols && rows && (this.terminal.cols !== cols || this.terminal.rows !== rows)) {
 			this.terminal.resize(cols, rows);
 		}
-		if (!snapshot) {
-			return;
+		if (snapshot) {
+			await this.enqueueTerminalWrite(snapshot, { preserveViewport: false });
 		}
-		await this.enqueueTerminalWrite(snapshot);
+		this.restoreViewport(viewportSnapshot);
 	}
 
 	private requestResize(): void {
 		if (!this.visibleContainer) {
 			return;
 		}
+		const viewportSnapshot = this.captureViewport();
 		this.fitAddon.fit();
+		this.restoreViewport(viewportSnapshot);
 		const bounds = this.visibleContainer.getBoundingClientRect();
 		const pixelWidth = Math.round(bounds.width);
 		const pixelHeight = Math.round(bounds.height);
@@ -614,7 +673,9 @@ class PersistentTerminal {
 				if (this.disposed) {
 					return;
 				}
+				const viewportSnapshot = this.captureViewport();
 				this.terminal.reset();
+				this.restoreViewport(viewportSnapshot);
 			});
 	}
 
@@ -691,6 +752,9 @@ class PersistentTerminal {
 		this.ioSocket = null;
 		this.controlSocket = null;
 		this.subscribers.clear();
+		this.hostElement.removeEventListener("wheel", this.trackUserViewportInteraction, { capture: true });
+		this.hostElement.removeEventListener("touchmove", this.trackUserViewportInteraction, { capture: true });
+		this.hostElement.removeEventListener("pointerdown", this.trackScrollbarViewportInteraction, { capture: true });
 		this.terminal.dispose();
 		this.hostElement.remove();
 	}


### PR DESCRIPTION
## Summary

- preserve the xterm viewport around terminal output writes, restore replay/reset, and fit/resize operations
- keep bottom-pinned terminals pinned to the new bottom, while restoring scrolled-back terminals to their previous line with clamping
- skip stale viewport restoration when the user scrolls or types during an async write/replay
- add focused terminal manager coverage for output, restore replay, resize clamping, bottom-pinned output, and async user-interaction races

## Validation

- npm run check
- npm --prefix web-ui run test
- npm run build

Fixes #539