### PR TITLE
fix(terminal): prevent macOS dictation from duplicating text in the task terminal

### DIFF
--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -205,6 +205,15 @@ class PersistentTerminal {
 			this.sendIoData(bytes);
 		});
 		this.terminal.attachCustomKeyEventHandler((event) => {
+			if (event.key === "Meta") {
+				// Bare Meta is how macOS dictation is stopped, and it arrives while the
+				// dictation composition session is still active. xterm's CompositionHelper
+				// only exempts Shift/Ctrl/Alt from its "real keydown interrupts composition"
+				// rule, so the Meta keydown makes it flush the composed text early and the
+				// following compositionend flushes it again, duplicating dictated text.
+				// A bare Meta press means nothing to the terminal, so swallow it entirely.
+				return false;
+			}
 			if (event.key === "Enter" && event.shiftKey) {
 				if (event.type === "keydown") {
 					this.terminal.input(SHIFT_ENTER_SEQUENCE);


### PR DESCRIPTION
## Summary

Ending macOS dictation with the Command key delivers a bare `Meta` keydown while the dictation composition session is still active (`isComposing: true`). xterm's `CompositionHelper.keydown` treats any keydown outside its Shift/Ctrl/Alt/CapsLock/IME(229) exemption list as a real key interrupting the composition and eagerly flushes the composed text to the PTY; the subsequent `compositionend` then flushes the same text again — so every dictated phrase appeared twice in the terminal.

Captured trace (textarea events + WebSocket sends) showing the double flush:

```
[15918.6] WS-SEND " 嗯，哈喽哈喽"                        ← eager flush
[15918.9] keydown key="Meta" keyCode=93 isComposing=true  ← Cmd pressed to end dictation
[16166.8] compositionend data=" 嗯，哈喽哈喽"
[16167.4] WS-SEND " 嗯，哈喽哈喽"                        ← second flush, identical
```

The fix swallows bare `Meta` presses in `attachCustomKeyEventHandler`, which runs before xterm's composition handling. A lone Meta press has no meaning to a terminal, and combo shortcuts (Cmd+C / Cmd+V) are unaffected because those events arrive keyed by the non-modifier key.

The underlying defect (Meta missing from the modifier exemptions) will also be reported upstream to xtermjs/xterm.js.

fixes #566

## Test plan

- [x] Manually verified on macOS 12 + Chrome against a source build: dictating into the task terminal and ending with Cmd no longer duplicates the phrase; Cmd-based shortcuts still work; CJK IME typing unaffected (its candidate keys arrive as keyCode 229, already exempt)
- [x] `npm run check` passes (pre-commit hook: typecheck + fast tests)
- [ ] No automated test: the behavior lives in the interaction between a real KeyboardEvent stream and xterm's internal CompositionHelper, which the existing test setup does not simulate

🤖 Generated with [Claude Code](https://claude.com/claude-code)