### PR TITLE
fix(cline-sdk): unblock ClinePass cards and model selection

### DIFF
--- a/src/cline-sdk/cline-pass-provider.ts
+++ b/src/cline-sdk/cline-pass-provider.ts
@@ -1,0 +1,52 @@
+// ClinePass (`cline-pass`) identity helpers for the bundled Cline SDK.
+//
+// The bundled `@clinebot/core` provider registry has no `cline-pass` entry, so a
+// card that inherits `cline-pass` from the shared `~/.cline` config fails at
+// model resolution with `Unknown or disabled provider "cline-pass"` before any
+// request is made.
+//
+// ClinePass is not a separate API surface though: it is the same Cline endpoint,
+// the same Cline account OAuth token, and the same OpenAI-compatible protocol as
+// the usage-billing `cline` provider. Only the model namespace differs — the
+// Cline API bills a request against the subscription when the model id is
+// `cline-pass/*`.
+//
+// So Kanban keeps `cline-pass` as its own selectable provider (own catalog
+// entry, own model list, own saved settings) and hands the bundled SDK the
+// `cline` provider id when it starts a session, leaving the `cline-pass/*` model
+// id untouched. Once the bundled SDK registers `cline-pass` itself, its own
+// definition takes over and these helpers stop contributing anything.
+
+export const CLINE_PROVIDER_ID = "cline";
+export const CLINE_PASS_PROVIDER_ID = "cline-pass";
+export const CLINE_PASS_PROVIDER_NAME = "ClinePass";
+export const CLINE_PASS_BASE_URL = "https://api.cline.bot/api/v1";
+// Mirrors the `cline-pass` default model published by the newer `@cline/llms`
+// provider catalog that the Cline CLI and extension run on.
+export const CLINE_PASS_DEFAULT_MODEL_ID = "cline-pass/glm-5.2";
+
+export function isClinePassProviderId(providerId: string | null | undefined): boolean {
+	return providerId?.trim().toLowerCase() === CLINE_PASS_PROVIDER_ID;
+}
+
+/**
+ * True for every provider backed by a Cline account: usage-billing `cline` and
+ * subscription `cline-pass` share one OAuth token, one API base URL, and one set
+ * of account endpoints (profile, balance, organizations, Featurebase).
+ */
+export function isClineAccountProviderId(providerId: string | null | undefined): boolean {
+	const normalizedProviderId = providerId?.trim().toLowerCase();
+	return normalizedProviderId === CLINE_PROVIDER_ID || normalizedProviderId === CLINE_PASS_PROVIDER_ID;
+}
+
+/**
+ * Maps a Kanban provider id onto the provider id the bundled SDK knows.
+ * `cline-pass` requests run through the registered `cline` provider; the
+ * `cline-pass/*` model id is what routes them to the subscription.
+ *
+ * Saved provider settings stay keyed by the Kanban provider id, because that is
+ * the key the Cline CLI and extension write in the shared config.
+ */
+export function resolveSdkRuntimeProviderId(providerId: string): string {
+	return isClinePassProviderId(providerId) ? CLINE_PROVIDER_ID : providerId;
+}

--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -21,6 +21,13 @@ import type {
 	RuntimeClineReasoningEffort,
 } from "../core/api-contract";
 import { openInBrowser } from "../server/browser";
