### PR TITLE
Run multiple isolated boards in parallel (CLINE_HOME)

### DIFF
--- a/src/cline-sdk/cline-mcp-settings-service.ts
+++ b/src/cline-sdk/cline-mcp-settings-service.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { z } from "zod";
-
+import { clineHomeDir } from "../config/cline-home";
 import type { RuntimeClineMcpServer, RuntimeClineMcpSettingsResponse } from "../core/api-contract";
 import { lockedFileSystem } from "../fs/locked-file-system";
 
@@ -95,7 +94,7 @@ export function resolveMcpSettingsPath(): string {
 	if (configuredPath) {
 		return resolve(configuredPath);
 	}
-	return join(homedir(), ".cline", "data", "settings", "cline_mcp_settings.json");
+	return join(clineHomeDir(), "data", "settings", "cline_mcp_settings.json");
 }
 
 function parseSettingsFile(filePath: string): RuntimeClineMcpServer[] {

--- a/src/config/cline-home.ts
+++ b/src/config/cline-home.ts
@@ -1,0 +1,17 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Base directory for all Kanban-owned runtime state — board/workspaces, task
+ * worktrees, and settings/data. Defaults to `~/.cline` (upstream/standalone).
+ *
+ * Set the `CLINE_HOME` environment variable to relocate everything under one
+ * directory so multiple Kanban instances run fully isolated (each with its own
+ * board, worktrees, and settings). `fleet` points this at a project-local
+ * `<project>/.fleet/cline`, keeping all runtime state with the project — like
+ * `.git` — and out of the home directory.
+ */
+export function clineHomeDir(): string {
+	const override = process.env.CLINE_HOME?.trim();
+	return override ? resolve(override) : join(homedir(), ".cline");
+}

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -8,6 +8,7 @@ import { getRuntimeAgentCatalogEntry, isRuntimeAgentLaunchSupported } from "../c
 import type { RuntimeAgentId, RuntimeProjectShortcut } from "../core/api-contract";
 import { type LockRequest, lockedFileSystem } from "../fs/locked-file-system";
 import { detectInstalledCommands } from "../terminal/agent-registry";
+import { clineHomeDir } from "./cline-home";
 import { areRuntimeProjectShortcutsEqual } from "./shortcut-utils";
 
 interface RuntimeGlobalConfigFileShape {
@@ -47,7 +48,6 @@ export interface RuntimeConfigUpdateInput {
 	openPrPromptTemplate?: string;
 }
 
-const RUNTIME_HOME_PARENT_DIR = ".cline";
 const RUNTIME_HOME_DIR = "kanban";
 const CONFIG_FILENAME = "config.json";
 const PROJECT_CONFIG_PARENT_DIR = ".cline";
@@ -113,7 +113,7 @@ export function pickBestInstalledAgentIdFromDetected(detectedCommands: readonly 
 }
 
 function getRuntimeHomePath(): string {
-	return join(homedir(), RUNTIME_HOME_PARENT_DIR, RUNTIME_HOME_DIR);
+	return join(clineHomeDir(), RUNTIME_HOME_DIR);
 }
 
 function normalizeAgentId(agentId: RuntimeAgentId | string | null | undefined): RuntimeAgentId {

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -302,6 +302,10 @@ export type RuntimeTaskSessionSummary = z.infer<typeof runtimeTaskSessionSummary
 export const runtimeWorkspaceStateResponseSchema = z.object({
 	repoPath: z.string(),
 	statePath: z.string(),
+	// Absolute root under which this instance's task worktrees live. Follows
+	// CLINE_HOME, so the client can display real worktree paths instead of
+	// reconstructing a hardcoded ~/.cline/worktrees.
+	taskWorktreesRoot: z.string(),
 	git: runtimeGitRepositoryInfoSchema,
 	board: runtimeBoardDataSchema,
 	sessions: z.record(z.string(), runtimeTaskSessionSummarySchema),

--- a/src/state/workspace-state.ts
+++ b/src/state/workspace-state.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { readFile, realpath, rm } from "node:fs/promises";
-import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { z } from "zod";
+import { clineHomeDir } from "../config/cline-home";
 
 import {
 	type RuntimeBoardColumnId,
@@ -20,7 +20,6 @@ import { createGitProcessEnv } from "../core/git-process-env";
 import { updateTaskDependencies } from "../core/task-board-mutations";
 import { type LockRequest, lockedFileSystem } from "../fs/locked-file-system";
 
-const RUNTIME_HOME_PARENT_DIR = ".cline";
 const RUNTIME_HOME_DIR = "kanban";
 const RUNTIME_WORKTREES_DIR = "worktrees";
 const WORKSPACES_DIR = "workspaces";
@@ -159,11 +158,11 @@ function createEmptyWorkspaceIndex(): WorkspaceIndexFile {
 }
 
 export function getRuntimeHomePath(): string {
-	return join(homedir(), RUNTIME_HOME_PARENT_DIR, RUNTIME_HOME_DIR);
+	return join(clineHomeDir(), RUNTIME_HOME_DIR);
 }
 
 export function getTaskWorktreesHomePath(): string {
-	return join(homedir(), RUNTIME_HOME_PARENT_DIR, RUNTIME_WORKTREES_DIR);
+	return join(clineHomeDir(), RUNTIME_WORKTREES_DIR);
 }
 
 export function getWorkspacesRootPath(): string {
@@ -531,6 +530,7 @@ function toWorkspaceStateResponse(
 	return {
 		repoPath: context.repoPath,
 		statePath: context.statePath,
+		taskWorktreesRoot: getTaskWorktreesHomePath(),
 		git: context.git,
 		board,
 		sessions,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -4,7 +4,6 @@
 // should stay in focused services instead of accumulating here.
 
 import { rm } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { TRPCError } from "@trpc/server";
 import { createClineMcpRuntimeService } from "../cline-sdk/cline-mcp-runtime-service";
@@ -12,6 +11,7 @@ import { createClineMcpSettingsService } from "../cline-sdk/cline-mcp-settings-s
 import { createClineProviderService } from "../cline-sdk/cline-provider-service";
 import { isClineClearSlashCommand } from "../cline-sdk/cline-slash-commands";
 import type { ClineTaskSessionService } from "../cline-sdk/cline-task-session-service";
+import { clineHomeDir } from "../config/cline-home";
 import type { RuntimeConfigState } from "../config/runtime-config";
 import { updateGlobalRuntimeConfig, updateRuntimeConfig } from "../config/runtime-config";
 import type {
@@ -100,9 +100,9 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		},
 	});
 	const debugResetTargetPaths = [
-		join(homedir(), ".cline", "data"),
-		join(homedir(), ".cline", "kanban"),
-		join(homedir(), ".cline", "worktrees"),
+		join(clineHomeDir(), "data"),
+		join(clineHomeDir(), "kanban"),
+		join(clineHomeDir(), "worktrees"),
 	] as const;
 
 	const buildConfigResponse = (runtimeConfig: RuntimeConfigState) =>

--- a/src/workspace/task-worktree-path.ts
+++ b/src/workspace/task-worktree-path.ts
@@ -30,8 +30,11 @@ export function getWorkspaceFolderLabelForWorktreePath(repoPath: string): string
 	return cleaned || "workspace";
 }
 
-export function buildTaskWorktreeDisplayPath(taskId: string, repoPath: string): string {
+export function buildTaskWorktreeDisplayPath(taskId: string, repoPath: string, worktreesRoot?: string | null): string {
 	const normalizedTaskId = normalizeTaskIdForWorktreePath(taskId);
 	const workspaceLabel = getWorkspaceFolderLabelForWorktreePath(repoPath);
-	return `${KANBAN_TASK_WORKTREES_DISPLAY_ROOT}/${normalizedTaskId}/${workspaceLabel}`;
+	// When the caller knows the real worktrees root (it follows CLINE_HOME), build
+	// an absolute path from it; otherwise fall back to the legacy ~/.cline display.
+	const root = worktreesRoot?.trim() ? worktreesRoot.replace(/[\\/]+$/g, "") : KANBAN_TASK_WORKTREES_DISPLAY_ROOT;
+	return `${root}/${normalizedTaskId}/${workspaceLabel}`;
 }

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -216,6 +216,7 @@ export default function App(): ReactElement {
 		isWorkspaceMetadataPending,
 		refreshWorkspaceState,
 		resetWorkspaceSyncState,
+		taskWorktreesRoot,
 	} = useWorkspaceSync({
 		currentProjectId,
 		streamedWorkspaceState,
@@ -935,6 +936,7 @@ export default function App(): ReactElement {
 												data={board}
 												taskSessions={sessions}
 												workspacePath={workspacePath}
+												taskWorktreesRoot={taskWorktreesRoot}
 												onCardSelect={handleCardSelect}
 												onCreateTask={handleOpenCreateTask}
 												onStartTask={handleStartTaskFromBoard}

--- a/web-ui/src/components/board-card.tsx
+++ b/web-ui/src/components/board-card.tsx
@@ -51,12 +51,18 @@ const DESCRIPTION_COLLAPSE_LABEL = "Less";
 const DESCRIPTION_COLLAPSE_SUFFIX = `… ${DESCRIPTION_EXPAND_LABEL}`;
 const DESCRIPTION_EXPANDED_SUFFIX = `… ${DESCRIPTION_COLLAPSE_LABEL}`;
 
-function reconstructTaskWorktreeDisplayPath(taskId: string, workspacePath: string | null | undefined): string | null {
+function reconstructTaskWorktreeDisplayPath(
+	taskId: string,
+	workspacePath: string | null | undefined,
+	worktreesRoot: string | null | undefined,
+): string | null {
 	if (!workspacePath) {
 		return null;
 	}
 	try {
-		return buildTaskWorktreeDisplayPath(taskId, workspacePath);
+		const path = buildTaskWorktreeDisplayPath(taskId, workspacePath, worktreesRoot ?? undefined);
+		// With a real root the path is absolute; abbreviate the home prefix for display.
+		return worktreesRoot ? formatPathForDisplay(path) : path;
 	} catch {
 		return null;
 	}
@@ -233,6 +239,7 @@ export function BoardCard({
 	isDependencyTarget = false,
 	isDependencyLinking = false,
 	workspacePath,
+	taskWorktreesRoot,
 	defaultClineModelId = null,
 }: {
 	card: BoardCardModel;
@@ -257,6 +264,7 @@ export function BoardCard({
 	isDependencyTarget?: boolean;
 	isDependencyLinking?: boolean;
 	workspacePath?: string | null;
+	taskWorktreesRoot?: string | null;
 	defaultClineModelId?: string | null;
 }): React.ReactElement {
 	const [isHovered, setIsHovered] = useState(false);
@@ -414,7 +422,7 @@ export function BoardCard({
 	const reviewWorkspacePath = reviewWorkspaceSnapshot
 		? formatPathForDisplay(reviewWorkspaceSnapshot.path)
 		: isTrashCard
-			? reconstructTaskWorktreeDisplayPath(card.id, workspacePath)
+			? reconstructTaskWorktreeDisplayPath(card.id, workspacePath, taskWorktreesRoot)
 			: null;
 	const reviewRefLabel = reviewWorkspaceSnapshot?.branch ?? reviewWorkspaceSnapshot?.headCommit?.slice(0, 8) ?? "HEAD";
 	const reviewChangeSummary = reviewWorkspaceSnapshot

--- a/web-ui/src/components/board-column.tsx
+++ b/web-ui/src/components/board-column.tsx
@@ -38,6 +38,7 @@ export function BoardColumn({
 	dependencyTargetTaskId,
 	isDependencyLinking,
 	workspacePath,
+	taskWorktreesRoot,
 	defaultClineModelId,
 }: {
 	column: BoardColumnModel;
@@ -68,6 +69,7 @@ export function BoardColumn({
 	dependencyTargetTaskId?: string | null;
 	isDependencyLinking?: boolean;
 	workspacePath?: string | null;
+	taskWorktreesRoot?: string | null;
 	defaultClineModelId?: string | null;
 }): React.ReactElement {
 	const canCreate = column.id === "backlog" && onCreateTask;
@@ -187,6 +189,7 @@ export function BoardColumn({
 											isDependencyTarget={dependencyTargetTaskId === card.id}
 											isDependencyLinking={isDependencyLinking}
 											workspacePath={workspacePath}
+											taskWorktreesRoot={taskWorktreesRoot}
 											defaultClineModelId={defaultClineModelId}
 											onSaveTitle={onSaveTitle}
 											onClick={() => {

--- a/web-ui/src/components/kanban-board.tsx
+++ b/web-ui/src/components/kanban-board.tsx
@@ -53,6 +53,7 @@ export function KanbanBoard({
 	onDragEnd,
 	onRequestProgrammaticCardMoveReady,
 	workspacePath,
+	taskWorktreesRoot,
 	defaultClineModelId,
 }: {
 	data: BoardData;
@@ -80,6 +81,7 @@ export function KanbanBoard({
 	onDragEnd: (result: DropResult) => void;
 	onRequestProgrammaticCardMoveReady?: (requestMove: RequestProgrammaticCardMove | null) => void;
 	workspacePath?: string | null;
+	taskWorktreesRoot?: string | null;
 	defaultClineModelId?: string | null;
 }): React.ReactElement {
 	const dragOccurredRef = useRef(false);
@@ -410,6 +412,7 @@ export function KanbanBoard({
 						dependencyTargetTaskId={dependencyLinking.draft?.targetTaskId ?? null}
 						isDependencyLinking={dependencyLinking.draft !== null}
 						workspacePath={workspacePath}
+						taskWorktreesRoot={taskWorktreesRoot}
 						defaultClineModelId={defaultClineModelId}
 						onCardClick={(card) => {
 							if (!dragOccurredRef.current) {

--- a/web-ui/src/hooks/use-workspace-sync.test.tsx
+++ b/web-ui/src/hooks/use-workspace-sync.test.tsx
@@ -44,6 +44,7 @@ function createWorkspaceState(taskId: string, revision: number): RuntimeWorkspac
 	return {
 		repoPath: "/tmp/project-a",
 		statePath: "/tmp/project-a/.cline/kanban",
+		taskWorktreesRoot: "/tmp/project-a/.cline/worktrees",
 		git: {
 			currentBranch: "main",
 			defaultBranch: "main",

--- a/web-ui/src/hooks/use-workspace-sync.ts
+++ b/web-ui/src/hooks/use-workspace-sync.ts
@@ -26,6 +26,7 @@ interface UseWorkspaceSyncInput {
 
 interface UseWorkspaceSyncResult {
 	workspacePath: string | null;
+	taskWorktreesRoot: string | null;
 	workspaceGit: RuntimeGitRepositoryInfo | null;
 	workspaceRevision: number | null;
 	setWorkspaceRevision: Dispatch<SetStateAction<number | null>>;
@@ -61,6 +62,7 @@ export function useWorkspaceSync({
 	setCanPersistWorkspaceState,
 }: UseWorkspaceSyncInput): UseWorkspaceSyncResult {
 	const [workspacePath, setWorkspacePath] = useState<string | null>(null);
+	const [taskWorktreesRoot, setTaskWorktreesRoot] = useState<string | null>(null);
 	const [workspaceGit, setWorkspaceGit] = useState<RuntimeGitRepositoryInfo | null>(null);
 	const [appliedWorkspaceProjectId, setAppliedWorkspaceProjectId] = useState<string | null>(null);
 	const [workspaceRevision, setWorkspaceRevision] = useState<number | null>(null);
@@ -107,6 +109,7 @@ export function useWorkspaceSync({
 				return;
 			}
 			setWorkspacePath(nextWorkspaceState.repoPath);
+			setTaskWorktreesRoot(nextWorkspaceState.taskWorktreesRoot);
 			setWorkspaceGit(nextWorkspaceState.git);
 			setSessions((currentSessions) => {
 				const incomingSessions = nextWorkspaceState.sessions ?? {};
@@ -194,6 +197,7 @@ export function useWorkspaceSync({
 
 	return {
 		workspacePath,
+		taskWorktreesRoot,
 		workspaceGit,
 		workspaceRevision,
 		setWorkspaceRevision,


### PR DESCRIPTION
Kanban kept all of its state — your boards, task worktrees, and settings — in one shared ~/.cline directory, so running two instances on different ports still meant one shared board that could clash.

You can now set CLINE_HOME to any directory to run a fully isolated instance: its own board, worktrees, and settings, side by side with others (for example, one per project). Leave it unset and Kanban uses ~/.cline exactly as before, so existing setups are unaffected.

Cards now also show the real worktree location (which follows CLINE_HOME) instead of a fixed ~/.cline/worktrees path.