### PR TITLE
feat: added VCS badge in Project Card

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -335,10 +335,14 @@ export const runtimeProjectTaskCountsSchema = z.object({
 });
 export type RuntimeProjectTaskCounts = z.infer<typeof runtimeProjectTaskCountsSchema>;
 
+export const runtimeProjectVcsSchema = z.enum(["github", "gerrit", "local"]);
+export type RuntimeProjectVcs = z.infer<typeof runtimeProjectVcsSchema>;
+
 export const runtimeProjectSummarySchema = z.object({
 	id: z.string(),
 	path: z.string(),
 	name: z.string(),
+	vcs: runtimeProjectVcsSchema.optional(),
 	taskCounts: runtimeProjectTaskCountsSchema,
 });
 export type RuntimeProjectSummary = z.infer<typeof runtimeProjectSummarySchema>;

--- a/src/server/workspace-registry.ts
+++ b/src/server/workspace-registry.ts
@@ -11,6 +11,7 @@ import {
 	loadWorkspaceBoardById,
 	loadWorkspaceContext,
 	loadWorkspaceState,
+	detectGitRemoteVcs,
 	type RuntimeWorkspaceIndexEntry,
 	removeWorkspaceIndexEntry,
 	removeWorkspaceStateFiles,
@@ -179,6 +180,7 @@ function toProjectSummary(project: {
 		id: project.workspaceId,
 		path: project.repoPath,
 		name,
+		vcs: detectGitRemoteVcs(project.repoPath),
 		taskCounts: project.taskCounts,
 	};
 }

--- a/src/state/workspace-state.ts
+++ b/src/state/workspace-state.ts
@@ -500,6 +500,27 @@ function detectGitRepositoryInfo(repoPath: string): RuntimeGitRepositoryInfo {
 	};
 }
 
+export function detectGitRemoteOriginUrl(repoPath: string): string | null {
+	return runGitCapture(repoPath, ["config", "--get", "remote.origin.url"]);
+}
+
+export function detectGitRemoteVcs(repoPath: string): "github" | "gerrit" | "local" | undefined {
+	const remoteUrl = detectGitRemoteOriginUrl(repoPath);
+	if (!remoteUrl) {
+		return "local";
+	}
+
+	if (/github\.com/i.test(remoteUrl)) {
+		return "github";
+	}
+
+	if (/(?:^|[:/@])gerrit/i.test(remoteUrl) || /\/a\//i.test(remoteUrl)) {
+		return "gerrit";
+	}
+
+	return undefined;
+}
+
 async function resolveWorkspacePath(cwd: string): Promise<string> {
 	const resolvedCwd = resolve(cwd);
 	let canonicalCwd = resolvedCwd;

--- a/web-ui/src/components/project-navigation-panel.test.tsx
+++ b/web-ui/src/components/project-navigation-panel.test.tsx
@@ -31,6 +31,7 @@ const PROJECTS: RuntimeProjectSummary[] = [
 		id: "project-1",
 		name: "Kanban",
 		path: "/tmp/kanban",
+		vcs: "local",
 		taskCounts: {
 			backlog: 0,
 			in_progress: 0,
@@ -194,6 +195,11 @@ describe("ProjectNavigationPanel width persistence", () => {
 		renderPanel();
 		expect(container.textContent).toContain("Kanban is in beta. Help us improve by sharing your experience.");
 		expect(container.textContent).toContain("Report issue");
+	});
+
+	it("shows a repository provider badge for Local projects", () => {
+		renderPanel();
+		expect(container.textContent).toContain("Local");
 	});
 
 	it("shows send feedback instead of report issue when Cline OAuth is available", () => {

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -20,7 +20,7 @@ import { Kbd } from "@/components/ui/kbd";
 import { Spinner } from "@/components/ui/spinner";
 import type { FeaturebaseFeedbackState } from "@/hooks/use-featurebase-feedback-widget";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import type { RuntimeAgentId, RuntimeClineProviderSettings, RuntimeProjectSummary } from "@/runtime/types";
+import type { RuntimeAgentId, RuntimeClineProviderSettings, RuntimeProjectSummary, RuntimeProjectVcs } from "@/runtime/types";
 import {
 	LocalStorageKey,
 	readLocalStorageItem,
@@ -44,6 +44,18 @@ interface TaskCountBadge {
 	toneClassName: string;
 	count: number;
 }
+
+const PROJECT_VCS_BADGE_LABELS: Record<RuntimeProjectVcs, string> = {
+	github: "GitHub",
+	gerrit: "Gerrit",
+	local: "Local",
+};
+
+const PROJECT_VCS_BADGE_CLASS_NAMES: Record<RuntimeProjectVcs, string> = {
+	github: "bg-blue-100 text-blue-800 border border-blue-200",
+	gerrit: "bg-amber-100 text-amber-900 border border-amber-200",
+	local: "bg-slate-100 text-slate-700 border border-slate-200",
+};
 
 export function ProjectNavigationPanel({
 	projects,
@@ -705,6 +717,16 @@ function ProjectRow({
 	const isRemovingProject = removingProjectId === project.id;
 	const hasAnyProjectRemoval = removingProjectId !== null;
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
+	const vcsBadge = project.vcs ? (
+		<span
+			className={cn(
+				"inline-flex items-center justify-center rounded-sm px-0.5 py-[1px] text-[8px] font-semibold uppercase tracking-[0.02em] leading-none",
+				PROJECT_VCS_BADGE_CLASS_NAMES[project.vcs],
+			)}
+		>
+			{PROJECT_VCS_BADGE_LABELS[project.vcs]}
+		</span>
+	) : null;
 	const taskCountBadges: TaskCountBadge[] = [
 		{
 			id: "backlog",
@@ -772,6 +794,7 @@ function ProjectRow({
 				>
 					{displayPath}
 				</div>
+				{vcsBadge ? <div className="mt-1 flex flex-wrap gap-1">{vcsBadge}</div> : null}
 				{taskCountBadges.length > 0 ? (
 					<div className="flex gap-1 mt-1">
 						{taskCountBadges.map((badge) => (


### PR DESCRIPTION
<img width="1125" height="912" alt="VcsBadge" src="https://github.com/user-attachments/assets/b19808f3-8236-4490-b3c1-0191ab4b3f9d" />


Added VCS badging for projects in the Kanban view: GitHub-sourced projects now show a GitHub badge, while local workspace projects display a Local badge.