### PR TITLE
feat(web-ui): let the agent panel expand to the full detail view width

### DIFF
--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -22,8 +22,12 @@ const {
 	mockClineSendText: vi.fn(async () => {}),
 }));
 
+const mockUseHotkeys = vi.fn();
+
 vi.mock("react-hotkeys-hook", () => ({
-	useHotkeys: () => {},
+	useHotkeys: (...args: unknown[]) => {
+		mockUseHotkeys(...args);
+	},
 }));
 
 vi.mock("@/hooks/use-is-mobile", () => ({
@@ -149,6 +153,23 @@ function requireAgentPanel(container: HTMLElement): HTMLElement {
 	return panel;
 }
 
+function requireDiffPanel(container: HTMLElement): HTMLElement {
+	const separator = requireResizeSeparator(container);
+	const panel = separator.nextElementSibling;
+	if (!(panel instanceof HTMLElement)) {
+		throw new Error("Expected a diff panel element.");
+	}
+	return panel;
+}
+
+function requireExpandAgentButton(container: HTMLElement): HTMLButtonElement {
+	const button = container.querySelector('button[aria-label="Expand agent view to full width"]');
+	if (!(button instanceof HTMLButtonElement)) {
+		throw new Error("Expected an expand agent button.");
+	}
+	return button;
+}
+
 function requireDetailDiffSeparator(container: HTMLElement): HTMLElement {
 	const separator = container.querySelector('[aria-label="Resize detail diff panels"]');
 	if (!(separator instanceof HTMLElement)) {
@@ -173,6 +194,7 @@ describe("CardDetailView", () => {
 
 	beforeEach(() => {
 		window.localStorage.clear();
+		mockUseHotkeys.mockClear();
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -775,5 +797,217 @@ describe("CardDetailView", () => {
 		});
 
 		expect(requireDetailDiffFileTreePanel(container).style.flex).toBe("0 0 18%");
+	});
+
+	it("gives the agent panel the full width and hides both side panels when expanded", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const agentPanel = requireAgentPanel(container);
+		const diffPanel = requireDiffPanel(container);
+		expect(agentPanel.style.width).not.toBe("100%");
+		expect(container.querySelector('[aria-label="Resize task cards and detail panels"]')).toBeInstanceOf(HTMLElement);
+
+		await act(async () => {
+			requireExpandAgentButton(container).click();
+		});
+
+		expect(agentPanel.style.width).toBe("100%");
+		expect(agentPanel.style.display).toBe("flex");
+		expect(diffPanel.style.display).toBe("none");
+		// Both side panels are gone: the task cards column unmounts and the diff column is hidden.
+		expect(container.querySelector('[aria-label="Resize task cards and detail panels"]')).toBeNull();
+		expect(container.querySelector('[aria-label="Resize agent and diff panels"]')).toBeNull();
+		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeNull();
+		expect(container.querySelector('button[aria-label="Collapse full width agent view"]')).toBeInstanceOf(
+			HTMLButtonElement,
+		);
+	});
+
+	it("restores the side panels when the expanded agent panel is collapsed again", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			requireExpandAgentButton(container).click();
+		});
+
+		const collapseButton = container.querySelector('button[aria-label="Collapse full width agent view"]');
+		if (!(collapseButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected a collapse agent button.");
+		}
+
+		await act(async () => {
+			collapseButton.click();
+		});
+
+		expect(requireAgentPanel(container).style.width).not.toBe("100%");
+		expect(requireDiffPanel(container).style.display).toBe("flex");
+		expect(container.querySelector('[aria-label="Resize task cards and detail panels"]')).toBeInstanceOf(HTMLElement);
+		expect(container.querySelector('button[aria-label="Expand split diff view"]')).toBeInstanceOf(HTMLButtonElement);
+	});
+
+	it("collapses the expanded agent panel on Escape without closing the detail view", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			requireExpandAgentButton(container).click();
+		});
+
+		expect(container.querySelector('button[aria-label="Collapse full width agent view"]')).toBeInstanceOf(
+			HTMLButtonElement,
+		);
+
+		await act(async () => {
+			window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+		});
+
+		expect(container.querySelector('button[aria-label="Collapse full width agent view"]')).toBeNull();
+		expect(requireExpandAgentButton(container)).toBeInstanceOf(HTMLButtonElement);
+	});
+
+	it("toggles the expanded agent panel with the mod+shift+f hotkey", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const registration = mockUseHotkeys.mock.calls.find((call) => call[0] === "mod+shift+f");
+		expect(registration).toBeDefined();
+
+		// The chat composer holds focus for most of a task, so the shortcut has to survive form tags.
+		expect(registration?.[2]).toMatchObject({
+			enableOnContentEditable: true,
+			enableOnFormTags: true,
+			preventDefault: true,
+		});
+
+		const pressToggleHotkey = async (): Promise<void> => {
+			const handler = mockUseHotkeys.mock.calls.find((call) => call[0] === "mod+shift+f")?.[1] as () => void;
+			await act(async () => {
+				handler();
+			});
+		};
+
+		// Captured up front: expanding removes the separator these lookups walk from.
+		const agentPanel = requireAgentPanel(container);
+
+		await pressToggleHotkey();
+		expect(agentPanel.style.width).toBe("100%");
+
+		await pressToggleHotkey();
+		expect(agentPanel.style.width).not.toBe("100%");
+		expect(requireAgentPanel(container)).toBe(agentPanel);
+	});
+
+	it("expands only one panel at a time when switching from the agent panel to the diff panel", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					sessionSummary={null}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		const agentPanel = requireAgentPanel(container);
+		const diffPanel = requireDiffPanel(container);
+
+		await act(async () => {
+			requireExpandAgentButton(container).click();
+		});
+		expect(agentPanel.style.width).toBe("100%");
+
+		// Collapse the agent panel first, then expand the diff panel from the restored toolbar.
+		await act(async () => {
+			window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+		});
+
+		const expandDiffButton = container.querySelector('button[aria-label="Expand split diff view"]');
+		if (!(expandDiffButton instanceof HTMLButtonElement)) {
+			throw new Error("Expected an expand diff button.");
+		}
+
+		await act(async () => {
+			expandDiffButton.click();
+		});
+
+		expect(diffPanel.style.width).toBe("100%");
+		expect(diffPanel.style.display).toBe("flex");
+		expect(agentPanel.style.display).toBe("none");
+		expect(container.querySelector('button[aria-label="Expand agent view to full width"]')).toBeNull();
 	});
 });

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -196,6 +196,12 @@ function WorkspaceChangesEmptyPanel({ title }: { title: string }): React.ReactEl
 
 type MobileTab = "chat" | "diff" | "files";
 
