### PR TITLE
fix: ECOMPROMISED lockfile crash under disk I/O pressure

### DIFF
--- a/src/fs/locked-file-system.ts
+++ b/src/fs/locked-file-system.ts
@@ -50,10 +50,10 @@ function createLockOptions(request: LockRequest, lockfilePath: string): LockOpti
 		retries: request.retries ?? DEFAULT_LOCK_RETRIES,
 		realpath: false,
 		lockfilePath,
+		// Don't crash on ECOMPROMISED — the lock is silently released instead.
+		// This prevents process crashes under disk I/O pressure.
+		onCompromised: request.onCompromised ?? (() => {}),
 	};
-	if (typeof request.onCompromised === "function") {
-		options.onCompromised = request.onCompromised;
-	}
 	return options;
 }
 
@@ -108,7 +108,11 @@ export class LockedFileSystem {
 			return await operation();
 		} finally {
 			for (const release of releases.reverse()) {
-				await release();
+				try {
+					await release();
+				} catch {
+					/* lock already released (e.g. ECOMPROMISED) */
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The default `onCompromised` handler in proper-lockfile throws, crashing the process. Under heavy disk I/O (large git diffs, system updates), lockfiles can be compromised, causing kanban to crash every ~15 minutes.

This makes `onCompromised` a silent no-op instead, and catches lock release errors in the `withLocks` finally block.