### PR TITLE
fix: --no-passcode commander option not working

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,7 @@ interface RootCommandOptions {
 	https?: boolean;
 	cert?: string;
 	key?: string;
-	noPasscode?: boolean;
+	passcode?: boolean;
 }
 
 type ShutdownIndicatorResult = "done" | "interrupted" | "failed";
@@ -727,7 +727,7 @@ function createProgram(invocationArgs: string[]): Command {
 				https: options.https === true,
 				cert: options.cert ?? null,
 				key: options.key ?? null,
-				noPasscode: options.noPasscode === true,
+				noPasscode: options.passcode === false,
 			},
 			shouldAutoOpenBrowser,
 		);


### PR DESCRIPTION
The --no-passcode flag was ignored because Commander creates options.passcode (negated from --no-passcode) but the code checked options.noPasscode which is never set.