+import {
+	CLINE_PASS_PROVIDER_ID,
+	CLINE_PASS_PROVIDER_NAME,
+	isClineAccountProviderId,
+	isClinePassProviderId,
+	resolveSdkRuntimeProviderId,
+} from "./cline-pass-provider";
 import { createKanbanClineLogger } from "./cline-runtime-logger";
 import {
 	addSdkCustomProvider,
@@ -41,6 +48,7 @@ import {
 	refreshManagedOauthCredentials,
 	SDK_DEFAULT_MODEL_ID,
 	SDK_DEFAULT_PROVIDER_ID,
+	SDK_MODELS_CATALOG_URL,
 	type SdkCustomProviderCapability,
 	type SdkProviderSettings,
 	saveSdkProviderSettings,
@@ -53,6 +61,7 @@ const WORKOS_TOKEN_PREFIX = "workos:";
 const DEFAULT_CLINE_API_BASE_URL = "https://api.cline.bot";
 const MANAGED_PROVIDER_ENV_KEYS: Record<ManagedClineOauthProviderId, readonly string[]> = {
 	cline: ["CLINE_API_KEY"],
+	"cline-pass": ["CLINE_API_KEY"],
 	oca: ["OCA_API_KEY"],
 	"openai-codex": [],
 };
@@ -64,11 +73,27 @@ const LITELLM_MODELS_RESPONSE_SCHEMA = z.object({
 });
 const LITELLM_MODEL_LIST_PATHNAMES = ["/models", "/model/info"] as const;
 const LITELLM_MODEL_LIST_TIMEOUT_MS = 2_500;
+// The bundled SDK ships no ClinePass models, so its model list is read from the
+// same public model catalog the SDK uses for live model metadata.
+const MODELS_CATALOG_MODEL_SCHEMA = z.object({
+	id: z.string().optional(),
+	name: z.string().optional(),
+	attachment: z.boolean().optional(),
+	reasoning: z.boolean().optional(),
+	modalities: z.object({ input: z.array(z.string()).optional() }).optional(),
+});
+const MODELS_CATALOG_SCHEMA = z.record(
+	z.string(),
+	z.object({ models: z.record(z.string(), MODELS_CATALOG_MODEL_SCHEMA).optional() }),
+);
+const MODELS_CATALOG_TIMEOUT_MS = 10_000;
+const MODELS_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
 const LOGGER = createKanbanClineLogger({ component: "cline-provider-service" });
 
 type ClineRemoteConfig = z.infer<typeof CLINE_REMOTE_CONFIG_SCHEMA>;
 type LiteLlmModelListPathname = (typeof LITELLM_MODEL_LIST_PATHNAMES)[number];
 type LiteLlmModelListItem = NonNullable<z.infer<typeof LITELLM_MODELS_RESPONSE_SCHEMA>["data"]>[number];
+type ModelsCatalogModel = z.infer<typeof MODELS_CATALOG_MODEL_SCHEMA>;
 type SdkReasoningEffort = NonNullable<NonNullable<SdkProviderSettings["reasoning"]>["effort"]>;
 
 export interface ResolvedClineLaunchConfig {
@@ -118,12 +143,20 @@ function parseClineRemoteConfigValue(value: string): ClineRemoteConfig {
 }
 
 function isManagedOauthProviderId(providerId: string): providerId is ManagedClineOauthProviderId {
-	return providerId === "cline" || providerId === "oca" || providerId === "openai-codex";
+	return (
+		providerId === "cline" ||
+		providerId === CLINE_PASS_PROVIDER_ID ||
+		providerId === "oca" ||
+		providerId === "openai-codex"
+	);
 }
 
 function formatManagedProviderDisplayName(providerId: ManagedClineOauthProviderId): string {
 	if (providerId === "cline") {
 		return "Cline";
+	}
+	if (providerId === CLINE_PASS_PROVIDER_ID) {
+		return CLINE_PASS_PROVIDER_NAME;
 	}
 	if (providerId === "oca") {
 		return "Oracle Code Assist";
@@ -150,7 +183,7 @@ function ensureWorkosPrefix(accessToken: string): string {
 }
 
 function toProviderApiKey(providerId: ManagedClineOauthProviderId, accessToken: string): string {
-	if (providerId === "cline") {
+	if (isClineAccountProviderId(providerId)) {
 		return `${WORKOS_TOKEN_PREFIX}${accessToken}`;
 	}
 	return accessToken;
@@ -313,6 +346,33 @@ async function fetchLiteLlmBaseUrlModels(settings: SdkProviderSettings | null): 
 	return [];
 }
 
+function toModelsCatalogProviderModel(modelId: string, model: ModelsCatalogModel): RuntimeClineProviderModel {
+	const supportsVision = model.modalities?.input?.includes("image") ?? false;
+	return {
+		id: modelId,
+		name: model.name?.trim() || modelId,
+		supportsVision: supportsVision || undefined,
+		supportsAttachments: (model.attachment ?? supportsVision) || undefined,
+		supportsReasoningEffort: model.reasoning || undefined,
+	};
+}
+
+async function fetchModelsCatalogProviderModels(providerId: string): Promise<RuntimeClineProviderModel[]> {
+	const response = await globalThis.fetch(SDK_MODELS_CATALOG_URL, {
+		method: "GET",
+		headers: { Accept: "application/json" },
+		signal: AbortSignal.timeout(MODELS_CATALOG_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		throw new Error(`Model catalog request returned HTTP ${response.status}.`);
+	}
+
+	const catalog = MODELS_CATALOG_SCHEMA.parse((await response.json()) as unknown);
+	return Object.entries(catalog[providerId]?.models ?? {}).map(([modelId, model]) =>
+		toModelsCatalogProviderModel(model.id?.trim() || modelId, model),
+	);
+}
+
 function createEmptyProviderSettingsSummary(): RuntimeClineProviderSettings {
 	return {
 		providerId: null,
@@ -422,13 +482,15 @@ async function refreshManagedOauthSettings(
 	const nextCredentials = await refreshManagedOauthCredentials({
 		providerId,
 		currentCredentials: {
-			access: providerId === "cline" ? stripWorkosPrefix(accessToken) : accessToken,
+			access: isClineAccountProviderId(providerId) ? stripWorkosPrefix(accessToken) : accessToken,
 			refresh: refreshToken,
 			expires: normalizeEpochMs(settings.auth?.expiresAt),
 			accountId: settings.auth?.accountId ?? undefined,
 		},
 		baseUrl: settings.baseUrl?.trim() || null,
-		oauthProvider: providerId,
+		// ClinePass refreshes against the Cline identity provider, exactly like the
+		// usage-billing `cline` provider does.
+		oauthProvider: resolveSdkRuntimeProviderId(providerId),
 	});
 	if (!nextCredentials) {
 		throw new Error(`OAuth credentials for provider "${providerId}" are invalid. Re-run OAuth login.`);
@@ -488,6 +550,32 @@ export function createClineProviderService() {
 		return promise;
 	}
 
+	// The bundled SDK catalog carries no ClinePass models, so the model list comes
+	// from the public catalog. Cached because Settings and the per-task model
+	// picker both ask for it, and a failure resolves to an empty list so callers
+	// keep whatever model is already saved.
+	let clinePassModelsCache: { promise: Promise<RuntimeClineProviderModel[]>; expiresAt: number } | null = null;
+
+	function fetchClinePassModelsDeduped(): Promise<RuntimeClineProviderModel[]> {
+		if (clinePassModelsCache && Date.now() < clinePassModelsCache.expiresAt) {
+			return clinePassModelsCache.promise;
+		}
+		const promise = fetchModelsCatalogProviderModels(CLINE_PASS_PROVIDER_ID).catch((error: unknown) => {
+			if (clinePassModelsCache?.promise === promise) {
+				clinePassModelsCache = null;
+			}
+			LOGGER.log("ClinePass model catalog request failed.", {
+				severity: "warn",
+				providerId: CLINE_PASS_PROVIDER_ID,
+				url: SDK_MODELS_CATALOG_URL,
+				errorMessage: toErrorMessage(error),
+			});
+			return [];
+		});
+		clinePassModelsCache = { promise, expiresAt: Date.now() + MODELS_CATALOG_CACHE_TTL_MS };
+		return promise;
+	}
+
 	return {
 		getProviderSettingsSummary(): RuntimeClineProviderSettings {
 			return getProviderSettingsSummary();
@@ -503,7 +591,7 @@ export function createClineProviderService() {
 				}
 
 				const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
-				if (normalizedProviderId !== "cline") {
+				if (!isClineAccountProviderId(normalizedProviderId)) {
 					return {
 						profile: null,
 					};
@@ -597,7 +685,7 @@ export function createClineProviderService() {
 			}
 
 			const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
-			if (normalizedProviderId !== "cline") {
+			if (!isClineAccountProviderId(normalizedProviderId)) {
 				throw new Error("Featurebase token requires a Cline provider.");
 			}
 
@@ -632,7 +720,7 @@ export function createClineProviderService() {
 					return { balance: null, activeAccountLabel: null, activeOrganizationId: null };
 				}
 				const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
-				if (normalizedProviderId !== "cline") {
+				if (!isClineAccountProviderId(normalizedProviderId)) {
 					return { balance: null, activeAccountLabel: null, activeOrganizationId: null };
 				}
 
@@ -695,7 +783,7 @@ export function createClineProviderService() {
 					return { organizations: [] };
 				}
 				const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
-				if (normalizedProviderId !== "cline") {
+				if (!isClineAccountProviderId(normalizedProviderId)) {
 					return { organizations: [] };
 				}
 
@@ -746,7 +834,7 @@ export function createClineProviderService() {
 					return { ok: false, error: "No provider settings configured." };
 				}
 				const normalizedProviderId = selectedSettings.provider.trim().toLowerCase();
-				if (normalizedProviderId !== "cline") {
+				if (!isClineAccountProviderId(normalizedProviderId)) {
 					return { ok: false, error: "Account switching requires a Cline provider." };
 				}
 
@@ -885,6 +973,16 @@ export function createClineProviderService() {
 				providerModels = [
 					...providerModels,
 					...liteLlmModels.filter((model) => !existingModelIds.has(model.id)),
+				].sort((left, right) => left.name.localeCompare(right.name));
+			}
+			// Without this the picker only ever offers the single saved ClinePass
+			// model, because the bundled SDK catalog has no ClinePass entry.
+			if (isClinePassProviderId(normalizedProviderId)) {
+				const clinePassModels = await fetchClinePassModelsDeduped();
+				const existingModelIds = new Set(providerModels.map((model) => model.id));
+				providerModels = [
+					...providerModels,
+					...clinePassModels.filter((model) => !existingModelIds.has(model.id)),
 				].sort((left, right) => left.name.localeCompare(right.name));
 			}
 
@@ -1181,7 +1279,9 @@ export function createClineProviderService() {
 				const credentials = await loginManagedOauthProvider({
 					providerId: input.providerId,
 					baseUrl,
-					oauthProvider: input.providerId,
+					// ClinePass signs in through the Cline identity provider; only the
+					// saved settings stay keyed by the ClinePass provider id.
+					oauthProvider: resolveSdkRuntimeProviderId(input.providerId),
 					callbacks: createRuntimeOauthCallbacks(input.providerId),
 				});
 

--- a/src/cline-sdk/cline-session-runtime.ts
+++ b/src/cline-sdk/cline-session-runtime.ts
@@ -8,6 +8,7 @@ import {
 	type ClineMcpToolBundle,
 	createClineMcpRuntimeService,
 } from "./cline-mcp-runtime-service";
+import { resolveSdkRuntimeProviderId } from "./cline-pass-provider";
 import { createKanbanClineLogger } from "./cline-runtime-logger";
 import { buildSessionIdPrefix, createSessionId } from "./cline-session-state";
 import { CLINE_MODEL_CATALOG_DEFAULTS } from "./sdk-provider-boundary";
@@ -207,7 +208,9 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 			startResult = await sessionHost.start({
 				config: {
 					sessionId: requestedSessionId,
-					providerId: request.providerId,
+					// ClinePass rides the registered `cline` provider; its `cline-pass/*`
+					// model id is what routes the request to the subscription.
+					providerId: resolveSdkRuntimeProviderId(request.providerId),
 					modelId: request.modelId,
 					apiKey: request.apiKey?.trim() || undefined,
 					baseUrl: request.baseUrl?.trim() || undefined,

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -20,6 +20,7 @@ import {
 	DEFAULT_INTERNAL_IDCS_CLIENT_ID,
 	DEFAULT_INTERNAL_IDCS_SCOPES,
 	DEFAULT_INTERNAL_IDCS_URL,
+	DEFAULT_MODELS_CATALOG_URL,
 	ensureCustomProvidersLoaded,
 	getLocalProviderModels,
 	getValidClineCredentials,
@@ -37,11 +38,22 @@ import {
 	startClineDeviceAuth as sdkStartClineDeviceAuth,
 } from "@clinebot/core";
 import type { AgentTool } from "@clinebot/shared";
+import {
+	CLINE_PASS_BASE_URL,
+	CLINE_PASS_DEFAULT_MODEL_ID,
+	CLINE_PASS_PROVIDER_ID,
+	CLINE_PASS_PROVIDER_NAME,
+	CLINE_PROVIDER_ID,
+	isClinePassProviderId,
+	resolveSdkRuntimeProviderId,
+} from "./cline-pass-provider";
 
-export type ManagedClineOauthProviderId = "cline" | "oca" | "openai-codex";
+export type ManagedClineOauthProviderId = "cline" | "cline-pass" | "oca" | "openai-codex";
 export type SdkReasoningEffort = NonNullable<NonNullable<ProviderSettings["reasoning"]>["effort"]>;
 export const SDK_DEFAULT_PROVIDER_ID = "cline";
 export const SDK_DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4.6";
+// The public model catalog the SDK itself reads for live model metadata.
+export const SDK_MODELS_CATALOG_URL: string = DEFAULT_MODELS_CATALOG_URL;
 export const CLINE_MODEL_CATALOG_DEFAULTS = {
 	loadLatestOnInit: true,
 	loadPrivateOnAuth: true,
@@ -235,7 +247,9 @@ export async function refreshManagedOauthCredentials(input: {
 	baseUrl?: string | null;
 	oauthProvider?: string | null;
 }): Promise<ManagedOauthCredentials | null> {
-	if (input.providerId === "cline") {
+	// ClinePass authenticates with the same Cline account credentials as the
+	// usage-billing `cline` provider, so it refreshes through the same flow.
+	if (resolveSdkRuntimeProviderId(input.providerId) === "cline") {
 		const credentials = await getValidClineCredentials(input.currentCredentials, {
 			apiBaseUrl: input.baseUrl?.trim() || "https://api.cline.bot",
 			provider: input.oauthProvider?.trim() || undefined,
@@ -262,7 +276,7 @@ export async function loginManagedOauthProvider(input: {
 	oauthProvider?: string | null;
 	callbacks: ManagedOauthCallbacks;
 }): Promise<ManagedOauthCredentials> {
-	if (input.providerId === "cline") {
+	if (resolveSdkRuntimeProviderId(input.providerId) === "cline") {
 		return await loginClineOAuth({
 			apiBaseUrl: input.baseUrl?.trim() || "https://api.cline.bot",
 			provider: input.oauthProvider?.trim() || undefined,
@@ -314,8 +328,29 @@ export async function completeClineDeviceAuth(input: {
 	};
 }
 
+// ClinePass shares the Cline provider's endpoint, credentials and capabilities,
+// so the catalog entry is derived from the registered `cline` provider instead of
+// restating them here.
+function buildClinePassCatalogItem(providers: SdkProviderCatalogItem[]): SdkProviderCatalogItem {
+	const clineProvider = providers.find((provider) => provider.id === CLINE_PROVIDER_ID);
+	return {
+		id: CLINE_PASS_PROVIDER_ID,
+		name: CLINE_PASS_PROVIDER_NAME,
+		defaultModelId: CLINE_PASS_DEFAULT_MODEL_ID,
+		baseUrl: clineProvider?.baseUrl ?? CLINE_PASS_BASE_URL,
+		env: clineProvider?.env ? [...clineProvider.env] : ["CLINE_API_KEY"],
+		capabilities: clineProvider?.capabilities ? [...clineProvider.capabilities] : ["oauth"],
+	};
+}
+
 export async function listSdkProviderCatalog(): Promise<SdkProviderCatalogItem[]> {
-	return await ClineCore.Llms.getAllProviders();
+	const providers = await ClineCore.Llms.getAllProviders();
+	// The bundled SDK has no ClinePass provider yet, so Kanban contributes the
+	// entry and stands down once the SDK registers its own.
+	if (providers.some((provider) => isClinePassProviderId(provider.id))) {
+		return providers;
+	}
+	return [...providers, buildClinePassCatalogItem(providers)];
 }
 
 function toSdkProviderModel(model: SdkLocalProviderModel): SdkProviderModel {

--- a/src/cline-sdk/sdk-runtime-boundary.ts
+++ b/src/cline-sdk/sdk-runtime-boundary.ts
@@ -22,6 +22,7 @@ import {
 	type ToolApprovalResult,
 	type UserInstructionConfigService,
 } from "@clinebot/core";
+import { resolveSdkRuntimeProviderId } from "./cline-pass-provider";
 import { CLINE_BUILTIN_SLASH_COMMANDS } from "./cline-slash-commands";
 import { getCliTelemetryService } from "./cline-telemetry-service";
 
@@ -111,15 +112,17 @@ export async function resolveClineSdkSystemPrompt(input: {
 	providerId: string;
 	rules?: string;
 }): Promise<string> {
-	// The Cline SDK can run against non-Cline providers too, but only the
-	// "cline" provider expects the extra workspace metadata block that powers
-	// its repo-aware behavior in the same way the official CLI does.
-	const shouldAppendWorkspaceMetadata = input.providerId === "cline";
+	// The Cline SDK can run against non-Cline providers too, but only the Cline
+	// providers ("cline" and ClinePass, which runs on the same endpoint) expect
+	// the extra workspace metadata block that powers their repo-aware behavior in
+	// the same way the official CLI does.
+	const sdkProviderId = resolveSdkRuntimeProviderId(input.providerId);
+	const shouldAppendWorkspaceMetadata = sdkProviderId === "cline";
 	const workspaceMetadata = shouldAppendWorkspaceMetadata ? await buildWorkspaceMetadata(input.cwd) : "";
 	return getClineDefaultSystemPrompt({
 		ide: "Kanban",
 		rootPath: input.cwd,
-		providerId: input.providerId,
+		providerId: sdkProviderId,
 		metadata: workspaceMetadata,
 		rules: input.rules ?? "",
 	});

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -598,7 +598,7 @@ export const runtimeProjectShortcutSchema = z.object({
 });
 export type RuntimeProjectShortcut = z.infer<typeof runtimeProjectShortcutSchema>;
 
-export const runtimeClineOauthProviderSchema = z.enum(["cline", "oca", "openai-codex"]);
+export const runtimeClineOauthProviderSchema = z.enum(["cline", "cline-pass", "oca", "openai-codex"]);
 export type RuntimeClineOauthProvider = z.infer<typeof runtimeClineOauthProviderSchema>;
 
 export const runtimeClineProviderSettingsSchema = z.object({

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -37,6 +37,7 @@ vi.mock("@clinebot/core", () => ({
 	loginOcaOAuth: vi.fn(),
 	loginOpenAICodex: vi.fn(),
 	resolveDefaultMcpSettingsPath: vi.fn(),
+	DEFAULT_MODELS_CATALOG_URL: "https://models.dev/api.json",
 	resolveClineDataDir: vi.fn(() => "/tmp/cline"),
 	loadMcpSettingsFile: vi.fn(),
 	ClineAccountService: class {

--- a/test/runtime/cline-sdk/cline-pass-provider-service.test.ts
+++ b/test/runtime/cline-sdk/cline-pass-provider-service.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clineAccountMocks = vi.hoisted(() => ({
+	fetchMe: vi.fn(),
+	fetchBalance: vi.fn(),
+	fetchOrganizationBalance: vi.fn(),
+	switchAccount: vi.fn(),
+	fetchRemoteConfig: vi.fn(),
+	fetchOrganization: vi.fn(),
+	fetchFeaturebaseToken: vi.fn(),
+}));
+
+const oauthMocks = vi.hoisted(() => ({
+	saveProviderSettings: vi.fn(),
+	getProviderSettings: vi.fn(),
+	getLastUsedProviderSettings: vi.fn(),
+	getValidClineCredentials: vi.fn(),
+	loginClineOAuth: vi.fn(),
+}));
+
+const llmsModelMocks = vi.hoisted(() => ({
+	getAllProviders: vi.fn(),
+	getModelsForProvider: vi.fn(),
+	resolveProviderModelCatalogKeys: vi.fn((providerId: string) => [providerId]),
+}));
+
+const localProviderMocks = vi.hoisted(() => ({
+	getLocalProviderModels: vi.fn(),
+	resolveProviderConfig: vi.fn(),
+}));
+
+vi.mock("@clinebot/core", () => ({
+	addLocalProvider: vi.fn(),
+	ensureCustomProvidersLoaded: vi.fn(),
+	getLocalProviderModels: localProviderMocks.getLocalProviderModels,
+	resolveProviderConfig: localProviderMocks.resolveProviderConfig,
+	getValidClineCredentials: oauthMocks.getValidClineCredentials,
+	getValidOcaCredentials: vi.fn(),
+	getValidOpenAICodexCredentials: vi.fn(),
+	loginClineOAuth: oauthMocks.loginClineOAuth,
+	loginOcaOAuth: vi.fn(),
+	loginOpenAICodex: vi.fn(),
+	resolveDefaultMcpSettingsPath: vi.fn(),
+	resolveClineDataDir: vi.fn(() => "/tmp/cline"),
+	loadMcpSettingsFile: vi.fn(),
+	DEFAULT_MODELS_CATALOG_URL: "https://models.dev/api.json",
+	ClineAccountService: class {
+		fetchMe = clineAccountMocks.fetchMe;
+		fetchBalance = clineAccountMocks.fetchBalance;
+		fetchOrganizationBalance = clineAccountMocks.fetchOrganizationBalance;
+		switchAccount = clineAccountMocks.switchAccount;
+		fetchRemoteConfig = clineAccountMocks.fetchRemoteConfig;
+		fetchOrganization = clineAccountMocks.fetchOrganization;
+		fetchFeaturebaseToken = clineAccountMocks.fetchFeaturebaseToken;
+	},
+	ProviderSettingsManager: class {
+		saveProviderSettings = oauthMocks.saveProviderSettings;
+		getProviderSettings = oauthMocks.getProviderSettings;
+		getLastUsedProviderSettings = oauthMocks.getLastUsedProviderSettings;
+		getProviderConfig = vi.fn(() => undefined);
+		getFilePath = vi.fn(() => "/tmp/provider-settings.json");
+		read = vi.fn(() => ({ providers: {} }));
+		write = vi.fn();
+	},
+	Llms: {
+		getAllProviders: llmsModelMocks.getAllProviders,
+		getModelsForProvider: llmsModelMocks.getModelsForProvider,
+		resolveProviderModelCatalogKeys: llmsModelMocks.resolveProviderModelCatalogKeys,
+	},
+	LlmsModels: {
+		getAllProviders: llmsModelMocks.getAllProviders,
+		getModelsForProvider: llmsModelMocks.getModelsForProvider,
+	},
+	LlmsProviders: {
+		supportsModelThinking: vi.fn(() => false),
+	},
+	InMemoryMcpManager: class {},
+	createMcpTools: vi.fn(async () => []),
+	DEFAULT_EXTERNAL_IDCS_CLIENT_ID: "",
+	DEFAULT_EXTERNAL_IDCS_SCOPES: "",
+	DEFAULT_EXTERNAL_IDCS_URL: "",
+	DEFAULT_INTERNAL_IDCS_CLIENT_ID: "",
+	DEFAULT_INTERNAL_IDCS_SCOPES: "",
+	DEFAULT_INTERNAL_IDCS_URL: "",
+}));
+
+vi.mock("../../../src/server/browser.js", () => ({
+	openInBrowser: vi.fn(),
+}));
+
+import { createClineProviderService } from "../../../src/cline-sdk/cline-provider-service";
+
+const CLINE_SDK_PROVIDER = {
+	id: "cline",
+	name: "Cline",
+	defaultModelId: "anthropic/claude-sonnet-4.6",
+	baseUrl: "https://api.cline.bot/api/v1",
+	env: ["CLINE_API_KEY"],
+	capabilities: ["reasoning", "prompt-cache", "tools", "oauth"],
+};
+
+function setSelectedProviderSettings(
+	settings: {
+		provider: string;
+		model?: string;
+		baseUrl?: string;
+		apiKey?: string;
+		auth?: {
+			accessToken?: string;
+			refreshToken?: string;
+			accountId?: string;
+			expiresAt?: number;
+		};
+	} | null,
+): void {
+	oauthMocks.getLastUsedProviderSettings.mockReturnValue(settings ?? undefined);
+	oauthMocks.getProviderSettings.mockImplementation((providerId: string) =>
+		settings && settings.provider === providerId ? settings : undefined,
+	);
+}
+
+function stubModelsCatalogFetch(): ReturnType<typeof vi.fn<typeof fetch>> {
+	const fetchMock = vi.fn<typeof fetch>(async () => {
+		return new Response(
+			JSON.stringify({
+				"cline-pass": {
+					id: "cline-pass",
+					name: "ClinePass",
+					api: "https://api.cline.bot/api/v1",
+					models: {
+						"cline-pass/glm-5.2": {
+							id: "cline-pass/glm-5.2",
+							name: "GLM-5.2",
+							reasoning: true,
+							attachment: false,
+							modalities: { input: ["text"] },
+						},
+						"cline-pass/kimi-k3": {
+							id: "cline-pass/kimi-k3",
+							name: "Kimi K3",
+							reasoning: false,
+							attachment: true,
+							modalities: { input: ["text", "image"] },
+						},
+					},
+				},
+				anthropic: { models: {} },
+			}),
+			{ status: 200 },
+		);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	llmsModelMocks.getAllProviders.mockResolvedValue([CLINE_SDK_PROVIDER]);
+	localProviderMocks.getLocalProviderModels.mockResolvedValue({ providerId: "cline-pass", models: [] });
+	localProviderMocks.resolveProviderConfig.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("getProviderCatalog with ClinePass", () => {
+	it("offers ClinePass even though the bundled SDK catalog has no entry for it", async () => {
+		setSelectedProviderSettings(null);
+
+		const result = await createClineProviderService().getProviderCatalog();
+		const clinePass = result.providers.find((provider) => provider.id === "cline-pass");
+
+		expect(clinePass).toEqual({
+			id: "cline-pass",
+			name: "ClinePass",
+			oauthSupported: true,
+			enabled: false,
+			defaultModelId: "cline-pass/glm-5.2",
+			baseUrl: "https://api.cline.bot/api/v1",
+			supportsBaseUrl: true,
+			env: ["CLINE_API_KEY"],
+		});
+	});
+
+	it("marks ClinePass as the enabled provider when it is the saved selection", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass", model: "cline-pass/glm-5.2" });
+
+		const result = await createClineProviderService().getProviderCatalog();
+		const clinePassEntries = result.providers.filter((provider) => provider.id === "cline-pass");
+
+		expect(clinePassEntries).toHaveLength(1);
+		expect(clinePassEntries[0]?.enabled).toBe(true);
+		expect(clinePassEntries[0]?.name).toBe("ClinePass");
+	});
+
+	it("defers to the SDK once it registers ClinePass itself", async () => {
+		llmsModelMocks.getAllProviders.mockResolvedValue([
+			CLINE_SDK_PROVIDER,
+			{
+				id: "cline-pass",
+				name: "ClinePass (SDK)",
+				defaultModelId: "cline-pass/from-sdk",
+				baseUrl: "https://api.cline.bot/api/v1",
+				env: ["CLINE_API_KEY"],
+				capabilities: ["oauth"],
+			},
+		]);
+		setSelectedProviderSettings(null);
+
+		const result = await createClineProviderService().getProviderCatalog();
+		const clinePassEntries = result.providers.filter((provider) => provider.id === "cline-pass");
+
+		expect(clinePassEntries).toHaveLength(1);
+		expect(clinePassEntries[0]?.name).toBe("ClinePass (SDK)");
+		expect(clinePassEntries[0]?.defaultModelId).toBe("cline-pass/from-sdk");
+	});
+});
+
+describe("getProviderModels for ClinePass", () => {
+	it("lists the ClinePass models published by the model catalog", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass", model: "cline-pass/glm-5.2" });
+		const fetchMock = stubModelsCatalogFetch();
+
+		const result = await createClineProviderService().getProviderModels("cline-pass");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://models.dev/api.json",
+			expect.objectContaining({ method: "GET", signal: expect.any(AbortSignal) }),
+		);
+		expect(result.models).toEqual([
+			{ id: "cline-pass/glm-5.2", name: "GLM-5.2", supportsReasoningEffort: true },
+			{
+				id: "cline-pass/kimi-k3",
+				name: "Kimi K3",
+				supportsVision: true,
+				supportsAttachments: true,
+			},
+		]);
+	});
+
+	it("falls back to the saved model when the catalog cannot be reached", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass", model: "cline-pass/deepseek-v4-pro" });
+		vi.stubGlobal(
+			"fetch",
+			vi.fn<typeof fetch>(async () => {
+				throw new Error("offline");
+			}),
+		);
+
+		const result = await createClineProviderService().getProviderModels("cline-pass");
+
+		expect(result.models).toEqual([{ id: "cline-pass/deepseek-v4-pro", name: "cline-pass/deepseek-v4-pro" }]);
+	});
+
+	it("does not reach for the catalog for providers the SDK already knows", async () => {
+		setSelectedProviderSettings({ provider: "cline", model: "anthropic/claude-sonnet-4.6" });
+		localProviderMocks.getLocalProviderModels.mockResolvedValue({
+			providerId: "cline",
+			models: [{ id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" }],
+		});
+		const fetchMock = stubModelsCatalogFetch();
+
+		const result = await createClineProviderService().getProviderModels("cline");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result.models.map((model) => model.id)).toEqual(["anthropic/claude-sonnet-4.6"]);
+	});
+});
+
+describe("resolveLaunchConfig for ClinePass", () => {
+	it("keeps the ClinePass provider id and prefixes the account token", async () => {
+		setSelectedProviderSettings({
+			provider: "cline-pass",
+			model: "cline-pass/glm-5.2",
+			auth: { accessToken: "workos:test-token", refreshToken: "refresh-token", expiresAt: Date.now() + 60_000 },
+		});
+		oauthMocks.getValidClineCredentials.mockResolvedValue({
+			access: "refreshed-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+		});
+
+		const result = await createClineProviderService().resolveLaunchConfig();
+
+		expect(result).toMatchObject({
+			providerId: "cline-pass",
+			modelId: "cline-pass/glm-5.2",
+			apiKey: "workos:refreshed-token",
+		});
+	});
+
+	it("refreshes ClinePass credentials through the Cline identity provider", async () => {
+		setSelectedProviderSettings({
+			provider: "cline-pass",
+			model: "cline-pass/glm-5.2",
+			auth: { accessToken: "workos:test-token", refreshToken: "refresh-token", expiresAt: Date.now() + 60_000 },
+		});
+		oauthMocks.getValidClineCredentials.mockResolvedValue({
+			access: "refreshed-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3_600_000,
+		});
+
+		await createClineProviderService().resolveLaunchConfig();
+
+		expect(oauthMocks.getValidClineCredentials).toHaveBeenCalledWith(
+			expect.objectContaining({ access: "test-token", refresh: "refresh-token" }),
+			expect.objectContaining({ provider: "cline" }),
+		);
+	});
+
+	it("uses CLINE_API_KEY when ClinePass has no saved credentials", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass", model: "cline-pass/glm-5.2" });
+		vi.stubEnv("CLINE_API_KEY", "env-cline-key");
+
+		const result = await createClineProviderService().resolveLaunchConfig();
+
+		expect(result.apiKey).toBe("env-cline-key");
+	});
+
+	it("names ClinePass in the error when no credentials are configured at all", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass", model: "cline-pass/glm-5.2" });
+		vi.stubEnv("CLINE_API_KEY", "");
+
+		await expect(createClineProviderService().resolveLaunchConfig()).rejects.toThrow(/ClinePass/);
+	});
+
+	it("falls back to the ClinePass default model when none is saved", async () => {
+		setSelectedProviderSettings({ provider: "cline-pass" });
+		vi.stubEnv("CLINE_API_KEY", "env-cline-key");
+
+		const result = await createClineProviderService().resolveLaunchConfig();
+
+		expect(result.modelId).toBe("cline-pass/glm-5.2");
+	});
+});
+
+describe("Cline account features with ClinePass selected", () => {
+	it("reads the account balance, because ClinePass is a Cline account", async () => {
+		setSelectedProviderSettings({
+			provider: "cline-pass",
+			auth: { accessToken: "test-token" },
+		});
+		clineAccountMocks.fetchMe.mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			displayName: "Test User",
+			organizations: [],
+		});
+		clineAccountMocks.fetchBalance.mockResolvedValue({ balance: 5_000_000, userId: "user-1" });
+
+		const result = await createClineProviderService().getClineAccountBalance();
+
+		expect(result).toEqual({
+			balance: 5_000_000,
+			activeAccountLabel: "Personal",
+			activeOrganizationId: null,
+		});
+	});
+
+	it("reports the ClinePass account profile", async () => {
+		setSelectedProviderSettings({
+			provider: "cline-pass",
+			auth: { accessToken: "test-token" },
+		});
+		clineAccountMocks.fetchMe.mockResolvedValue({
+			id: "user-1",
+			email: "test@example.com",
+			displayName: "Test User",
+		});
+
+		const result = await createClineProviderService().getClineAccountProfile();
+
+		expect(result.profile).toEqual({
+			accountId: "user-1",
+			email: "test@example.com",
+			displayName: "Test User",
+		});
+	});
+
+	it("still ignores providers that are not backed by a Cline account", async () => {
+		setSelectedProviderSettings({ provider: "anthropic", apiKey: "sk-test" });
+
+		const result = await createClineProviderService().getClineAccountBalance();
+
+		expect(result).toEqual({ balance: null, activeAccountLabel: null, activeOrganizationId: null });
+	});
+});

--- a/test/runtime/cline-sdk/cline-pass-provider.test.ts
+++ b/test/runtime/cline-sdk/cline-pass-provider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	CLINE_PASS_DEFAULT_MODEL_ID,
+	CLINE_PASS_PROVIDER_ID,
+	isClineAccountProviderId,
+	isClinePassProviderId,
+	resolveSdkRuntimeProviderId,
+} from "../../../src/cline-sdk/cline-pass-provider";
+
+describe("isClinePassProviderId", () => {
+	it("matches the ClinePass provider id regardless of casing and padding", () => {
+		expect(isClinePassProviderId("cline-pass")).toBe(true);
+		expect(isClinePassProviderId(" Cline-Pass ")).toBe(true);
+	});
+
+	it("does not match other providers or missing ids", () => {
+		expect(isClinePassProviderId("cline")).toBe(false);
+		expect(isClinePassProviderId("clinepass")).toBe(false);
+		expect(isClinePassProviderId(null)).toBe(false);
+		expect(isClinePassProviderId(undefined)).toBe(false);
+	});
+});
+
+describe("isClineAccountProviderId", () => {
+	it("accepts both providers that authenticate with a Cline account", () => {
+		expect(isClineAccountProviderId("cline")).toBe(true);
+		expect(isClineAccountProviderId("cline-pass")).toBe(true);
+	});
+
+	it("rejects providers that use their own credentials", () => {
+		expect(isClineAccountProviderId("anthropic")).toBe(false);
+		expect(isClineAccountProviderId("openai-codex")).toBe(false);
+		expect(isClineAccountProviderId("oca")).toBe(false);
+		expect(isClineAccountProviderId(null)).toBe(false);
+	});
+});
+
+describe("resolveSdkRuntimeProviderId", () => {
+	it("routes ClinePass through the provider the bundled SDK registers", () => {
+		expect(resolveSdkRuntimeProviderId(CLINE_PASS_PROVIDER_ID)).toBe("cline");
+	});
+
+	it("leaves every other provider id untouched", () => {
+		expect(resolveSdkRuntimeProviderId("cline")).toBe("cline");
+		expect(resolveSdkRuntimeProviderId("anthropic")).toBe("anthropic");
+		expect(resolveSdkRuntimeProviderId("my-custom-provider")).toBe("my-custom-provider");
+	});
+});
+
+describe("ClinePass model ids", () => {
+	it("keeps the ClinePass namespace on the default model, which is what routes billing", () => {
+		expect(CLINE_PASS_DEFAULT_MODEL_ID.startsWith(`${CLINE_PASS_PROVIDER_ID}/`)).toBe(true);
+	});
+});

--- a/test/runtime/cline-sdk/cline-session-runtime.test.ts
+++ b/test/runtime/cline-sdk/cline-session-runtime.test.ts
@@ -124,6 +124,49 @@ describe("InMemoryClineSessionRuntime", () => {
 		);
 	});
 
+	it("starts ClinePass sessions on the provider the bundled SDK registers, keeping the ClinePass model", async () => {
+		const fakeHost = {
+			start: vi.fn(async (input: { config?: { sessionId?: string } }) => ({
+				sessionId: input.config?.sessionId ?? "session-1",
+				result: {},
+			})),
+			send: vi.fn(async () => ({})),
+			stop: vi.fn(async () => {}),
+			abort: vi.fn(async () => {}),
+			delete: vi.fn(async () => true),
+			dispose: vi.fn(async () => {}),
+			get: vi.fn(async () => undefined),
+			list: vi.fn(async () => []),
+			readMessages: vi.fn(async () => []),
+			subscribe: vi.fn(() => () => {}),
+		};
+
+		const runtime = createInMemoryClineSessionRuntime({
+			createSessionHost: async () => fakeHost,
+			createMcpRuntimeService: createNoopMcpRuntimeService,
+		});
+
+		await runtime.startTaskSession({
+			taskId: "task-1",
+			cwd: "/tmp/worktree",
+			prompt: "Investigate startup",
+			providerId: "cline-pass",
+			modelId: "cline-pass/glm-5.2",
+			apiKey: "workos:test-token",
+			systemPrompt: "You are a helpful coding assistant.",
+		});
+
+		expect(fakeHost.start).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.objectContaining({
+					providerId: "cline",
+					modelId: "cline-pass/glm-5.2",
+					apiKey: "workos:test-token",
+				}),
+			}),
+		);
+	});
+
 	it("leaves reasoning effort unset when no override is provided", async () => {
 		const fakeHost = {
 			start: vi.fn(async (input: { config?: { sessionId?: string; reasoningEffort?: string } }) => ({

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -85,6 +85,7 @@ vi.mock("@clinebot/core", () => ({
 	resolveClineDataDir: oauthMocks.resolveClineDataDir,
 	loadMcpSettingsFile: oauthMocks.loadMcpSettingsFile,
 	resolveProviderConfig: llmsModelMocks.resolveProviderConfig,
+	DEFAULT_MODELS_CATALOG_URL: "https://models.dev/api.json",
 	ClineAccountService: class {
 		constructor(options: { apiBaseUrl: string; getAuthToken: () => Promise<string | undefined | null> }) {
 			clineAccountMocks.constructedOptions.push(options);

--- a/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
+++ b/web-ui/src/hooks/use-runtime-settings-cline-controller.ts
@@ -144,7 +144,7 @@ export interface UseRuntimeSettingsClineControllerResult {
 
 function toManagedClineOauthProvider(value: string): RuntimeClineOauthProvider | null {
 	const normalized = value.trim().toLowerCase();
-	if (normalized === "cline" || normalized === "oca" || normalized === "openai-codex") {
+	if (normalized === "cline" || normalized === "cline-pass" || normalized === "oca" || normalized === "openai-codex") {
 		return normalized;
 	}
 	return null;

--- a/web-ui/src/runtime/native-agent.ts
+++ b/web-ui/src/runtime/native-agent.ts
@@ -43,10 +43,11 @@ export function isClineProviderAuthenticated(settings: RuntimeClineProviderSetti
 }
 
 /**
- * Returns true only when the selected provider is the Cline managed OAuth
- * provider **and** an access token is configured.  This is stricter than
- * {@link isClineProviderAuthenticated} which accepts any configured provider
- * (Claude API key, Codex, etc.).
+ * Returns true only when the selected provider is one of the Cline account
+ * managed OAuth providers (`cline` usage billing or `cline-pass` subscription,
+ * which share one Cline account token) **and** an access token is configured.
+ * This is stricter than {@link isClineProviderAuthenticated} which accepts any
+ * configured provider (Claude API key, Codex, etc.).
  *
  * Use this for features that require a Cline-issued token (e.g. Featurebase
  * JWT authentication).
@@ -56,7 +57,7 @@ export function isClineOauthAuthenticated(settings: RuntimeClineProviderSettings
 		return false;
 	}
 	return (
-		settings.oauthProvider === "cline" &&
+		(settings.oauthProvider === "cline" || settings.oauthProvider === "cline-pass") &&
 		settings.oauthAccessTokenConfigured === true &&
 		settings.oauthRefreshTokenConfigured === true
 	);


### PR DESCRIPTION
fixes #552

This is a fix for the `bug`-labeled report in #552 — ClinePass cards fail to start, and
the model picker shows a single model. Feature-request discussion #547 has the background
and the original root-cause analysis.

## The bug

Starting a card with the `cline-pass` provider fails immediately:

```
Error: Unknown or disabled provider "cline-pass".
```

Settings also lets you *select* ClinePass but shows only a single model — both symptoms in #552.

## Root cause

The bundled `@clinebot/core` provider registry has no `cline-pass` entry, so `GatewayRegistry.resolveModel` throws before any request is made. Reproducible against the pinned SDK in three lines:

```js
import { Llms } from "@clinebot/core"; // 0.0.38, what kanban@0.1.70 bundles
const gw = Llms.createGateway({ providerConfigs: [{ providerId: "cline-pass", apiKey: "k" }] });
await gw.stream({ providerId: "cline-pass", modelId: "cline-pass/glm-5.2", messages: [{ role: "user", content: "hi" }] });
// → Unknown or disabled provider "cline-pass".
```

The two UI symptoms are separate Kanban-side effects of the same gap:

- `getProviderCatalog()` synthesizes an entry for whatever provider the shared `~/.cline` config has selected, so `cline-pass` looks supported even though the SDK has never heard of it.
- `getProviderModels()` falls back to the single saved model when the SDK returns none — hence "only one model at a time".

Bumping the dependency does not help: `@clinebot/core@latest` on npm is still `0.0.38`, and no version in that lineage defines `cline-pass`. The provider only exists in the newer `@cline/core` + `@cline/llms` lineage that the `cline` CLI and the extension run on, and migrating Kanban across that gap (0.0.38 → 0.0.69, four packages) is a much larger change than this issue.

## The fix

ClinePass is not a separate API surface. Comparing the two provider definitions in `@cline/llms`, `cline-pass` and `cline` are identical apart from name, default model and model list:

| | `cline` | `cline-pass` |
|---|---|---|
| baseUrl | `https://api.cline.bot/api/v1` | `https://api.cline.bot/api/v1` |
| protocol / client | `openai-chat` / `openai-compatible` | `openai-chat` / `openai-compatible` |
| auth | Cline account OAuth (`workos:` token) | Cline account OAuth (`workos:` token) |
| env | `CLINE_API_KEY` | `CLINE_API_KEY` |

Only the model namespace differs — the Cline API bills a request against the subscription when the model id is `cline-pass/*`.

So Kanban keeps `cline-pass` as its own selectable provider (own catalog entry, own model list, own saved settings, which stay keyed by the id the CLI and extension write) and hands the bundled SDK the `cline` provider id when it starts a session, leaving the `cline-pass/*` model id untouched. Verified against the pinned SDK with an intercepting `fetch` — routing a `cline-pass/*` model through the registered `cline` provider produces exactly the request the newer SDK would send:

```
POST https://api.cline.bot/api/v1/chat/completions
Authorization: Bearer workos:<token>
{"model":"cline-pass/glm-5.2","stream":true,...}
```

Changes, all inside the `src/cline-sdk/` boundary plus two web-ui call sites:

- **`cline-pass-provider.ts`** (new) — provider ids, the `isClineAccountProviderId` predicate, and `resolveSdkRuntimeProviderId`, which maps `cline-pass` → `cline` for SDK calls only.
- **Session start and system prompt** — routed through the registered `cline` provider, so ClinePass gets the same workspace-metadata prompt the official CLI uses.
- **Catalog** — a ClinePass entry derived from the registered `cline` provider (no restated endpoint/capabilities), so it is offered even when it is not the current selection. It stands down automatically if the SDK ever registers `cline-pass` itself; there is a test for that.
- **Model list** — read from the public model catalog the SDK already uses for live model metadata (`DEFAULT_MODELS_CATALOG_URL`, which publishes the ClinePass models with names, capabilities and context windows), cached for 10 min in the service closure like the existing profile cache, and degrading to the saved model when offline. No hardcoded model table.
- **Cline account features** — OAuth login/refresh, `CLINE_API_KEY`, and profile / balance / organizations / account switching / Featurebase now accept both Cline-account providers instead of only `cline`. Previously, selecting ClinePass silently blanked all of them.

The one hardcoded value is `CLINE_PASS_DEFAULT_MODEL_ID = "cline-pass/glm-5.2"`, used as the catalog entry's default model; it mirrors the `defaultModelId` published for `cline-pass` in `@cline/llms`.

## Testing

- `test/runtime/cline-sdk/cline-pass-provider.test.ts` — provider-id predicates and SDK routing.
- `test/runtime/cline-sdk/cline-pass-provider-service.test.ts` — catalog contribution (including deferring to the SDK), model listing from the catalog plus the offline fallback, launch config (token prefixing, `CLINE_API_KEY`, ClinePass-named error, default model), and Cline account features with ClinePass selected.
- `test/runtime/cline-sdk/cline-session-runtime.test.ts` — regression test that a ClinePass session starts on `providerId: "cline"` while keeping `modelId: "cline-pass/glm-5.2"`.
- Existing `@clinebot/core` test mocks gained the `DEFAULT_MODELS_CATALOG_URL` export.

`npm run check` and `npm run build` both pass. `npm run test` matches the pre-existing failures on `main` (`git-history`, `runtime-state-stream.integration`, `task-command-exit.integration` — all load-sensitive and passing in isolation). `dist/cli.js` now contains the `cline-pass` handling that was previously absent.

## Notes for reviewers

- If a maintainer would rather source the model list from the authenticated `GET /api/v1/models` endpoint (the account's real entitlements) than from the public catalog, that swap is contained to one function — I used the public catalog because I could verify its shape without a ClinePass account.
- Credentials are read from the provider settings keyed by the selected provider id, with no fallback between `cline` and `cline-pass`. If a user's token happens to live only under `cline`, ClinePass shows as not signed in and one sign-in from Settings fixes it. Happy to add the fallback if you'd prefer it.
- I have a ClinePass-less environment, so the request shape is verified by interception against the pinned SDK rather than a live subscription call. A maintainer with a ClinePass account can confirm the round trip in one card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
