### PR TITLE
fix(terminal): stop routing terminal clipboard writes through OSC 52

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -23,7 +23,6 @@
         "@sentry/react": "^10.45.0",
         "@tailwindcss/vite": "^4.2.1",
         "@trpc/client": "^11.11.0",
-        "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -3362,15 +3361,6 @@
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
       "license": "MIT"
     },
-    "node_modules/@xterm/addon-clipboard": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
-      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
-      "license": "MIT",
-      "dependencies": {
-        "js-base64": "^3.7.5"
-      }
-    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -4253,12 +4243,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
       "version": "2.2.1",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -29,7 +29,6 @@
     "@sentry/react": "^10.45.0",
     "@tailwindcss/vite": "^4.2.1",
     "@trpc/client": "^11.11.0",
-    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -1,4 +1,3 @@
-import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -189,7 +188,13 @@ class PersistentTerminal {
 			rows: initialGeometry.rows,
 		});
 		this.terminal.loadAddon(this.fitAddon);
-		this.terminal.loadAddon(new ClipboardAddon());
+		// Not loading ClipboardAddon intentionally: it relays OSC 52 clipboard-set
+		// requests from whatever CLI is running in the terminal (e.g. Claude Code's
+		// own select-to-copy) into navigator.clipboard.writeText() with no active
+		// user gesture, which corrupts multi-byte CJK text. The addon's own base64
+		// decode is not at fault (verified correct); the Cmd+C handler below calls
+		// the same API but synchronously inside a real keydown event, and is
+		// unaffected. See https://github.com/cline/kanban/issues/574.
 		this.terminal.loadAddon(new WebLinksAddon());
 		this.terminal.loadAddon(this.unicode11Addon);
 		this.terminal.unicode.activeVersion = "11";


### PR DESCRIPTION
## Summary

kanban loads xterm.js's `ClipboardAddon`, which relays OSC 52 clipboard-set escape sequences from whatever CLI is running in the terminal (Claude Code's own select-to-copy) into `navigator.clipboard.writeText()`. That path corrupts multi-byte CJK text on the system clipboard; kanban's own Cmd+C handler, which calls the same API directly from a real keydown event, is unaffected.

fixes #574

## Root cause

Ruled out before landing on this fix:

- Claude Code's OSC 52 payload itself is correct — the same session run directly in iTerm2 (no browser) auto-copies via the same OSC 52 mechanism and pastes correctly.
- `ClipboardAddon`'s own base64/UTF-8 decode is correct (verified with instrumentation + its own round-trip validity check).
- The only thing that differs between the working path (Cmd+C, called synchronously inside a real user gesture) and the broken path (OSC 52 relay, called asynchronously with no active gesture) is that gesture context — both call the identical `navigator.clipboard.writeText()`.

So this isn't patching a bug in kanban's code or in the addon's logic (both check out); it's dropping the one feature that depends on a Chrome behavior around gesture-less clipboard writes that's outside anything this repo controls.

## Test plan

- `npm run check` passes (lint, typecheck, fast tests)
- Manually verified on a real macOS/Chrome setup: copying Chinese text from the task terminal via Cmd+C now pastes correctly (checked via TextEdit, Maccy, and `pbpaste`); auto-copy-on-select (previously relayed via OSC 52) no longer fires, as expected since that behavior only existed through the removed addon
- No automated test added: this depends on real OS clipboard/pasteboard behavior and an actual CLI emitting OSC 52, which isn't practical to simulate in CI