### PR TITLE
Preserve task columns during shutdown

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -614,7 +614,7 @@ async function runMainCommand(options: CliOptions, shouldAutoOpenBrowser: boolea
 		isShuttingDown = true;
 		runPendingAutoUpdateOnShutdown();
 		if (options.skipShutdownCleanup) {
-			console.warn("Skipping shutdown task cleanup for this instance.");
+			console.warn("Skipping shutdown session cleanup for this instance.");
 		}
 		await runtime.shutdown({
 			skipSessionCleanup: options.skipShutdownCleanup,
@@ -682,7 +682,7 @@ function createProgram(invocationArgs: string[]): Command {
 		.option("--host <ip>", "Host IP to bind the server to (default: 127.0.0.1).")
 		.option("--port <number|auto>", "Runtime port (1-65535) or auto.", parseCliPortValue)
 		.option("--no-open", "Do not open browser automatically.")
-		.option("--skip-shutdown-cleanup", "Do not move sessions to done or delete task worktrees on shutdown.")
+		.option("--skip-shutdown-cleanup", "Do not stop or persist task sessions during shutdown.")
 		.option("--https", "Enable HTTPS. Requires both --cert and --key.")
 		.option("--cert <path>", "Path to a TLS certificate PEM file (implies HTTPS).")
 		.option("--key <path>", "Path to a TLS private key PEM file (implies HTTPS).")

--- a/src/server/shutdown-coordinator.ts
+++ b/src/server/shutdown-coordinator.ts
@@ -1,56 +1,13 @@
 import type { RuntimeTaskSessionSummary, RuntimeWorkspaceStateResponse } from "../core/api-contract";
-import { updateTaskDependencies } from "../core/task-board-mutations";
 import { listWorkspaceIndexEntries, loadWorkspaceState, saveWorkspaceState } from "../state/workspace-state";
-import type { TerminalSessionManager } from "../terminal/session-manager";
-import { deleteTaskWorktree, removeTaskWorktreeSetupLock } from "../workspace/task-worktree";
+import { removeTaskWorktreeSetupLock } from "../workspace/task-worktree";
 import type { WorkspaceRegistry } from "./workspace-registry";
-import { collectProjectWorktreeTaskIdsForRemoval } from "./workspace-registry";
 
 export interface RuntimeShutdownCoordinatorDependencies {
 	workspaceRegistry: Pick<WorkspaceRegistry, "listManagedWorkspaces">;
 	warn: (message: string) => void;
 	closeRuntimeServer: () => Promise<void>;
 	skipSessionCleanup?: boolean;
-}
-
-function moveTaskToTrash(
-	board: RuntimeWorkspaceStateResponse["board"],
-	taskId: string,
-): RuntimeWorkspaceStateResponse["board"] {
-	const columns = board.columns.map((column) => ({
-		...column,
-		cards: [...column.cards],
-	}));
-	let removedCard: RuntimeWorkspaceStateResponse["board"]["columns"][number]["cards"][number] | undefined;
-
-	for (const column of columns) {
-		const cardIndex = column.cards.findIndex((candidate) => candidate.id === taskId);
-		if (cardIndex === -1) {
-			continue;
-		}
-		removedCard = column.cards[cardIndex];
-		column.cards.splice(cardIndex, 1);
-		break;
-	}
-
-	if (!removedCard) {
-		return board;
-	}
-	const trashColumnIndex = columns.findIndex((column) => column.id === "trash");
-	if (trashColumnIndex === -1) {
-		return board;
-	}
-	const trashColumn = columns[trashColumnIndex];
-	if (!trashColumn.cards.some((candidate) => candidate.id === taskId)) {
-		trashColumn.cards.unshift({
-			...removedCard,
-			updatedAt: Date.now(),
-		});
-	}
-	return updateTaskDependencies({
-		...board,
-		columns,
-	});
 }
 
 async function persistInterruptedSessions(
@@ -60,23 +17,19 @@ async function persistInterruptedSessions(
 		workspaceState?: RuntimeWorkspaceStateResponse;
 		resolveSummary?: (taskId: string) => RuntimeTaskSessionSummary | null;
 	},
-): Promise<string[]> {
+): Promise<void> {
 	if (interruptedTaskIds.length === 0) {
-		return [];
+		return;
 	}
 	const workspaceState = options?.workspaceState ?? (await loadWorkspaceState(workspacePath));
-	const worktreeTaskIds = collectProjectWorktreeTaskIdsForRemoval(workspaceState.board);
-	const worktreeTaskIdsToCleanup = interruptedTaskIds.filter((taskId) => worktreeTaskIds.has(taskId));
-	let nextBoard = workspaceState.board;
-	for (const taskId of interruptedTaskIds) {
-		nextBoard = moveTaskToTrash(nextBoard, taskId);
-	}
 	const nextSessions = {
 		...workspaceState.sessions,
 	};
+	let updated = false;
 	for (const taskId of interruptedTaskIds) {
 		const summary = options?.resolveSummary?.(taskId) ?? workspaceState.sessions[taskId] ?? null;
 		if (summary) {
+			updated = true;
 			nextSessions[taskId] = {
 				...summary,
 				state: "interrupted",
@@ -86,37 +39,13 @@ async function persistInterruptedSessions(
 			};
 		}
 	}
-	await saveWorkspaceState(workspacePath, {
-		board: nextBoard,
-		sessions: nextSessions,
-	});
-	return worktreeTaskIdsToCleanup;
-}
-
-async function cleanupInterruptedTaskWorktrees(
-	repoPath: string,
-	taskIds: string[],
-	warn: (message: string) => void,
-): Promise<void> {
-	if (taskIds.length === 0) {
+	if (!updated) {
 		return;
 	}
-	const deletions = await Promise.all(
-		taskIds.map(async (taskId) => ({
-			taskId,
-			deleted: await deleteTaskWorktree({
-				repoPath,
-				taskId,
-			}),
-		})),
-	);
-	for (const { taskId, deleted } of deletions) {
-		if (deleted.ok) {
-			continue;
-		}
-		const message = deleted.error ?? `Could not delete task workspace for task "${taskId}" during shutdown.`;
-		warn(message);
-	}
+	await saveWorkspaceState(workspacePath, {
+		board: workspaceState.board,
+		sessions: nextSessions,
+	});
 }
 
 async function cleanupTaskWorktreeSetupLocks(
@@ -135,31 +64,6 @@ async function cleanupTaskWorktreeSetupLocks(
 	);
 }
 
-function shouldInterruptSessionOnShutdown(summary: RuntimeTaskSessionSummary): boolean {
-	if (summary.state === "running") {
-		return true;
-	}
-	return summary.state === "awaiting_review";
-}
-
-function collectShutdownInterruptedTaskIds(
-	interruptedSummaries: RuntimeTaskSessionSummary[],
-	terminalManager: TerminalSessionManager,
-): string[] {
-	const taskIds = new Set(interruptedSummaries.map((summary) => summary.taskId));
-	for (const summary of terminalManager.listSummaries()) {
-		if (!shouldInterruptSessionOnShutdown(summary)) {
-			continue;
-		}
-		taskIds.add(summary.taskId);
-	}
-	return Array.from(taskIds);
-}
-
-function collectWorkColumnTaskIds(workspaceState: RuntimeWorkspaceStateResponse): string[] {
-	return Array.from(collectProjectWorktreeTaskIdsForRemoval(workspaceState.board));
-}
-
 export async function shutdownRuntimeServer(deps: RuntimeShutdownCoordinatorDependencies): Promise<void> {
 	if (deps.skipSessionCleanup) {
 		await deps.closeRuntimeServer();
@@ -176,19 +80,16 @@ export async function shutdownRuntimeServer(deps: RuntimeShutdownCoordinatorDepe
 
 	for (const { workspacePath, terminalManager } of deps.workspaceRegistry.listManagedWorkspaces()) {
 		const interrupted = terminalManager.markInterruptedAndStopAll();
-		const interruptedTaskIds = new Set(collectShutdownInterruptedTaskIds(interrupted, terminalManager));
+		const interruptedTaskIds = interrupted.map((summary) => summary.taskId);
 		if (!workspacePath) {
 			continue;
 		}
 		managedWorkspacePaths.add(workspacePath);
 		try {
 			const workspaceState = await loadWorkspaceState(workspacePath);
-			for (const taskId of collectWorkColumnTaskIds(workspaceState)) {
-				interruptedTaskIds.add(taskId);
-			}
 			interruptedByWorkspace.push({
 				workspacePath,
-				interruptedTaskIds: Array.from(interruptedTaskIds),
+				interruptedTaskIds,
 				workspaceState,
 				resolveSummary: (taskId) => terminalManager.getSummary(taskId),
 			});
@@ -199,38 +100,13 @@ export async function shutdownRuntimeServer(deps: RuntimeShutdownCoordinatorDepe
 	}
 
 	const indexedWorkspaces = await listWorkspaceIndexEntries();
-	for (const workspace of indexedWorkspaces) {
-		if (managedWorkspacePaths.has(workspace.repoPath)) {
-			continue;
-		}
-		try {
-			const workspaceState = await loadWorkspaceState(workspace.repoPath);
-			const interruptedTaskIds = collectWorkColumnTaskIds(workspaceState);
-			if (interruptedTaskIds.length === 0) {
-				continue;
-			}
-			interruptedByWorkspace.push({
-				workspacePath: workspace.repoPath,
-				interruptedTaskIds,
-				workspaceState,
-			});
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			deps.warn(`Could not load workspace state for ${workspace.repoPath} during shutdown cleanup. ${message}`);
-		}
-	}
 
 	await Promise.all(
 		interruptedByWorkspace.map(async (workspace) => {
-			const worktreeTaskIds = await persistInterruptedSessions(
-				workspace.workspacePath,
-				workspace.interruptedTaskIds,
-				{
-					workspaceState: workspace.workspaceState,
-					resolveSummary: workspace.resolveSummary,
-				},
-			);
-			await cleanupInterruptedTaskWorktrees(workspace.workspacePath, worktreeTaskIds, deps.warn);
+			await persistInterruptedSessions(workspace.workspacePath, workspace.interruptedTaskIds, {
+				workspaceState: workspace.workspaceState,
+				resolveSummary: workspace.resolveSummary,
+			});
 		}),
 	);
 

--- a/test/integration/runtime-state-stream.integration.test.ts
+++ b/test/integration/runtime-state-stream.integration.test.ts
@@ -1133,7 +1133,7 @@ describe.sequential("runtime state stream integration", () => {
 		}
 	}, 45_000);
 
-	it("moves stale completed review cards to trash on shutdown", async () => {
+	it("preserves stale completed review cards and their worktrees on shutdown", async () => {
 		const { path: tempHome, cleanup: cleanupHome } = createTempDir("kanban-home-stale-exit-review-");
 		const { path: projectPath, cleanup: cleanupProject } = createTempDir("kanban-project-stale-exit-review-");
 
@@ -1229,10 +1229,10 @@ describe.sequential("runtime state stream integration", () => {
 
 			const reviewCards = finalState.payload.board.columns.find((column) => column.id === "review")?.cards ?? [];
 			const trashCards = finalState.payload.board.columns.find((column) => column.id === "trash")?.cards ?? [];
-			expect(reviewCards.some((card) => card.id === taskId)).toBe(false);
-			expect(trashCards.some((card) => card.id === taskId)).toBe(true);
-			expect(finalState.payload.sessions[taskId]?.state).toBe("interrupted");
-			expect(finalState.payload.sessions[taskId]?.reviewReason).toBe("interrupted");
+			expect(reviewCards.some((card) => card.id === taskId)).toBe(true);
+			expect(trashCards.some((card) => card.id === taskId)).toBe(false);
+			expect(finalState.payload.sessions[taskId]?.state).toBe("awaiting_review");
+			expect(finalState.payload.sessions[taskId]?.reviewReason).toBe("exit");
 			const workspaceInfo = await requestJson<RuntimeTaskWorkspaceInfoResponse>({
 				baseUrl: `http://127.0.0.1:${secondPort}`,
 				procedure: "workspace.getTaskContext",
@@ -1244,7 +1244,7 @@ describe.sequential("runtime state stream integration", () => {
 				},
 			});
 			expect(workspaceInfo.status).toBe(200);
-			expect(workspaceInfo.payload.exists).toBe(false);
+			expect(workspaceInfo.payload.exists).toBe(true);
 		} finally {
 			await secondServer.stop();
 			cleanupProject();

--- a/test/integration/shutdown-coordinator.integration.test.ts
+++ b/test/integration/shutdown-coordinator.integration.test.ts
@@ -95,7 +95,7 @@ function createSession(taskId: string, state: "running" | "awaiting_review" | "i
 }
 
 describe.sequential("shutdown coordinator integration", () => {
-	it("moves all in-progress and review cards to trash for every indexed project on shutdown", async () => {
+	it("stops managed sessions without changing task columns or unrelated indexed workspaces", async () => {
 		await withTemporaryHome(async () => {
 			const { path: sandboxRoot, cleanup } = createTempDir("kanban-shutdown-scope-");
 			try {
@@ -164,20 +164,28 @@ describe.sequential("shutdown coordinator integration", () => {
 				expect(didCloseRuntimeServer).toBe(true);
 
 				const managedAfter = await loadWorkspaceState(managedProjectPath);
+				const managedInProgress =
+					managedAfter.board.columns.find((column) => column.id === "in_progress")?.cards ?? [];
+				const managedReview = managedAfter.board.columns.find((column) => column.id === "review")?.cards ?? [];
 				const managedTrash = managedAfter.board.columns.find((column) => column.id === "trash")?.cards ?? [];
-				expect(managedTrash.map((card) => card.id).sort()).toEqual(
-					["managed-idle", "managed-missing-session", "managed-running"].sort(),
+				expect(managedInProgress.map((card) => card.id).sort()).toEqual(
+					["managed-missing-session", "managed-running"].sort(),
 				);
+				expect(managedReview.map((card) => card.id)).toEqual(["managed-idle"]);
+				expect(managedTrash).toEqual([]);
 				expect(managedAfter.sessions["managed-running"]?.state).toBe("interrupted");
-				expect(managedAfter.sessions["managed-idle"]?.state).toBe("interrupted");
+				expect(managedAfter.sessions["managed-idle"]?.state).toBe("idle");
 				expect(managedAfter.sessions["managed-missing-session"]).toBeUndefined();
 
 				const indexedAfter = await loadWorkspaceState(indexedProjectPath);
+				const indexedInProgress =
+					indexedAfter.board.columns.find((column) => column.id === "in_progress")?.cards ?? [];
+				const indexedReview = indexedAfter.board.columns.find((column) => column.id === "review")?.cards ?? [];
 				const indexedTrash = indexedAfter.board.columns.find((column) => column.id === "trash")?.cards ?? [];
-				expect(indexedTrash.map((card) => card.id).sort()).toEqual(
-					["indexed-awaiting-review", "indexed-missing-session"].sort(),
-				);
-				expect(indexedAfter.sessions["indexed-awaiting-review"]?.state).toBe("interrupted");
+				expect(indexedInProgress.map((card) => card.id)).toEqual(["indexed-missing-session"]);
+				expect(indexedReview.map((card) => card.id)).toEqual(["indexed-awaiting-review"]);
+				expect(indexedTrash).toEqual([]);
+				expect(indexedAfter.sessions["indexed-awaiting-review"]?.state).toBe("awaiting_review");
 				expect(indexedAfter.sessions["indexed-missing-session"]).toBeUndefined();
 			} finally {
 				cleanup();


### PR DESCRIPTION
## Summary

- stop and persist only task sessions that were actually active during shutdown
- preserve task cards in their existing columns instead of moving work to Done
- preserve task worktrees so their lifecycle remains tied to explicit task and project actions
- update the shutdown cleanup flag description to reflect its session-focused behavior

## Testing

- `npm run check`
- 59 test files passed
- 581 tests passed