+// At most one side-by-side detail panel can own the full width at a time, so the
+// expanded panel is modelled as a single exclusive value rather than one flag per panel.
+type ExpandedDetailPanel = "agent" | "diff" | null;
+
+const TOGGLE_EXPANDED_PANEL_HOTKEY = "mod+shift+f";
+
 const MOBILE_TABS: { id: MobileTab; label: string; icon: React.ReactElement }[] = [
 	{ id: "chat", label: "Chat", icon: <MessageSquare size={14} /> },
 	{ id: "diff", label: "Diff", icon: <GitCompareArrows size={14} /> },
@@ -304,6 +310,27 @@ function DiffToolbar({
 					aria-label={isExpanded ? "Collapse split diff view" : "Expand split diff view"}
 				/>
 			) : null}
+		</div>
+	);
+}
+
+function AgentToolbar({
+	isExpanded,
+	onToggleExpand,
+}: {
+	isExpanded: boolean;
+	onToggleExpand: () => void;
+}): React.ReactElement {
+	return (
+		<div className="flex items-center gap-1 border-b border-divider px-2 py-1">
+			<Button
+				variant="ghost"
+				size="sm"
+				icon={isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+				onClick={onToggleExpand}
+				className="ml-auto h-5"
+				aria-label={isExpanded ? "Collapse full width agent view" : "Expand agent view to full width"}
+			/>
 		</div>
 	);
 }
@@ -439,7 +466,9 @@ export function CardDetailView({
 	const [selectedPath, setSelectedPath] = useState<string | null>(null);
 	const [diffComments, setDiffComments] = useState<Map<string, DiffLineComment>>(new Map());
 	const [diffMode, setDiffMode] = useState<RuntimeWorkspaceChangesMode>("working_copy");
-	const [isDiffExpanded, setIsDiffExpanded] = useState(false);
+	const [expandedPanel, setExpandedPanel] = useState<ExpandedDetailPanel>(null);
+	const isDiffExpanded = expandedPanel === "diff";
+	const isAgentExpanded = expandedPanel === "agent";
 	const {
 		taskCardsPanelRatio,
 		setTaskCardsPanelRatio,
@@ -564,12 +593,12 @@ export function CardDetailView({
 				if (isTypingTarget(event.target)) {
 					return;
 				}
-				if (isDiffExpanded) {
+				if (expandedPanel) {
 					event.preventDefault();
-					setIsDiffExpanded(false);
+					setExpandedPanel(null);
 				}
 			},
-			[gitHistoryPanel, isDiffExpanded, onCloseGitHistory],
+			[expandedPanel, gitHistoryPanel, onCloseGitHistory],
 		),
 	);
 
@@ -601,32 +630,53 @@ export function CardDetailView({
 		if (!isDiffExpanded && bottomTerminalOpen) {
 			onBottomTerminalClose();
 		}
-		setIsDiffExpanded((previous) => !previous);
+		setExpandedPanel((previous) => (previous === "diff" ? null : "diff"));
 	}, [bottomTerminalOpen, isDiffExpanded, onBottomTerminalClose]);
+
+	const handleToggleAgentExpand = useCallback(() => {
+		setExpandedPanel((previous) => (previous === "agent" ? null : "agent"));
+	}, []);
+
+	useHotkeys(
+		TOGGLE_EXPANDED_PANEL_HOTKEY,
+		handleToggleAgentExpand,
+		{
+			enableOnFormTags: true,
+			enableOnContentEditable: true,
+			preventDefault: true,
+		},
+		[handleToggleAgentExpand],
+	);
+
+	// Only the diff panel opts out of expansion here; collapsing the agent panel from a
+	// diff interaction would hide a panel the user never expanded from this surface.
+	const collapseExpandedDiff = useCallback(() => {
+		setExpandedPanel((previous) => (previous === "diff" ? null : previous));
+	}, []);
 
 	const handleAddDiffComments = useCallback(
 		(formatted: string) => {
 			if (showClineAgentChatPanel) {
 				clineAgentChatPanelRef.current?.appendToDraft(formatted);
-				setIsDiffExpanded(false);
+				collapseExpandedDiff();
 				return;
 			}
 			onAddReviewComments?.(selection.card.id, formatted);
 		},
-		[onAddReviewComments, selection.card.id, showClineAgentChatPanel],
+		[collapseExpandedDiff, onAddReviewComments, selection.card.id, showClineAgentChatPanel],
 	);
 
 	const handleSendDiffComments = useCallback(
 		(formatted: string) => {
 			if (showClineAgentChatPanel) {
 				void clineAgentChatPanelRef.current?.sendText(formatted);
-				setIsDiffExpanded(false);
+				collapseExpandedDiff();
 				return;
 			}
 			onSendReviewComments?.(selection.card.id, formatted);
-			setIsDiffExpanded(false);
+			collapseExpandedDiff();
 		},
-		[onSendReviewComments, selection.card.id, showClineAgentChatPanel],
+		[collapseExpandedDiff, onSendReviewComments, selection.card.id, showClineAgentChatPanel],
 	);
 
 	const showBottomTerminal = bottomTerminalOpen && !!bottomTerminalTaskId;
@@ -796,7 +846,7 @@ export function CardDetailView({
 
 	return (
 		<div ref={detailLayoutRef} className="flex min-h-0 flex-1 overflow-hidden bg-surface-0">
-			{!isDiffExpanded ? (
+			{!expandedPanel ? (
 				<>
 					<div className="flex min-h-0 min-w-0" style={{ width: taskCardsPanelPercent }}>
 						<ColumnContextPanel
@@ -834,7 +884,7 @@ export function CardDetailView({
 			) : null}
 			<div
 				className="flex min-h-0 min-w-0 flex-col overflow-hidden"
-				style={{ width: isDiffExpanded ? "100%" : detailContentPanelPercent }}
+				style={{ width: expandedPanel ? "100%" : detailContentPanelPercent }}
 			>
 				{gitHistoryPanel ? (
 					<div className="flex min-h-0 flex-1 overflow-hidden">{gitHistoryPanel}</div>
@@ -842,12 +892,18 @@ export function CardDetailView({
 					<>
 						<div ref={mainRowRef} className="flex min-h-0 flex-1 overflow-hidden">
 							<div
-								className="min-h-0 min-w-0"
-								style={{ display: isDiffExpanded ? "none" : "flex", width: agentPanelPercent }}
+								className="min-h-0 min-w-0 flex-col"
+								style={{
+									display: isDiffExpanded ? "none" : "flex",
+									width: isAgentExpanded ? "100%" : agentPanelPercent,
+								}}
 							>
-								{agentChatPanel}
+								{!isDiffExpanded ? (
+									<AgentToolbar isExpanded={isAgentExpanded} onToggleExpand={handleToggleAgentExpand} />
+								) : null}
+								<div className="flex min-h-0 min-w-0 flex-1">{agentChatPanel}</div>
 							</div>
-							{!isDiffExpanded ? (
+							{!expandedPanel ? (
 								<ResizeHandle
 									orientation="vertical"
 									ariaLabel="Resize agent and diff panels"
@@ -856,10 +912,13 @@ export function CardDetailView({
 								/>
 							) : null}
 							<div
-								className="flex min-h-0 min-w-0 flex-col"
-								style={{ width: isDiffExpanded ? "100%" : diffPanelPercent }}
+								className="min-h-0 min-w-0 flex-col"
+								style={{
+									display: isAgentExpanded ? "none" : "flex",
+									width: isDiffExpanded ? "100%" : diffPanelPercent,
+								}}
 							>
-								{isRuntimeAvailable ? (
+								{isRuntimeAvailable && !isAgentExpanded ? (
 									<DiffToolbar
 										mode={diffMode}
 										onModeChange={setDiffMode}

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -601,6 +601,7 @@ const MORE_SHORTCUTS = [
 	{ keys: [MOD, "Shift", "A"], label: "Toggle plan / act" },
 	{ keys: [ALT, "Shift", "Enter"], label: "Start and open task" },
 	{ keys: [MOD, "M"], label: "Expand terminal" },
+	{ keys: [MOD, "Shift", "F"], label: "Expand agent panel" },
 	{ keys: ["Esc"], label: "Close / back" },
 ];
 


### PR DESCRIPTION
## Summary

The task detail view can only maximize its **right-hand** column today. `DiffToolbar` has an expand control that gives the diff panel 100% width, but the agent chat in the **middle** has no equivalent — there is no way from the UI to reclaim the space taken by the task cards column on the left and the diff panel on the right.

This adds the mirror-image control, so the middle column can take the full width.

```
before                                  after (agent expanded)
┌────────┬──────────────┬────────────┐  ┌────────────────────────────────────┐
│ Task   │  Agent chat  │ Diff   [⤢] │  │         Agent chat        [⤡]      │
│ cards  │  (no way to  │ + tree     │  │         full width                 │
│ list   │   maximize)  │            │  │                                    │
└────────┴──────────────┴────────────┘  └────────────────────────────────────┘
```

## What changed

- **Exclusive expansion state.** `isDiffExpanded: boolean` becomes `expandedPanel: "agent" | "diff" | null`. Two independent booleans would allow an invalid "both expanded" state; the union makes that unrepresentable. `isDiffExpanded` / `isAgentExpanded` are derived, so existing call sites are untouched.
- **`AgentToolbar`** above the agent chat: a `Maximize2` / `Minimize2` ghost button reusing `DiffToolbar`'s exact styling (`border-b border-divider px-2 py-1`, `ml-auto h-5`). Side benefit — the agent and diff columns' content tops now line up.
- **`⌘⇧F` / `Ctrl+Shift+F`** toggles it, registered with `enableOnFormTags` + `enableOnContentEditable` so it works while the chat composer holds focus. Registered locally in `card-detail-view.tsx` (where the state lives) rather than threading a callback through `App.tsx`.
- **Escape** now collapses whichever panel is expanded, extending the existing handler.
- Shortcut listed in the keyboard shortcuts reference panel.

When the agent panel is expanded, the task cards column unmounts and the diff column is hidden with `display: none` — the same technique the existing diff expansion already uses for the agent panel, so chat and diff scroll state survive the toggle.

## Why `mod+shift+f`

`mod+b`, `mod+j`, `mod+m`, `mod+g`, `mod+shift+s` and `c` are taken. `mod+e` is avoided because #344 proposes it for the project sidebar. `f` = full width.

## Relationship to existing PRs

- #43 makes the diff panel collapsible so the agent panel grows. It does **not** collapse the task cards column, so it does not produce a full-width middle. If #43 lands first this will need a small rebase onto its collapsed-diff state.
- #344 adds a sidebar toggle on the **home** view; no overlap with the detail view.

## Test plan

Six new tests in `card-detail-view.test.tsx` (20 total in the file, all passing):

- [x] Expanding gives the agent panel `width: 100%`, unmounts the task cards column, hides the diff column, and removes both resize handles
- [x] Collapsing restores both side panels and the diff toolbar
- [x] Escape collapses the expanded agent panel without closing the detail view
- [x] `mod+shift+f` is registered with the form-tag/contenteditable options and toggles both ways
- [x] Only one panel is expanded at a time when switching agent → diff
- [x] Existing diff-expansion, panel-ratio and diff-comment tests unchanged

Verified locally:

- `npx vitest run` — 70 files, 503 tests passing
- `npm run typecheck` — clean
- `npm run lint` — clean (398 files)
- `npm run build` — clean
- Pre-commit hook (biome + root typecheck + `test:fast`, 549 tests) — passing

Note: the toolbar is desktop-only; the mobile layout already uses tabs and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)