### PR TITLE
fix(web-ui): keep failed agent runs in review instead of auto-completing them

### DIFF
--- a/web-ui/src/components/board-card.test.tsx
+++ b/web-ui/src/components/board-card.test.tsx
@@ -695,6 +695,92 @@ describe("BoardCard", () => {
 		expect(container.textContent).not.toContain("Thinking...");
 	});
 
+	it("shows a red failure indicator for a review card whose session ended in an error", async () => {
+		await act(async () => {
+			root.render(
+				<BoardCard
+					card={createCard()}
+					index={0}
+					columnId="review"
+					sessionSummary={createSummary("awaiting_review", {
+						reviewReason: "error",
+						warningMessage: "Unknown agent error",
+						latestHookActivity: {
+							activityText: "Agent error: boom",
+							toolName: null,
+							toolInputSummary: null,
+							finalMessage: "boom",
+							hookEventName: "agent_error",
+							notificationType: null,
+							source: "cline-sdk",
+						},
+					})}
+				/>,
+			);
+		});
+
+		const dot = container.querySelector(".rounded-full") as HTMLElement | null;
+		expect(dot).not.toBeNull();
+		expect(dot?.style.backgroundColor).toBe("var(--color-status-red)");
+		expect(container.textContent).toContain("boom");
+	});
+
+	it("shows a red failure indicator when a failed session carries a final assistant message", async () => {
+		await act(async () => {
+			root.render(
+				<BoardCard
+					card={createCard()}
+					index={0}
+					columnId="in_progress"
+					sessionSummary={createSummary("failed", {
+						latestHookActivity: {
+							activityText: null,
+							toolName: null,
+							toolInputSummary: null,
+							finalMessage: "Provider connection lost",
+							hookEventName: "agent_end",
+							notificationType: null,
+							source: "cline-sdk",
+						},
+					})}
+				/>,
+			);
+		});
+
+		const dot = container.querySelector(".rounded-full") as HTMLElement | null;
+		expect(dot).not.toBeNull();
+		expect(dot?.style.backgroundColor).toBe("var(--color-status-red)");
+		expect(container.textContent).toContain("Provider connection lost");
+	});
+
+	it("keeps the green success indicator for a clean review card", async () => {
+		await act(async () => {
+			root.render(
+				<BoardCard
+					card={createCard()}
+					index={0}
+					columnId="review"
+					sessionSummary={createSummary("awaiting_review", {
+						latestHookActivity: {
+							activityText: null,
+							toolName: null,
+							toolInputSummary: null,
+							finalMessage: "Ready for review",
+							hookEventName: "assistant_delta",
+							notificationType: null,
+							source: "cline-sdk",
+						},
+					})}
+				/>,
+			);
+		});
+
+		const dot = container.querySelector(".rounded-full") as HTMLElement | null;
+		expect(dot).not.toBeNull();
+		expect(dot?.style.backgroundColor).toBe("var(--color-status-green)");
+		expect(container.textContent).toContain("Ready for review");
+	});
+
 	it("shows normal agent messages without the agent prefix", async () => {
 		await act(async () => {
 			root.render(

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -154,6 +154,12 @@ function getCardSessionActivity(summary: RuntimeTaskSessionSummary | undefined):
 	const toolInputSummary = hookActivity?.toolInputSummary?.trim() ?? null;
 	const finalMessage = hookActivity?.finalMessage?.trim();
 	const hookEventName = hookActivity?.hookEventName?.trim() ?? null;
+	if ((summary.state === "awaiting_review" && summary.reviewReason === "error") || summary.state === "failed") {
+		return {
+			dotColor: SESSION_ACTIVITY_COLOR.error,
+			text: finalMessage ?? summary.warningMessage?.trim() ?? "Agent failed",
+		};
+	}
 	if (summary.state === "awaiting_review" && finalMessage) {
 		return { dotColor: SESSION_ACTIVITY_COLOR.success, text: finalMessage };
 	}
@@ -168,8 +174,7 @@ function getCardSessionActivity(summary: RuntimeTaskSessionSummary | undefined):
 		};
 	}
 	if (activityText) {
-		let dotColor: string =
-			summary.state === "failed" ? SESSION_ACTIVITY_COLOR.error : SESSION_ACTIVITY_COLOR.thinking;
+		let dotColor: string = SESSION_ACTIVITY_COLOR.thinking;
 		let text = activityText;
 		const toolCallLabel = resolveToolCallLabel(activityText, toolName, toolInputSummary);
 		if (toolCallLabel) {
@@ -196,10 +201,6 @@ function getCardSessionActivity(summary: RuntimeTaskSessionSummary | undefined):
 			return { dotColor: SESSION_ACTIVITY_COLOR.thinking, text: "Thinking..." };
 		}
 		return { dotColor, text };
-	}
-	if (summary.state === "failed") {
-		const failedText = finalMessage ?? activityText ?? "Task failed to start";
-		return { dotColor: SESSION_ACTIVITY_COLOR.error, text: failedText };
 	}
 	if (summary.state === "awaiting_review") {
 		return { dotColor: SESSION_ACTIVITY_COLOR.success, text: "Waiting for review" };

--- a/web-ui/src/hooks/use-board-interactions.ts
+++ b/web-ui/src/hooks/use-board-interactions.ts
@@ -525,6 +525,7 @@ export function useBoardInteractions({
 
 	useReviewAutoActions({
 		board,
+		sessions,
 		taskGitActionLoadingByTaskId,
 		runAutoReviewGitAction,
 		requestMoveTaskToTrash: requestMoveTaskToTrashWithAnimation,

--- a/web-ui/src/hooks/use-review-auto-actions.test.tsx
+++ b/web-ui/src/hooks/use-review-auto-actions.test.tsx
@@ -3,6 +3,11 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
 import { useReviewAutoActions } from "@/hooks/use-review-auto-actions";
+import type {
+	RuntimeTaskSessionReviewReason,
+	RuntimeTaskSessionState,
+	RuntimeTaskSessionSummary,
+} from "@/runtime/types";
 import { resetWorkspaceMetadataStore, setTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 import type { BoardColumnId, BoardData, ReviewTaskWorkspaceSnapshot } from "@/types";
 
@@ -47,18 +52,41 @@ const workspaceSnapshots: Record<string, ReviewTaskWorkspaceSnapshot> = {
 	},
 };
 
+function createSessionSummary(
+	state: RuntimeTaskSessionState,
+	reviewReason: RuntimeTaskSessionReviewReason,
+): RuntimeTaskSessionSummary {
+	return {
+		taskId: "task-1",
+		state,
+		agentId: "cline",
+		workspacePath: "/tmp/task-1",
+		pid: null,
+		startedAt: 1,
+		updatedAt: 1,
+		lastOutputAt: 1,
+		reviewReason,
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+	};
+}
+
 function HookHarness({
 	board,
+	sessions = {},
 	runAutoReviewGitAction,
 	requestMoveTaskToTrash,
 }: {
 	board: BoardData;
+	sessions?: Record<string, RuntimeTaskSessionSummary>;
 	runAutoReviewGitAction: (taskId: string, action: TaskGitAction) => Promise<boolean>;
 	requestMoveTaskToTrash: (taskId: string, fromColumnId: BoardColumnId) => Promise<void>;
 }): null {
 	setTaskWorkspaceSnapshot(workspaceSnapshots["task-1"] ?? null);
 	useReviewAutoActions({
 		board,
+		sessions,
 		taskGitActionLoadingByTaskId: {},
 		runAutoReviewGitAction,
 		requestMoveTaskToTrash,
@@ -126,5 +154,84 @@ describe("useReviewAutoActions", () => {
 
 		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
 		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+	});
+
+	it("does not auto-commit or auto-move a review card whose session failed", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard(true)}
+					sessions={{ "task-1": createSessionSummary("awaiting_review", "error") }}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
+		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+	});
+
+	it("cancels an already scheduled auto action when the session fails before the timer fires", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard(true)}
+					sessions={{ "task-1": createSessionSummary("awaiting_review", "exit") }}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard(true)}
+					sessions={{ "task-1": createSessionSummary("awaiting_review", "error") }}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
+		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+	});
+
+	it("still auto-commits a clean review card when the session ended without error", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard(true)}
+					sessions={{ "task-1": createSessionSummary("awaiting_review", "exit") }}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(runAutoReviewGitAction).toHaveBeenCalledWith("task-1", "commit");
 	});
 });

--- a/web-ui/src/hooks/use-review-auto-actions.ts
+++ b/web-ui/src/hooks/use-review-auto-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
+import type { RuntimeTaskSessionSummary } from "@/runtime/types";
 import { findCardSelection } from "@/state/board-state";
 import { getTaskWorkspaceSnapshot, subscribeToAnyTaskMetadata } from "@/stores/workspace-metadata-store";
 import type { BoardCard, BoardColumnId, BoardData, TaskAutoReviewMode } from "@/types";
@@ -23,6 +24,7 @@ interface RequestMoveTaskToTrashOptions {
 
 interface UseReviewAutoActionsOptions {
 	board: BoardData;
+	sessions: Record<string, RuntimeTaskSessionSummary>;
 	taskGitActionLoadingByTaskId: Record<string, TaskGitActionLoadingStateLike>;
 	runAutoReviewGitAction: (taskId: string, action: TaskGitAction) => Promise<boolean>;
 	requestMoveTaskToTrash: (
@@ -35,12 +37,14 @@ interface UseReviewAutoActionsOptions {
 
 export function useReviewAutoActions({
 	board,
+	sessions,
 	taskGitActionLoadingByTaskId,
 	runAutoReviewGitAction,
 	requestMoveTaskToTrash,
 	resetKey,
 }: UseReviewAutoActionsOptions): void {
 	const boardRef = useRef<BoardData>(board);
+	const sessionsRef = useRef<Record<string, RuntimeTaskSessionSummary>>(sessions);
 	const runAutoReviewGitActionRef = useRef(runAutoReviewGitAction);
 	const requestMoveTaskToTrashRef = useRef(requestMoveTaskToTrash);
 	const awaitingCleanActionByTaskIdRef = useRef<Record<string, TaskGitAction>>({});
@@ -52,6 +56,10 @@ export function useReviewAutoActions({
 	useEffect(() => {
 		boardRef.current = board;
 	}, [board]);
+
+	useEffect(() => {
+		sessionsRef.current = sessions;
+	}, [sessions]);
 
 	useEffect(() => {
 		runAutoReviewGitActionRef.current = runAutoReviewGitAction;
@@ -153,6 +161,13 @@ export function useReviewAutoActions({
 					continue;
 				}
 
+				const session = sessionsRef.current[reviewTask.id];
+				if (session?.reviewReason === "error" || session?.state === "failed") {
+					delete awaitingCleanActionByTaskIdRef.current[reviewTask.id];
+					clearAutoReviewTimer(reviewTask.id);
+					continue;
+				}
+
 				const autoReviewMode = resolveTaskAutoReviewMode(reviewTask.autoReviewMode);
 				const loadingState = taskGitActionLoadingByTaskId[reviewTask.id];
 				const isGitActionInFlight =
@@ -180,6 +195,10 @@ export function useReviewAutoActions({
 								return;
 							}
 							if (!isTaskAutoReviewEnabled(latestSelection.card)) {
+								return;
+							}
+							const latestSession = sessionsRef.current[reviewTask.id];
+							if (latestSession?.reviewReason === "error" || latestSession?.state === "failed") {
 								return;
 							}
 							const latestMode = resolveTaskAutoReviewMode(latestSelection.card.autoReviewMode);
@@ -215,6 +234,10 @@ export function useReviewAutoActions({
 					if (!isTaskAutoReviewEnabled(latestSelection.card)) {
 						return;
 					}
+					const latestSession = sessionsRef.current[reviewTask.id];
+					if (latestSession?.reviewReason === "error" || latestSession?.state === "failed") {
+						return;
+					}
 					const latestMode = resolveTaskAutoReviewMode(latestSelection.card.autoReviewMode);
 					if (latestMode !== autoReviewMode) {
 						return;
@@ -236,6 +259,12 @@ export function useReviewAutoActions({
 			source: "board_or_loading_change",
 		});
 	}, [board, evaluateAutoReview, taskGitActionLoadingByTaskId]);
+
+	useEffect(() => {
+		evaluateAutoReview({
+			source: "sessions_change",
+		});
+	}, [evaluateAutoReview, sessions]);
 
 	useEffect(() => {
 		return subscribeToAnyTaskMetadata((taskId) => {


### PR DESCRIPTION
Fixes #524

### Problem

When an agent run fails mid-task (LLM/provider error), the session lands in the Review column with `reviewReason: "error"` — but the auto-review automation never looks at that signal. If the failed run left partial changes on disk, `useReviewAutoActions` auto-commits them and auto-moves the card to Done. The card face shows a green "success" dot with the error text. As reported in #524: you return in the morning to a Done card that is actually broken, with no visual trace it failed.

### Root cause

`useReviewAutoActions` receives only `board` (which carries no session state) and keys its decisions solely on `autoReviewEnabled` + `changedFiles`. `RuntimeTaskSessionSummary.reviewReason` already reaches the web-ui (`sessions` state in `App.tsx`, threaded to `BoardCard` as `sessionSummary`), and is even in scope at the hook's call site in `use-board-interactions.ts` — it just was never passed in. Similarly, `getCardSessionActivity` in `board-card.tsx` branches on `state === "awaiting_review"` without checking `reviewReason`, so failed runs get the green success dot.

### Change

- Thread `sessions` into `useReviewAutoActions` (ref pattern, same as the existing `boardRef`), and re-run `evaluateAutoReview` when `sessions` changes — so a failure arriving over the state stream is acted on immediately, not only on the next board change.
- In `evaluateAutoReview`, skip ALL auto actions (arming, auto-commit/PR, move-to-done) for a card whose session has `reviewReason: "error"` or `state: "failed"` — mirroring the existing disabled-path cleanup. The same failure gate is re-checked *inside both delayed callbacks* at timer-fire time (next to the existing column/enabled/mode re-checks), closing the race where a session flips to error after an action was scheduled but before its timer fires. Cards with `reviewReason` of `exit`/`attention`/`hook`/`null` (incl. manually dragged cards with no session) behave exactly as before.
- In `getCardSessionActivity`, failure now dominates success-style final messages: `awaiting_review` + `reviewReason: "error"` and `state: "failed"` render a red error dot with the failure message (falls back to `warningMessage`, then a static label for PTY exits with no hook activity), keeping the credit-limit branch's precedence. The previously unreachable late `failed` branches are removed (the compiler flags them as dead after the new early branch).

No server-side or contract changes — the signal already flows to the client.

### Tests

- `use-review-auto-actions.test.tsx`: bug repro (error session + changed files → no git action, no auto-done); happy-path guard (clean `exit` review still auto-commits/auto-dones); race guard (session fails after the action is scheduled, before timers advance → nothing fires).
- `board-card.test.tsx`: error dot + message for failed reviews (incl. `state: "failed"` carrying a success-style final assistant message); green dot unchanged for clean reviews.
- `npm run check`, `npm --prefix web-ui run test` (70 files / 503 tests), `npm run build` all green locally (Node 22).

### Prior art

A similar fix was made independently in a fork (VictorGambarini/ai-kanban#28) but never upstreamed; this implementation was written from the root cause against current `main` and additionally covers the PTY exit path (no hook activity) via the `warningMessage` fallback.
