### PR TITLE
fix: session recovery and incomplete tool turn handling after restart

### DIFF
--- a/src/cline-sdk/cline-session-runtime.ts
+++ b/src/cline-sdk/cline-session-runtime.ts
@@ -116,7 +116,7 @@ export interface ClineSessionRuntime {
 	clearTaskSessions(taskId: string): Promise<void>;
 	getTaskSessionId(taskId: string): string | null;
 	getTaskProviderId(taskId: string): string | null;
-	canRestartTaskSession(taskId: string): boolean;
+	canRestartTaskSession(_taskId: string): boolean;
 	readPersistedTaskSession(taskId: string): Promise<ClinePersistedTaskSessionSnapshot | null>;
 	dispose(): Promise<void>;
 }
@@ -288,7 +288,30 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 	}): Promise<StartClineSessionRuntimeResult> {
 		const lastStartRequest = this.lastStartRequestByTaskId.get(input.taskId);
 		if (!lastStartRequest) {
-			throw new Error(`No previous Cline session config is available for task ${input.taskId}.`);
+			const persistedSnapshot = await this.readPersistedTaskSession(input.taskId);
+			const record = persistedSnapshot?.record;
+			if (!record) {
+				throw new Error(`No previous Cline session config is available for task ${input.taskId}.`);
+			}
+			const recovered: StartClineSessionRuntimeRequest = {
+				taskId: input.taskId,
+				cwd: record.cwd || record.workspaceRoot,
+				providerId: record.provider,
+				modelId: record.model,
+				mode: input.mode || "act",
+				apiKey: undefined as unknown as string,
+				baseUrl: undefined as unknown as string,
+				reasoningEffort: undefined,
+				systemPrompt: "",
+				taskTitle: undefined as unknown as string,
+				userInstructionService: undefined,
+				requestToolApproval: undefined,
+				prompt: input.prompt,
+				initialMessages: input.initialMessages,
+				images: input.images,
+			};
+			this.lastStartRequestByTaskId.set(input.taskId, recovered);
+			return await this.startTaskSession(recovered);
 		}
 
 		return await this.startTaskSession({
@@ -409,8 +432,9 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 		return this.lastStartRequestByTaskId.get(taskId)?.providerId ?? null;
 	}
 
-	canRestartTaskSession(taskId: string): boolean {
-		return this.lastStartRequestByTaskId.has(taskId);
+	canRestartTaskSession(_taskId: string): boolean {
+		// Allow restart even without in-memory config — restartTaskSession will recover from persisted data
+		return true;
 	}
 
 	async readPersistedTaskSession(taskId: string): Promise<ClinePersistedTaskSessionSnapshot | null> {

--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -159,6 +159,33 @@ function buildClineStartPrompt(prompt: string, startInPlanMode?: boolean): strin
 		trimmedPrompt ? `\n\nTask:\n${trimmedPrompt}` : " Ask the user what they want planned if the task is unclear.",
 	].join(" ");
 }
+
+function stripIncompleteToolTurns(messages: any[]): any[] {
+	// Collect tool_use IDs and tool_result IDs across ALL messages
+	const resultIds = new Set<string>();
+	let lastIncompleteIdx = -1;
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i] as Record<string, unknown>;
+		const content = msg.content as Array<Record<string, unknown>> | undefined;
+		if (!content) continue;
+		for (const block of content) {
+			if (block.type === "tool_result" && typeof block.tool_use_id === "string") {
+				resultIds.add(block.tool_use_id);
+			}
+		}
+		if (msg.role === "assistant") {
+			let hasUnresolvedCalls = false;
+			for (const block of content) {
+				if (block.type === "tool_use" && typeof block.id === "string") {
+					if (!resultIds.has(block.id)) hasUnresolvedCalls = true;
+				}
+			}
+			if (hasUnresolvedCalls) lastIncompleteIdx = i;
+		}
+	}
+	if (lastIncompleteIdx === -1) return messages;
+	return messages.slice(0, lastIncompleteIdx);
+}
 export class InMemoryClineTaskSessionService implements ClineTaskSessionService {
 	private readonly pendingTurnCancelTaskIds = new Set<string>();
 	private readonly providerIdByTaskId = new Map<string, string>();
@@ -278,7 +305,7 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			prompt: input.prompt,
 			mode: input.mode,
 			images: input.images,
-			initialMessages: persistedSnapshot?.messages,
+			initialMessages: stripIncompleteToolTurns(persistedSnapshot?.messages ?? []),
 		});
 		return {
 			result: restartedSession.result,
@@ -309,7 +336,7 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			prompt: input.prompt,
 			mode: input.mode,
 			images: input.images,
-			initialMessages: compactedMessages,
+			initialMessages: stripIncompleteToolTurns(compactedMessages),
 		});
 		return {
 			result: restartedSession.result,
@@ -420,7 +447,9 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 					cwd: request.cwd,
 					prompt: runtimePrompt,
 					taskTitle: request.taskTitle,
-					initialMessages: persistedResumeSnapshot?.messages ?? request.initialMessages,
+					initialMessages: stripIncompleteToolTurns(
+						persistedResumeSnapshot?.messages ?? request.initialMessages ?? [],
+					),
 					images: request.images,
 					providerId,
 					modelId,


### PR DESCRIPTION
After kanban crashes and restarts, tasks can't be resumed because:

1. restartTaskSession throws 'No previous Cline session config' — the in-memory config map is empty
2. sendTaskSessionInput returns null — the in-memory entry map is empty
3. Continuing from persisted history fails with 'Tool result is missing' — the crash happened mid-tool-call

This patch:
- Recovers session config from persisted Cline SDK sessions
- Rebinds missing entries from persisted disk data
- Filters incomplete tool_use/tool_result pairs from history before resuming