### PR TITLE
feat: enable OpenCode and Gemini launch agents

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -213,10 +213,11 @@ They are distinct from Cline SDK plugin runtime hooks such as `beforeRun`,
     - `task_started` and `exec_command_begin` to `to_in_progress`
     - `*_approval_request` to `to_review`
   - Codex `notify` completion path also emits `to_review`
-- Gemini
-  - `BeforeAgent` and `AfterTool` emit `to_in_progress`
-  - `AfterAgent` emits `to_review`
-  - hook command writes `{}` to stdout immediately to satisfy Gemini hook contract, then notifies in background
+- Antigravity CLI
+  - `PreInvocation` emits `to_in_progress`
+  - `PreToolUse`, `PostToolUse`, and `PostInvocation` emit `activity`
+  - `Stop` emits `to_review`
+  - `antigravity-hook --event ...` writes `{}` to stdout immediately to satisfy the hook contract, then notifies in background
 - OpenCode
   - plugin maps busy activity to `to_in_progress`
   - plugin maps idle/error and permission ask to `to_review`

--- a/man/kanban.1
+++ b/man/kanban.1
@@ -12,7 +12,7 @@ kanban \- local orchestration board for coding agents
 .RI " " [ options ]
 .br
 .B kanban hooks
-.RI " " ingest|notify|gemini-hook|codex-wrapper
+.RI " " ingest|notify|antigravity-hook|codex-wrapper
 .RI " " [ options ]
 .br
 .B kanban mcp
@@ -109,7 +109,8 @@ same options as
 .BR ingest ,
 but best-effort.
 .br
-.B gemini-hook
+.B antigravity-hook
+.RI [ --event " " PreInvocation|PreToolUse|PostToolUse|PostInvocation|Stop ]
 .br
 .B codex-wrapper
 .B --real-binary

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -50,6 +50,8 @@ interface CodexWrapperArgs {
 	agentArgs: string[];
 }
 
+type AntigravityHookEvent = "PreInvocation" | "PreToolUse" | "PostToolUse" | "PostInvocation" | "Stop";
+
 function formatError(error: unknown): string {
 	if (error instanceof TRPCClientError) {
 		return error.message;
@@ -81,6 +83,21 @@ function parseHookEvent(value: string): RuntimeHookEvent {
 		throw new Error(`Invalid event "${value}". Must be one of: ${[...VALID_EVENTS].join(", ")}`);
 	}
 	return value as RuntimeHookEvent;
+}
+
+function parseAntigravityHookEvent(value: string): AntigravityHookEvent {
+	if (
+		value !== "PreInvocation" &&
+		value !== "PreToolUse" &&
+		value !== "PostToolUse" &&
+		value !== "PostInvocation" &&
+		value !== "Stop"
+	) {
+		throw new Error(
+			`Invalid Antigravity hook event "${value}". Must be one of: PreInvocation, PreToolUse, PostToolUse, PostInvocation, Stop`,
+		);
+	}
+	return value;
 }
 
 function parseJsonObject(value: string): Record<string, unknown> | null {
@@ -518,15 +535,15 @@ async function readStdinText(): Promise<string> {
 	return chunks.join("");
 }
 
-function mapGeminiHookEvent(eventName: string): RuntimeHookEvent | null {
-	if (eventName === "AfterAgent") {
-		return "to_review";
-	}
-	if (eventName === "BeforeAgent") {
+function mapAntigravityHookEvent(eventName: string): RuntimeHookEvent | null {
+	if (eventName === "PreInvocation") {
 		return "to_in_progress";
 	}
-	if (eventName === "AfterTool" || eventName === "BeforeTool" || eventName === "Notification") {
+	if (eventName === "PreToolUse" || eventName === "PostToolUse" || eventName === "PostInvocation") {
 		return "activity";
+	}
+	if (eventName === "Stop") {
+		return "to_review";
 	}
 	return null;
 }
@@ -554,7 +571,7 @@ async function runCodexHookSubcommand(
 	}
 }
 
-async function runGeminiHookSubcommand(): Promise<void> {
+async function runAntigravityHookSubcommand(eventNameArg: AntigravityHookEvent | undefined): Promise<void> {
 	let payload = "";
 	try {
 		payload = await readStdinText();
@@ -568,24 +585,31 @@ async function runGeminiHookSubcommand(): Promise<void> {
 		const parsed = JSON.parse(payload || "{}") as { hook_event_name?: unknown };
 		payloadRecord = asRecord(parsed);
 		hookEventName =
-			typeof parsed.hook_event_name === "string"
+			eventNameArg ??
+			(typeof parsed.hook_event_name === "string"
 				? parsed.hook_event_name
 				: payloadRecord && typeof payloadRecord.hookEventName === "string"
 					? payloadRecord.hookEventName
-					: "";
+					: payloadRecord && typeof payloadRecord.hookName === "string"
+						? payloadRecord.hookName
+						: payloadRecord && typeof payloadRecord.eventName === "string"
+							? payloadRecord.eventName
+							: payloadRecord && typeof payloadRecord.event === "string"
+								? payloadRecord.event
+								: "");
 	} catch {
-		hookEventName = "";
+		hookEventName = eventNameArg ?? "";
 		payloadRecord = null;
 	}
 
 	process.stdout.write("{}\n");
 
-	const mappedEvent = mapGeminiHookEvent(hookEventName);
+	const mappedEvent = mapAntigravityHookEvent(hookEventName);
 	if (!mappedEvent) {
 		return;
 	}
 	const metadata = normalizeHookMetadata(mappedEvent, payloadRecord, {
-		source: "gemini",
+		source: "antigravity",
 		hookEventName: hookEventName || undefined,
 	});
 	spawnBackgroundKanban(appendMetadataFlags(["hooks", "notify", "--event", mappedEvent], metadata));
@@ -780,10 +804,11 @@ export function registerHooksCommand(program: Command): void {
 		);
 
 	hooks
-		.command("gemini-hook")
-		.description("Gemini hook entrypoint.")
-		.action(async () => {
-			await runGeminiHookSubcommand();
+		.command("antigravity-hook")
+		.description("Antigravity hook entrypoint.")
+		.option("--event <event>", "Antigravity hook event name.", parseAntigravityHookEvent)
+		.action(async (options: { event?: AntigravityHookEvent }) => {
+			await runAntigravityHookSubcommand(options.event);
 		});
 
 	hooks

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -112,7 +112,8 @@ export function pickBestInstalledAgentIdFromDetected(detectedCommands: readonly 
 	for (const agentId of AUTO_SELECT_AGENT_PRIORITY) {
 		const catalogEntry = getRuntimeAgentCatalogEntry(agentId);
 		const binary = catalogEntry?.binary ?? agentId;
-		if (detected.has(binary) || detected.has(agentId)) {
+		const idAliasMatchesInstalledCommand = agentId !== "gemini" && detected.has(agentId);
+		if (detected.has(binary) || idAliasMatchesInstalledCommand) {
 			return agentId;
 		}
 	}

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -54,7 +54,14 @@ const PROJECT_CONFIG_PARENT_DIR = ".cline";
 const PROJECT_CONFIG_DIR = "kanban";
 const PROJECT_CONFIG_FILENAME = "config.json";
 const DEFAULT_AGENT_ID: RuntimeAgentId = "cline";
-const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = ["claude", "codex", "droid", "kiro"];
+const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = [
+	"claude",
+	"codex",
+	"opencode",
+	"droid",
+	"kiro",
+	"gemini",
+];
 const DEFAULT_AGENT_AUTONOMOUS_MODE_ENABLED = true;
 const DEFAULT_READY_FOR_REVIEW_NOTIFICATIONS_ENABLED = true;
 const DEFAULT_COMMIT_PROMPT_TEMPLATE = `You are in a worktree on a detached HEAD. When you are finished with the task, commit the working changes onto {{base_ref}}.

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -60,11 +60,11 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 	},
 	{
 		id: "gemini",
-		label: "Antigravity / Gemini CLI",
-		binary: "gemini",
+		label: "Antigravity CLI",
+		binary: "agy",
 		baseArgs: [],
-		autonomousArgs: ["--yolo"],
-		installUrl: "https://github.com/google-gemini/gemini-cli",
+		autonomousArgs: ["--dangerously-skip-permissions"],
+		installUrl: "https://antigravity.google/docs/cli-getting-started",
 	},
 ];
 

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -60,7 +60,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 	},
 	{
 		id: "gemini",
-		label: "Gemini CLI",
+		label: "Antigravity / Gemini CLI",
 		binary: "gemini",
 		baseArgs: [],
 		autonomousArgs: ["--yolo"],
@@ -68,16 +68,14 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 	},
 ];
 
-// Temporarily keep launch support scoped to the core agent set.
-// Re-enable additional CLIs by uncommenting entries below when ready.
 export const RUNTIME_LAUNCH_SUPPORTED_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"cline",
 	"claude",
 	"codex",
+	"opencode",
 	"droid",
 	"kiro",
-	// "opencode",
-	// "gemini",
+	"gemini",
 ];
 
 const RUNTIME_LAUNCH_SUPPORTED_AGENT_ID_SET = new Set<RuntimeAgentId>(RUNTIME_LAUNCH_SUPPORTED_AGENT_IDS);

--- a/src/prompts/append-system-prompt.ts
+++ b/src/prompts/append-system-prompt.ts
@@ -59,7 +59,7 @@ function renderLinearSetupGuidanceForAgent(agentId: RuntimeAgentId | null): stri
 		case "codex":
 			return "- If Linear MCP is not available in the current agent (OpenAI Codex), suggest running: `codex mcp add linear --url https://mcp.linear.app/mcp`";
 		case "gemini":
-			return "- If Linear MCP is not available in the current agent (Gemini CLI), suggest running: `gemini mcp add linear https://mcp.linear.app/mcp --transport http --scope user`";
+			return "- If Linear MCP is not available in the current agent (Antigravity CLI), tell the user to open `/mcp` in `agy`, or add Linear to `~/.gemini/config/mcp_config.json` / `.agents/mcp_config.json` using `https://mcp.linear.app/mcp`.";
 		case "opencode":
 			return "- If Linear MCP is not available in the current agent (OpenCode), suggest running `opencode mcp add`, then use name `linear` and URL `https://mcp.linear.app/mcp`.";
 		case "droid":

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -568,6 +568,10 @@ function getHookAgentDirectory(agentId: RuntimeAgentId): string {
 	return join(getRuntimeHomePath(), "hooks", agentId);
 }
 
+function getAntigravityPluginDirectory(): string {
+	return join(homedir(), ".gemini", "antigravity-cli", "plugins", "kanban");
+}
+
 const KIRO_KANBAN_AGENT_NAME = "kanban";
 
 function getKiroAgentConfigPath(): string {
@@ -806,54 +810,52 @@ const geminiAdapter: AgentSessionAdapter = {
 	async prepare(input) {
 		const args = [...input.args];
 		const env: Record<string, string | undefined> = {};
+		let deferredStartupInput: string | undefined;
 
-		if (input.autonomousModeEnabled && !hasCliOption(args, "--yolo")) {
-			args.push("--yolo");
+		if (input.autonomousModeEnabled && !hasCliOption(args, "--dangerously-skip-permissions")) {
+			args.push("--dangerously-skip-permissions");
 		}
 
-		if (input.resumeFromTrash && !hasCliOption(args, "--resume")) {
-			args.push("--resume", "latest");
-		}
-
-		if (input.startInPlanMode) {
-			args.push("--approval-mode=plan");
+		if (input.resumeFromTrash && !hasCliOption(args, "--continue")) {
+			args.push("--continue");
 		}
 
 		const hooks = resolveHookContext(input);
 		if (hooks) {
-			const configPath = join(getHookAgentDirectory("gemini"), "settings.json");
-			const geminiHookCommand = buildHooksCommand(["gemini-hook"]);
+			const pluginDirectory = getAntigravityPluginDirectory();
+			const pluginManifestPath = join(pluginDirectory, "plugin.json");
+			const hooksPath = join(pluginDirectory, "hooks.json");
+			const preInvocationHookCommand = buildHooksCommand(["antigravity-hook", "--event", "PreInvocation"]);
+			const preToolUseHookCommand = buildHooksCommand(["antigravity-hook", "--event", "PreToolUse"]);
+			const postToolUseHookCommand = buildHooksCommand(["antigravity-hook", "--event", "PostToolUse"]);
+			const postInvocationHookCommand = buildHooksCommand(["antigravity-hook", "--event", "PostInvocation"]);
+			const stopHookCommand = buildHooksCommand(["antigravity-hook", "--event", "Stop"]);
 
-			const config = {
-				hooks: {
-					BeforeTool: [
+			const hooksConfig = {
+				kanban: {
+					PreInvocation: [{ type: "command", command: preInvocationHookCommand }],
+					PreToolUse: [
 						{
-							hooks: [{ type: "command", command: geminiHookCommand }],
+							matcher: "*",
+							hooks: [{ type: "command", command: preToolUseHookCommand }],
 						},
 					],
-					AfterTool: [
+					PostToolUse: [
 						{
-							hooks: [{ type: "command", command: geminiHookCommand }],
+							matcher: "*",
+							hooks: [{ type: "command", command: postToolUseHookCommand }],
 						},
 					],
-					AfterAgent: [
-						{
-							hooks: [{ type: "command", command: geminiHookCommand }],
-						},
-					],
-					BeforeAgent: [
-						{
-							hooks: [{ type: "command", command: geminiHookCommand }],
-						},
-					],
-					Notification: [
-						{
-							hooks: [{ type: "command", command: geminiHookCommand }],
-						},
-					],
+					PostInvocation: [{ type: "command", command: postInvocationHookCommand }],
+					Stop: [{ type: "command", command: stopHookCommand }],
 				},
 			};
-			await ensureTextFile(configPath, JSON.stringify(config, null, 2));
+			const pluginManifest = {
+				name: "kanban",
+				description: "Kanban task state hooks for Antigravity CLI sessions.",
+			};
+			await ensureTextFile(pluginManifestPath, JSON.stringify(pluginManifest, null, 2));
+			await ensureTextFile(hooksPath, JSON.stringify(hooksConfig, null, 2));
 			Object.assign(
 				env,
 				createHookRuntimeEnv({
@@ -861,21 +863,20 @@ const geminiAdapter: AgentSessionAdapter = {
 					workspaceId: hooks.workspaceId,
 				}),
 			);
-			env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = configPath;
 		}
 
 		const trimmed = input.prompt.trim();
-		if (trimmed) {
+		if (input.startInPlanMode) {
+			const planningCommand = trimmed ? `/planning ${trimmed}` : "/planning";
+			deferredStartupInput = toBracketedPasteSubmission(planningCommand);
+		} else if (trimmed) {
 			args.push("-i", trimmed);
-			return {
-				args,
-				env,
-			};
 		}
 
 		return {
 			args,
 			env,
+			deferredStartupInput,
 		};
 	},
 };

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -127,6 +127,13 @@ function hasCliOption(args: string[], optionName: string): boolean {
 	return false;
 }
 
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return null;
+	}
+	return value as Record<string, unknown>;
+}
+
 function getClineHookScriptPath(
 	hooksDir: string,
 	hookName: "Notification" | "TaskComplete" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse",
@@ -1025,6 +1032,33 @@ function tryExtractOpenCodeModelFromConfig(rawConfig: string): string | null {
 	return null;
 }
 
+async function readOpenCodeConfigObject(configPath: string | null): Promise<Record<string, unknown> | null> {
+	if (!configPath) {
+		return null;
+	}
+	try {
+		const rawConfig = await readFile(configPath, "utf8");
+		try {
+			return asObjectRecord(JSON.parse(rawConfig));
+		} catch {
+			return asObjectRecord(JSON.parse(stripJsonComments(rawConfig)));
+		}
+	} catch {
+		return null;
+	}
+}
+
+function mergeOpenCodePluginConfig(
+	baseConfig: Record<string, unknown> | null,
+	pluginFileUrl: string,
+): Record<string, unknown> {
+	const basePlugins = Array.isArray(baseConfig?.plugin) ? baseConfig.plugin : [];
+	return {
+		...(baseConfig ?? {}),
+		plugin: [...basePlugins, pluginFileUrl],
+	};
+}
+
 async function resolveOpenCodePreferredModelArg(configPath: string | null): Promise<string | null> {
 	if (configPath) {
 		try {
@@ -1116,6 +1150,9 @@ const opencodeAdapter: AgentSessionAdapter = {
 		if (input.resumeFromTrash && !hasCliOption(args, "--continue")) {
 			args.push("--continue");
 		}
+		if (input.autonomousModeEnabled && !hasCliOption(args, "--auto")) {
+			args.push("--auto");
+		}
 
 		if (input.startInPlanMode) {
 			env.OPENCODE_EXPERIMENTAL_PLAN_MODE = "true";
@@ -1136,9 +1173,8 @@ const opencodeAdapter: AgentSessionAdapter = {
 			);
 			await ensureTextFile(pluginPath, pluginContent);
 			const pluginFileUrl = pathToFileURL(pluginPath).href;
-			const config = {
-				plugin: [pluginFileUrl],
-			};
+			const baseConfig = await readOpenCodeConfigObject(baseConfigPath);
+			const config = mergeOpenCodePluginConfig(baseConfig, pluginFileUrl);
 			await ensureTextFile(configPath, JSON.stringify(config));
 			Object.assign(
 				env,

--- a/test/runtime/config/runtime-config.test.ts
+++ b/test/runtime/config/runtime-config.test.ts
@@ -67,13 +67,14 @@ function writeFakeCommand(binDir: string, command: string): void {
 
 describe.sequential("runtime-config auto agent selection", () => {
 	it("selects agents using the configured priority order", () => {
-		expect(pickBestInstalledAgentIdFromDetected(["codex", "opencode", "gemini"])).toBe("codex");
-		expect(pickBestInstalledAgentIdFromDetected(["opencode", "droid", "gemini"])).toBe("opencode");
-		expect(pickBestInstalledAgentIdFromDetected(["kiro-cli", "gemini"])).toBe("kiro");
-		expect(pickBestInstalledAgentIdFromDetected(["droid", "gemini", "cline"])).toBe("droid");
-		expect(pickBestInstalledAgentIdFromDetected(["gemini", "cline"])).toBe("gemini");
+		expect(pickBestInstalledAgentIdFromDetected(["codex", "opencode", "agy"])).toBe("codex");
+		expect(pickBestInstalledAgentIdFromDetected(["opencode", "droid", "agy"])).toBe("opencode");
+		expect(pickBestInstalledAgentIdFromDetected(["kiro-cli", "agy"])).toBe("kiro");
+		expect(pickBestInstalledAgentIdFromDetected(["droid", "agy", "cline"])).toBe("droid");
+		expect(pickBestInstalledAgentIdFromDetected(["agy", "cline"])).toBe("gemini");
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "codex", "cline"])).toBe("claude");
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "droid"])).toBe("claude");
+		expect(pickBestInstalledAgentIdFromDetected(["gemini", "cline"])).toBeNull();
 		expect(pickBestInstalledAgentIdFromDetected(["cline"])).toBeNull();
 		expect(pickBestInstalledAgentIdFromDetected([])).toBeNull();
 	});
@@ -89,7 +90,7 @@ describe.sequential("runtime-config auto agent selection", () => {
 		try {
 			writeFakeCommand(tempBin, "opencode");
 			writeFakeCommand(tempBin, "codex");
-			writeFakeCommand(tempBin, "gemini");
+			writeFakeCommand(tempBin, "agy");
 
 			const previousShell = process.env.SHELL;
 			try {

--- a/test/runtime/config/runtime-config.test.ts
+++ b/test/runtime/config/runtime-config.test.ts
@@ -68,10 +68,10 @@ function writeFakeCommand(binDir: string, command: string): void {
 describe.sequential("runtime-config auto agent selection", () => {
 	it("selects agents using the configured priority order", () => {
 		expect(pickBestInstalledAgentIdFromDetected(["codex", "opencode", "gemini"])).toBe("codex");
-		expect(pickBestInstalledAgentIdFromDetected(["opencode", "droid", "gemini"])).toBe("droid");
+		expect(pickBestInstalledAgentIdFromDetected(["opencode", "droid", "gemini"])).toBe("opencode");
 		expect(pickBestInstalledAgentIdFromDetected(["kiro-cli", "gemini"])).toBe("kiro");
 		expect(pickBestInstalledAgentIdFromDetected(["droid", "gemini", "cline"])).toBe("droid");
-		expect(pickBestInstalledAgentIdFromDetected(["gemini", "cline"])).toBeNull();
+		expect(pickBestInstalledAgentIdFromDetected(["gemini", "cline"])).toBe("gemini");
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "codex", "cline"])).toBe("claude");
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "droid"])).toBe("claude");
 		expect(pickBestInstalledAgentIdFromDetected(["cline"])).toBeNull();
@@ -206,7 +206,7 @@ describe.sequential("runtime-config auto agent selection", () => {
 		}
 	});
 
-	it("normalizes unsupported configured agents to the default launch agent", async () => {
+	it("preserves configured OpenCode and Gemini launch agents", async () => {
 		const { path: tempHome, cleanup: cleanupHome } = createTempDir("kanban-home-runtime-config-set-");
 		const { path: tempProject, cleanup: cleanupProject } = createTempDir("kanban-project-runtime-config-set-");
 		const { path: tempBin, cleanup: cleanupBin } = createTempDir("kanban-bin-runtime-config-set-");
@@ -231,7 +231,12 @@ describe.sequential("runtime-config auto agent selection", () => {
 
 			await withTemporaryEnv({ home: tempHome, pathPrefix: tempBin }, async () => {
 				const state = await loadRuntimeConfig(tempProject);
-				expect(state.selectedAgentId).toBe("cline");
+				expect(state.selectedAgentId).toBe("gemini");
+
+				const updated = await updateRuntimeConfig(tempProject, {
+					selectedAgentId: "opencode",
+				});
+				expect(updated.selectedAgentId).toBe("opencode");
 			});
 		} finally {
 			cleanupBin();

--- a/test/runtime/terminal/agent-registry.test.ts
+++ b/test/runtime/terminal/agent-registry.test.ts
@@ -138,7 +138,7 @@ describe("buildRuntimeConfigResponse", () => {
 		expect(response.agents.find((agent) => agent.id === "opencode")?.command).toBe("opencode");
 		expect(response.agents.find((agent) => agent.id === "droid")?.command).toBe("droid");
 		expect(response.agents.find((agent) => agent.id === "kiro")?.command).toBe("kiro-cli chat");
-		expect(response.agents.find((agent) => agent.id === "gemini")?.command).toBe("gemini");
+		expect(response.agents.find((agent) => agent.id === "gemini")?.command).toBe("agy");
 	});
 
 	it("sets debug mode from runtime environment variables", () => {

--- a/test/runtime/terminal/agent-registry.test.ts
+++ b/test/runtime/terminal/agent-registry.test.ts
@@ -78,12 +78,22 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(true);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual([
+			"claude",
+			"codex",
+			"cline",
+			"opencode",
+			"droid",
+			"kiro",
+			"gemini",
+		]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);
+		expect(response.agents.find((agent) => agent.id === "opencode")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "droid")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "kiro")?.defaultArgs).toEqual(["chat"]);
+		expect(response.agents.find((agent) => agent.id === "gemini")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.installed).toBe(true);
 	});
 
@@ -106,17 +116,29 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(false);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual([
+			"claude",
+			"codex",
+			"cline",
+			"opencode",
+			"droid",
+			"kiro",
+			"gemini",
+		]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);
+		expect(response.agents.find((agent) => agent.id === "opencode")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "droid")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "kiro")?.defaultArgs).toEqual(["chat"]);
+		expect(response.agents.find((agent) => agent.id === "gemini")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.installed).toBe(true);
 		expect(response.agents.find((agent) => agent.id === "claude")?.command).toBe("claude");
 		expect(response.agents.find((agent) => agent.id === "codex")?.command).toBe("codex");
+		expect(response.agents.find((agent) => agent.id === "opencode")?.command).toBe("opencode");
 		expect(response.agents.find((agent) => agent.id === "droid")?.command).toBe("droid");
 		expect(response.agents.find((agent) => agent.id === "kiro")?.command).toBe("kiro-cli chat");
+		expect(response.agents.find((agent) => agent.id === "gemini")?.command).toBe("gemini");
 	});
 
 	it("sets debug mode from runtime environment variables", () => {

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -277,6 +277,45 @@ describe("prepareAgentLaunch hook strategies", () => {
 		expect(plugin).toContain('currentState = "idle"');
 	});
 
+	it("preserves existing OpenCode config when adding Kanban hooks", async () => {
+		const homePath = setupTempHome();
+		const userConfigPath = join(homePath, "opencode-user.jsonc");
+		writeFileSync(
+			userConfigPath,
+			`{
+				// User provider and plugin settings should survive hook injection.
+				"model": "openai/gpt-4o",
+				"mcp": { "linear": { "url": "https://mcp.linear.app/mcp" } },
+				"plugin": ["file:///user/plugin.js"]
+			}`,
+			"utf8",
+		);
+
+		const launch = await prepareAgentLaunch({
+			taskId: "task-opencode-config",
+			agentId: "opencode",
+			binary: "opencode",
+			args: [],
+			cwd: "/tmp",
+			prompt: "",
+			env: { OPENCODE_CONFIG: userConfigPath },
+			workspaceId: "workspace-1",
+		});
+
+		const generatedConfigPath = launch.env.OPENCODE_CONFIG;
+		expect(generatedConfigPath).toBeDefined();
+		expect(generatedConfigPath).not.toBe(userConfigPath);
+		const config = JSON.parse(readFileSync(generatedConfigPath ?? "", "utf8")) as {
+			model?: string;
+			mcp?: Record<string, unknown>;
+			plugin?: string[];
+		};
+		expect(config.model).toBe("openai/gpt-4o");
+		expect(config.mcp?.linear).toBeDefined();
+		expect(config.plugin).toContain("file:///user/plugin.js");
+		expect(config.plugin?.some((plugin) => plugin.endsWith("/kanban.js"))).toBe(true);
+	});
+
 	it("loads OpenCode preferred model from LOCALAPPDATA state and auth paths", async () => {
 		const homePath = setupTempHome();
 		const localAppDataPath = join(homePath, "AppData", "Local");
@@ -698,6 +737,17 @@ describe("prepareAgentLaunch hook strategies", () => {
 			prompt: "",
 		});
 		expect(codexLaunch.args).toContain("--dangerously-bypass-approvals-and-sandbox");
+
+		const opencodeLaunch = await prepareAgentLaunch({
+			taskId: "task-opencode-auto",
+			agentId: "opencode",
+			binary: "opencode",
+			args: [],
+			autonomousModeEnabled: true,
+			cwd: "/tmp",
+			prompt: "",
+		});
+		expect(opencodeLaunch.args).toContain("--auto");
 
 		const geminiLaunch = await prepareAgentLaunch({
 			taskId: "task-gemini-auto",

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -209,26 +209,45 @@ describe("prepareAgentLaunch hook strategies", () => {
 		expect(settings.hooks?.PostToolUseFailure).toBeDefined();
 	});
 
-	it("writes Gemini settings with AfterTool mapped to to_in_progress", async () => {
+	it("writes Antigravity plugin hooks with native event names", async () => {
 		setupTempHome();
 		await prepareAgentLaunch({
 			taskId: "task-1",
 			agentId: "gemini",
-			binary: "gemini",
+			binary: "agy",
 			args: [],
 			cwd: "/tmp",
 			prompt: "",
 			workspaceId: "workspace-1",
 		});
 
-		const settingsPath = join(homedir(), ".cline", "kanban", "hooks", "gemini", "settings.json");
-		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as {
-			hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+		const pluginPath = join(homedir(), ".gemini", "antigravity-cli", "plugins", "kanban", "plugin.json");
+		const plugin = JSON.parse(readFileSync(pluginPath, "utf8")) as { name?: string };
+		expect(plugin.name).toBe("kanban");
+
+		const hooksPath = join(homedir(), ".gemini", "antigravity-cli", "plugins", "kanban", "hooks.json");
+		const hooks = JSON.parse(readFileSync(hooksPath, "utf8")) as {
+			kanban?: {
+				PreInvocation?: Array<{ command?: string }>;
+				PreToolUse?: Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
+				PostToolUse?: Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
+				PostInvocation?: Array<{ command?: string }>;
+				Stop?: Array<{ command?: string }>;
+			};
 		};
-		const afterToolCommand = settings.hooks?.AfterTool?.[0]?.hooks?.[0]?.command;
-		expect(afterToolCommand).toContain("hooks");
-		expect(afterToolCommand).toContain("gemini-hook");
-		const hookScriptPath = join(homedir(), ".cline", "kanban", "hooks", "gemini", "gemini-hook.mjs");
+		expect(hooks.kanban?.PreInvocation?.[0]?.command).toContain("--event");
+		expect(hooks.kanban?.PreInvocation?.[0]?.command).toContain("PreInvocation");
+		expect(hooks.kanban?.PreToolUse?.[0]?.matcher).toBe("*");
+		expect(hooks.kanban?.PreToolUse?.[0]?.hooks?.[0]?.command).toContain("--event");
+		expect(hooks.kanban?.PreToolUse?.[0]?.hooks?.[0]?.command).toContain("PreToolUse");
+		expect(hooks.kanban?.PostToolUse?.[0]?.matcher).toBe("*");
+		expect(hooks.kanban?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("--event");
+		expect(hooks.kanban?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("PostToolUse");
+		expect(hooks.kanban?.PostInvocation?.[0]?.command).toContain("--event");
+		expect(hooks.kanban?.PostInvocation?.[0]?.command).toContain("PostInvocation");
+		expect(hooks.kanban?.Stop?.[0]?.command).toContain("--event");
+		expect(hooks.kanban?.Stop?.[0]?.command).toContain("Stop");
+		const hookScriptPath = join(homedir(), ".cline", "kanban", "hooks", "gemini", "antigravity-hook.mjs");
 		expect(existsSync(hookScriptPath)).toBe(false);
 	});
 
@@ -455,6 +474,25 @@ describe("prepareAgentLaunch hook strategies", () => {
 		expect(launch.deferredStartupInput?.endsWith("\r")).toBe(true);
 	});
 
+	it("defers Antigravity planning startup input until startup UI is ready", async () => {
+		setupTempHome();
+		const launch = await prepareAgentLaunch({
+			taskId: "task-antigravity-plan",
+			agentId: "gemini",
+			binary: "agy",
+			args: [],
+			cwd: "/tmp",
+			prompt: "Audit the release workflow",
+			startInPlanMode: true,
+		});
+
+		expect(launch.args).not.toContain("--approval-mode=plan");
+		expect(launch.args).not.toContain("Audit the release workflow");
+		expect(launch.deferredStartupInput).toContain("\u001b[200~");
+		expect(launch.deferredStartupInput).toContain("/planning Audit the release workflow");
+		expect(launch.deferredStartupInput?.endsWith("\r")).toBe(true);
+	});
+
 	it("writes Cline hook scripts and injects --hooks-dir", async () => {
 		setupTempHome();
 		const launch = await prepareAgentLaunch({
@@ -553,13 +591,13 @@ describe("prepareAgentLaunch hook strategies", () => {
 		const geminiLaunch = await prepareAgentLaunch({
 			taskId: "task-gemini",
 			agentId: "gemini",
-			binary: "gemini",
+			binary: "agy",
 			args: [],
 			cwd: "/tmp",
 			prompt: "",
 			resumeFromTrash: true,
 		});
-		expect(geminiLaunch.args).toEqual(expect.arrayContaining(["--resume", "latest"]));
+		expect(geminiLaunch.args).toContain("--continue");
 
 		const opencodeLaunch = await prepareAgentLaunch({
 			taskId: "task-opencode",
@@ -664,13 +702,13 @@ describe("prepareAgentLaunch hook strategies", () => {
 		const geminiLaunch = await prepareAgentLaunch({
 			taskId: "task-gemini-auto",
 			agentId: "gemini",
-			binary: "gemini",
+			binary: "agy",
 			args: [],
 			autonomousModeEnabled: true,
 			cwd: "/tmp",
 			prompt: "",
 		});
-		expect(geminiLaunch.args).toContain("--yolo");
+		expect(geminiLaunch.args).toContain("--dangerously-skip-permissions");
 
 		const kiroLaunch = await prepareAgentLaunch({
 			taskId: "task-kiro-auto",
@@ -723,13 +761,13 @@ describe("prepareAgentLaunch hook strategies", () => {
 		const geminiLaunch = await prepareAgentLaunch({
 			taskId: "task-gemini-no-auto",
 			agentId: "gemini",
-			binary: "gemini",
-			args: ["--yolo"],
+			binary: "agy",
+			args: ["--dangerously-skip-permissions"],
 			autonomousModeEnabled: false,
 			cwd: "/tmp",
 			prompt: "",
 		});
-		expect(geminiLaunch.args).toContain("--yolo");
+		expect(geminiLaunch.args).toContain("--dangerously-skip-permissions");
 
 		const clineLaunch = await prepareAgentLaunch({
 			taskId: "task-cline-no-auto",

--- a/web-ui/src/components/runtime-settings-dialog.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.tsx
@@ -92,7 +92,15 @@ const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string }>
 
 export type RuntimeSettingsSection = "shortcuts";
 
-const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = [
+	"cline",
+	"claude",
+	"codex",
+	"opencode",
+	"droid",
+	"kiro",
+	"gemini",
+];
 
 type SettingsNavId = "general" | "cline" | "git-prompts" | "notifications" | "appearance" | "project";
 

--- a/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
+++ b/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
@@ -307,11 +307,17 @@ function resolveInstallInstructions(agentId: RuntimeAgentId): string {
 	if (agentId === "codex") {
 		return "OpenAI's coding agent CLI with access to the latest GPT models.";
 	}
+	if (agentId === "opencode") {
+		return "OpenCode's provider-agnostic coding agent CLI for terminal-based task sessions.";
+	}
 	if (agentId === "droid") {
 		return "Factory's coding agent with access to the latest frontier models.";
 	}
 	if (agentId === "kiro") {
 		return "Amazon's coding agent with access to the latest frontier models.";
+	}
+	if (agentId === "gemini") {
+		return "Google Antigravity's coding agent CLI, launched from Kanban with agy.";
 	}
 	return "Install from the official docs.";
 }

--- a/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
+++ b/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
@@ -83,7 +83,15 @@ export const TASK_START_ONBOARDING_SLIDES: OnboardingSlide[] = [
 	},
 ];
 
-const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = [
+	"cline",
+	"claude",
+	"codex",
+	"opencode",
+	"droid",
+	"kiro",
+	"gemini",
+];
 const FALLBACK_ONBOARDING_SLIDE: OnboardingSlide = {
 	kind: "agent-selection",
 	title: "",

--- a/web-ui/src/runtime/native-agent.test.ts
+++ b/web-ui/src/runtime/native-agent.test.ts
@@ -223,12 +223,12 @@ describe("native-agent helpers", () => {
 		).toBe(true);
 	});
 
-	it("ignores non-launch agents when checking native CLI availability", () => {
+	it("accepts newly launch-supported native CLI agents when available", () => {
 		const config = createRuntimeConfigResponse("claude");
 		config.agents = [
 			{
 				id: "gemini",
-				label: "Gemini CLI",
+				label: "Antigravity / Gemini CLI",
 				binary: "gemini",
 				command: "gemini",
 				defaultArgs: [],
@@ -236,7 +236,7 @@ describe("native-agent helpers", () => {
 				configured: false,
 			},
 		];
-		expect(isTaskAgentSetupSatisfied(config)).toBe(false);
+		expect(isTaskAgentSetupSatisfied(config)).toBe(true);
 	});
 
 	it("selects the latest incoming chat message only for the matching task", () => {

--- a/web-ui/src/runtime/native-agent.test.ts
+++ b/web-ui/src/runtime/native-agent.test.ts
@@ -228,9 +228,9 @@ describe("native-agent helpers", () => {
 		config.agents = [
 			{
 				id: "gemini",
-				label: "Antigravity / Gemini CLI",
-				binary: "gemini",
-				command: "gemini",
+				label: "Antigravity CLI",
+				binary: "agy",
+				command: "agy",
 				defaultArgs: [],
 				installed: true,
 				configured: false,


### PR DESCRIPTION
Summary
Enable the existing OpenCode and Gemini CLI launch paths in my fork so I can test them directly.

Changes
- Enable OpenCode and Gemini in the launch-supported agent catalog.
- Include OpenCode and Gemini in runtime auto-selection.
- Show OpenCode and Gemini in settings and onboarding agent lists.
- Update registry, config, and native-agent tests for the newly launch-supported agents.

Verification
- npm run lint
- npm run typecheck
- npm --prefix web-ui run typecheck
- npm test
- npm --prefix web-ui test
- npm run build
- Manual QA: node dist/cli.js --help
- Manual QA: node dist/cli.js task --help
- Manual QA: node dist/cli.js task start --help
- Manual QA: node --import tsx runtime driver confirmed selectedAgentId=opencode, effectiveCommand=opencode, and both opencode/gemini installed=true on PATH

Usage
This is mainly for testing OpenCode and Gemini CLI from my fork branch: happycastle114:feat/enable-opencode-gemini-agents.