### PR TITLE
fix(terminal): cap scrollback and cache/chunk restore (fixes #581)

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -1177,6 +1177,7 @@ export const runtimeTerminalWsRestoreMessageSchema = z.object({
 	snapshot: z.string(),
 	cols: z.number().int().positive().nullable().optional(),
 	rows: z.number().int().positive().nullable().optional(),
+	restoreGeneration: z.number().int().positive().optional(),
 });
 export type RuntimeTerminalWsRestoreMessage = z.infer<typeof runtimeTerminalWsRestoreMessageSchema>;
 

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -67,6 +67,7 @@ interface SessionEntry {
 	summary: RuntimeTaskSessionSummary;
 	active: ActiveProcessState | null;
 	terminalStateMirror: TerminalStateMirror | null;
+	restoreGeneration: number;
 	listenerIdCounter: number;
 	listeners: Map<number, TerminalSessionListener>;
 	restartRequest: RestartableSessionRequest | null;
@@ -248,6 +249,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 				summary: cloneSummary(summary),
 				active: null,
 				terminalStateMirror: null,
+				restoreGeneration: 0,
 				listenerIdCounter: 1,
 				listeners: new Map(),
 				restartRequest: null,
@@ -289,7 +291,11 @@ export class TerminalSessionManager implements TerminalSessionService {
 		if (!entry?.terminalStateMirror) {
 			return null;
 		}
-		return await entry.terminalStateMirror.getSnapshot();
+		const snapshot = await entry.terminalStateMirror.getSnapshot();
+		return {
+			...snapshot,
+			restoreGeneration: entry.restoreGeneration,
+		};
 	}
 
 	async startTaskSession(request: StartTaskSessionRequest): Promise<RuntimeTaskSessionSummary> {
@@ -528,6 +534,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		};
 		entry.active = active;
 		entry.terminalStateMirror = terminalStateMirror;
+		entry.restoreGeneration += 1;
 
 		const startedAt = now();
 		updateSummary(entry, {
@@ -681,6 +688,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		};
 		entry.active = active;
 		entry.terminalStateMirror = terminalStateMirror;
+		entry.restoreGeneration += 1;
 
 		updateSummary(entry, {
 			state: "running",
@@ -968,6 +976,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			summary: createDefaultSummary(taskId),
 			active: null,
 			terminalStateMirror: null,
+			restoreGeneration: 0,
 			listenerIdCounter: 1,
 			listeners: new Map(),
 			restartRequest: null,

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -4,7 +4,17 @@ import headlessTerminalModule from "@xterm/headless";
 const { SerializeAddon } = serializeAddonModule as typeof import("@xterm/addon-serialize");
 const { Terminal } = headlessTerminalModule as typeof import("@xterm/headless");
 
-const TERMINAL_SCROLLBACK = 10_000;
+/**
+ * Server-side headless terminal scrollback.
+ *
+ * Kept deliberately small because the entire buffer is serialized via
+ * `serializeAddon.serialize()` and shipped over the WebSocket on every
+ * viewer connect (task switch). A 10,000-line buffer caused ~60s main-thread
+ * freezes (#581) and RSS spikes toward OOM (#273) during long agent runs.
+ * 1,000 lines is enough to show recent output while keeping the restore
+ * snapshot ~10x smaller.
+ */
+const TERMINAL_SCROLLBACK = 1_000;
 
 export interface TerminalRestoreSnapshot {
 	snapshot: string;

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -18,6 +18,7 @@ export interface TerminalRestoreSnapshot {
 	snapshot: string;
 	cols: number;
 	rows: number;
+	restoreGeneration?: number;
 }
 
 interface TerminalStateMirrorOptions {

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -5,14 +5,12 @@ const { SerializeAddon } = serializeAddonModule as typeof import("@xterm/addon-s
 const { Terminal } = headlessTerminalModule as typeof import("@xterm/headless");
 
 /**
- * Server-side headless terminal scrollback.
+ * Server-side headless terminal buffer cap (1,000 lines).
  *
- * Kept deliberately small because the entire buffer is serialized via
- * `serializeAddon.serialize()` and shipped over the WebSocket on every
- * viewer connect (task switch). A 10,000-line buffer caused ~60s main-thread
- * freezes (#581) and RSS spikes toward OOM (#273) during long agent runs.
- * 1,000 lines is enough to show recent output while keeping the restore
- * snapshot ~10x smaller.
+ * Restore serves a cached full `serialize()` of this buffer, not a viewport-only
+ * slice. Output and resize mark the cache dirty; connect does not serialize on
+ * every keystroke. A 10,000-line buffer caused ~60s main-thread freezes (#581)
+ * and RSS spikes toward OOM (#273) during long agent runs.
  */
 const TERMINAL_SCROLLBACK = 1_000;
 
@@ -30,6 +28,8 @@ export class TerminalStateMirror {
 	private readonly terminal: InstanceType<typeof Terminal>;
 	private readonly serializeAddon = new SerializeAddon();
 	private operationQueue: Promise<void> = Promise.resolve();
+	private snapshotDirty = true;
+	private cachedSnapshot: TerminalRestoreSnapshot | null = null;
 
 	constructor(cols: number, rows: number, options: TerminalStateMirrorOptions = {}) {
 		this.terminal = new Terminal({
@@ -50,6 +50,7 @@ export class TerminalStateMirror {
 			() =>
 				new Promise<void>((resolve) => {
 					this.terminal.write(chunkCopy, () => {
+						this.snapshotDirty = true;
 						resolve();
 					});
 				}),
@@ -62,16 +63,23 @@ export class TerminalStateMirror {
 		}
 		this.enqueueOperation(() => {
 			this.terminal.resize(cols, rows);
+			this.snapshotDirty = true;
 		});
 	}
 
 	async getSnapshot(): Promise<TerminalRestoreSnapshot> {
 		await this.operationQueue;
-		return {
+		if (!this.snapshotDirty && this.cachedSnapshot) {
+			return this.cachedSnapshot;
+		}
+		// Full serialize of the 1k buffer. Callers must not pass { scrollback: 0 }.
+		this.cachedSnapshot = {
 			snapshot: this.serializeAddon.serialize(),
 			cols: this.terminal.cols,
 			rows: this.terminal.rows,
 		};
+		this.snapshotDirty = false;
+		return this.cachedSnapshot;
 	}
 
 	dispose(): void {

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -503,6 +503,7 @@ export function createTerminalWebSocketBridge({
 					snapshot: snapshot?.snapshot ?? "",
 					cols: snapshot?.cols ?? null,
 					rows: snapshot?.rows ?? null,
+					restoreGeneration: snapshot?.restoreGeneration,
 				});
 			})
 			.catch(() => {

--- a/test/runtime/terminal/session-manager-auto-restart.test.ts
+++ b/test/runtime/terminal/session-manager-auto-restart.test.ts
@@ -195,4 +195,34 @@ describe("TerminalSessionManager auto-restart", () => {
 		expect(session.write).toHaveBeenCalledWith(deferredStartupInput);
 		expect(session.write).toHaveBeenCalledTimes(1);
 	});
+
+	it("keeps restoreGeneration for one live PTY and increments on a new start", async () => {
+		const spawnedSessions: Array<ReturnType<typeof createMockPtySession>> = [];
+		ptySessionSpawnMock.mockImplementation((request: MockSpawnRequest) => {
+			const session = createMockPtySession(111, request);
+			spawnedSessions.push(session);
+			return session;
+		});
+
+		const manager = new TerminalSessionManager();
+		const startRequest = {
+			taskId: "task-1",
+			agentId: "codex" as const,
+			binary: "codex",
+			args: [],
+			cwd: "/tmp/task-1",
+			prompt: "Fix the bug",
+		};
+
+		await manager.startTaskSession(startRequest);
+		const first = await manager.getRestoreSnapshot("task-1");
+		const second = await manager.getRestoreSnapshot("task-1");
+		expect(first?.restoreGeneration).toBe(1);
+		expect(second?.restoreGeneration).toBe(1);
+
+		spawnedSessions[0]?.triggerExit(0);
+		await manager.startTaskSession(startRequest);
+		const third = await manager.getRestoreSnapshot("task-1");
+		expect(third?.restoreGeneration).toBe(2);
+	});
 });

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -216,6 +216,7 @@ describe("TerminalSessionManager", () => {
 			terminalStateMirror: {
 				getSnapshot: getSnapshotSpy,
 			},
+			restoreGeneration: 7,
 			listenerIdCounter: 1,
 			listeners: new Map(),
 		};
@@ -231,6 +232,7 @@ describe("TerminalSessionManager", () => {
 			snapshot: "serialized terminal",
 			cols: 120,
 			rows: 40,
+			restoreGeneration: 7,
 		});
 		expect(getSnapshotSpy).toHaveBeenCalledTimes(1);
 	});

--- a/test/runtime/terminal/terminal-state-mirror.test.ts
+++ b/test/runtime/terminal/terminal-state-mirror.test.ts
@@ -67,4 +67,53 @@ describe("TerminalStateMirror", () => {
 
 		expect(onInputResponse).toHaveBeenCalledWith("\u001b[1;1R");
 	});
+
+	it("keeps lines above the viewport in the restore snapshot", async () => {
+		const rows = 8;
+		const mirror = createMirror(40, rows);
+		const lines = Array.from({ length: rows + 12 }, (_, i) => `line-${i}`);
+		mirror.applyOutput(Buffer.from(`${lines.join("\r\n")}\r\n`, "utf8"));
+
+		const snapshot = await mirror.getSnapshot();
+
+		expect(snapshot.snapshot).toContain("line-0");
+		expect(snapshot.snapshot).toContain(`line-${rows + 11}`);
+	});
+
+	it("reuses the restore snapshot when nothing has been written or resized", async () => {
+		const mirror = createMirror();
+		mirror.applyOutput(Buffer.from("stable-output\r\n", "utf8"));
+
+		const first = await mirror.getSnapshot();
+		const second = await mirror.getSnapshot();
+
+		expect(second).toBe(first);
+		expect(second.snapshot).toContain("stable-output");
+	});
+
+	it("rebuilds the restore snapshot after new output", async () => {
+		const mirror = createMirror();
+		mirror.applyOutput(Buffer.from("before-output\r\n", "utf8"));
+		const first = await mirror.getSnapshot();
+
+		mirror.applyOutput(Buffer.from("after-output\r\n", "utf8"));
+		const second = await mirror.getSnapshot();
+
+		expect(second).not.toBe(first);
+		expect(second.snapshot).toContain("before-output");
+		expect(second.snapshot).toContain("after-output");
+	});
+
+	it("rebuilds the restore snapshot after a resize", async () => {
+		const mirror = createMirror(80, 24);
+		mirror.applyOutput(Buffer.from("before-resize\r\n", "utf8"));
+		const first = await mirror.getSnapshot();
+
+		mirror.resize(120, 40);
+		const second = await mirror.getSnapshot();
+
+		expect(second).not.toBe(first);
+		expect(second.cols).toBe(120);
+		expect(second.rows).toBe(40);
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -47,6 +47,7 @@ function rawDataToBuffer(data: RawData): Buffer {
 
 class FakeTerminalManager implements TerminalSessionService {
 	private readonly listenersByTaskId = new Map<string, Set<TerminalSessionListener>>();
+	restoreGeneration = 1;
 
 	attach(taskId: string, listener: TerminalSessionListener): (() => void) | null {
 		const listeners = this.listenersByTaskId.get(taskId) ?? new Set<TerminalSessionListener>();
@@ -66,8 +67,13 @@ class FakeTerminalManager implements TerminalSessionService {
 			snapshot: "",
 			cols: 80,
 			rows: 24,
+			restoreGeneration: this.restoreGeneration,
 		}),
 	);
+
+	beginNewSession(): void {
+		this.restoreGeneration += 1;
+	}
 	recoverStaleSession = vi.fn(() => createSummary());
 	writeInput = vi.fn(() => createSummary());
 	resize = vi.fn(() => true);
@@ -463,5 +469,45 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(controlSocketA.socket);
 		await closeSocket(ioSocketB.socket);
 		await closeSocket(controlSocketB.socket);
+	});
+
+	it("includes restoreGeneration on restore and keeps it for the same session", async () => {
+		const controlUrl = `${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-a`;
+
+		const first = await openQueuedWebSocket(controlUrl);
+		const restoreA = await waitForControlMessage(first, (message) => message.type === "restore");
+		expect(restoreA).toMatchObject({
+			type: "restore",
+			restoreGeneration: 1,
+		});
+		await closeSocket(first.socket);
+
+		const second = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-b`,
+		);
+		const restoreB = await waitForControlMessage(second, (message) => message.type === "restore");
+		expect(restoreB).toMatchObject({
+			type: "restore",
+			restoreGeneration: 1,
+		});
+		await closeSocket(second.socket);
+	});
+
+	it("sends a higher restoreGeneration after a new session starts", async () => {
+		const first = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-a`,
+		);
+		const restoreA = await waitForControlMessage(first, (message) => message.type === "restore");
+		expect(restoreA).toMatchObject({ type: "restore", restoreGeneration: 1 });
+		await closeSocket(first.socket);
+
+		terminalManager.beginNewSession();
+
+		const second = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-b`,
+		);
+		const restoreB = await waitForControlMessage(second, (message) => message.type === "restore");
+		expect(restoreB).toMatchObject({ type: "restore", restoreGeneration: 2 });
+		await closeSocket(second.socket);
 	});
 });

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -12,6 +12,7 @@ import type {
 	RuntimeTerminalWsClientMessage,
 	RuntimeTerminalWsServerMessage,
 } from "@/runtime/types";
+import { type AppliedRestore, shouldSkipWarmRestore } from "@/terminal/restore-generation";
 import { splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
 import { clearTerminalGeometry, reportTerminalGeometry } from "@/terminal/terminal-geometry-registry";
 import { createKanbanTerminalOptions } from "@/terminal/terminal-options";
@@ -162,6 +163,7 @@ class PersistentTerminal {
 	private restoreCompleted = false;
 	private outputTextDecoder = new TextDecoder();
 	private terminalWriteQueue: Promise<void> = Promise.resolve();
+	private lastRestore: AppliedRestore | null = null;
 	private disposed = false;
 
 	constructor(
@@ -314,18 +316,23 @@ class PersistentTerminal {
 		snapshot: string,
 		cols: number | null | undefined,
 		rows: number | null | undefined,
+		restoreGeneration?: number,
 	): Promise<void> {
+		if (shouldSkipWarmRestore(this.lastRestore, { restoreGeneration, cols, rows })) {
+			return;
+		}
 		await this.terminalWriteQueue.catch(() => undefined);
 		this.terminal.reset();
 		if (cols && rows && (this.terminal.cols !== cols || this.terminal.rows !== rows)) {
 			this.terminal.resize(cols, rows);
 		}
-		if (!snapshot) {
-			return;
+		if (snapshot) {
+			for (const chunk of splitRestoreSnapshot(snapshot)) {
+				await this.enqueueTerminalWrite(chunk);
+			}
 		}
-		for (const chunk of splitRestoreSnapshot(snapshot)) {
-			await this.enqueueTerminalWrite(chunk);
-		}
+		this.lastRestore =
+			restoreGeneration !== undefined && cols && rows ? { generation: restoreGeneration, cols, rows } : null;
 	}
 
 	private requestResize(): void {
@@ -424,7 +431,7 @@ class PersistentTerminal {
 
 			if (payload.type === "restore") {
 				this.restoreCompleted = false;
-				void this.applyRestore(payload.snapshot, payload.cols, payload.rows)
+				void this.applyRestore(payload.snapshot, payload.cols, payload.rows, payload.restoreGeneration)
 					.then(() => {
 						if (this.disposed || this.controlSocket !== controlSocket) {
 							return;
@@ -694,6 +701,7 @@ class PersistentTerminal {
 		this.ioSocket = null;
 		this.controlSocket = null;
 		this.subscribers.clear();
+		this.lastRestore = null;
 		this.terminal.dispose();
 		this.hostElement.remove();
 	}

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -12,6 +12,7 @@ import type {
 	RuntimeTerminalWsClientMessage,
 	RuntimeTerminalWsServerMessage,
 } from "@/runtime/types";
+import { splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
 import { clearTerminalGeometry, reportTerminalGeometry } from "@/terminal/terminal-geometry-registry";
 import { createKanbanTerminalOptions } from "@/terminal/terminal-options";
 import {
@@ -322,7 +323,9 @@ class PersistentTerminal {
 		if (!snapshot) {
 			return;
 		}
-		await this.enqueueTerminalWrite(snapshot);
+		for (const chunk of splitRestoreSnapshot(snapshot)) {
+			await this.enqueueTerminalWrite(chunk);
+		}
 	}
 
 	private requestResize(): void {

--- a/web-ui/src/terminal/restore-generation.test.ts
+++ b/web-ui/src/terminal/restore-generation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipWarmRestore } from "@/terminal/restore-generation";
+
+const lastRestore = { generation: 3, cols: 80, rows: 24 };
+
+describe("shouldSkipWarmRestore", () => {
+	it("skips when generation and size already match the last apply", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 3,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(true);
+	});
+
+	it("applies when the restore generation is newer", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 4,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when cols or rows changed for the same generation", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 3,
+				cols: 120,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when the server omitted restoreGeneration", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when this viewer has not restored yet", () => {
+		expect(
+			shouldSkipWarmRestore(null, {
+				restoreGeneration: 3,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+});

--- a/web-ui/src/terminal/restore-generation.ts
+++ b/web-ui/src/terminal/restore-generation.ts
@@ -1,0 +1,23 @@
+export interface AppliedRestore {
+	generation: number;
+	cols: number;
+	rows: number;
+}
+
+export interface IncomingRestore {
+	restoreGeneration?: number;
+	cols: number | null | undefined;
+	rows: number | null | undefined;
+}
+
+export function shouldSkipWarmRestore(lastRestore: AppliedRestore | null, incoming: IncomingRestore): boolean {
+	if (incoming.restoreGeneration === undefined || lastRestore === null) {
+		return false;
+	}
+
+	return (
+		lastRestore.generation === incoming.restoreGeneration &&
+		lastRestore.cols === incoming.cols &&
+		lastRestore.rows === incoming.rows
+	);
+}

--- a/web-ui/src/terminal/restore-snapshot-chunks.test.ts
+++ b/web-ui/src/terminal/restore-snapshot-chunks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { RESTORE_WRITE_CHUNK_BYTES, splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
+
+describe("splitRestoreSnapshot", () => {
+	it("returns no writes for an empty snapshot", () => {
+		expect(splitRestoreSnapshot("")).toEqual([]);
+	});
+
+	it("keeps a snapshot that fits in one parse budget as one write", () => {
+		const snapshot = "a".repeat(RESTORE_WRITE_CHUNK_BYTES);
+
+		expect(splitRestoreSnapshot(snapshot)).toEqual([snapshot]);
+	});
+
+	it("splits one byte over the parse budget into two writes", () => {
+		const snapshot = "a".repeat(RESTORE_WRITE_CHUNK_BYTES + 1);
+
+		const chunks = splitRestoreSnapshot(snapshot);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0]).toHaveLength(RESTORE_WRITE_CHUNK_BYTES);
+		expect(chunks[1]).toBe("a");
+		expect(chunks.join("")).toBe(snapshot);
+	});
+
+	it("joins back to the original snapshot with no drop or reorder", () => {
+		const snapshot = `${"ab".repeat(10_000)}🙂${"cd".repeat(8_000)}`;
+
+		expect(splitRestoreSnapshot(snapshot).join("")).toBe(snapshot);
+	});
+});

--- a/web-ui/src/terminal/restore-snapshot-chunks.ts
+++ b/web-ui/src/terminal/restore-snapshot-chunks.ts
@@ -1,0 +1,36 @@
+/** xterm parse budget for restore writes, not a second scrollback cap. */
+export const RESTORE_WRITE_CHUNK_BYTES = 16 * 1024;
+
+export function splitRestoreSnapshot(snapshot: string, chunkBytes: number = RESTORE_WRITE_CHUNK_BYTES): string[] {
+	if (snapshot.length === 0) {
+		return [];
+	}
+
+	const encoder = new TextEncoder();
+	const parts: string[] = [];
+	let start = 0;
+	let usedBytes = 0;
+	let index = 0;
+
+	while (index < snapshot.length) {
+		const codePoint = snapshot.codePointAt(index);
+		if (codePoint === undefined) {
+			break;
+		}
+		const char = String.fromCodePoint(codePoint);
+		const charBytes = encoder.encode(char).byteLength;
+		if (usedBytes > 0 && usedBytes + charBytes > chunkBytes) {
+			parts.push(snapshot.slice(start, index));
+			start = index;
+			usedBytes = 0;
+		}
+		usedBytes += charBytes;
+		index += char.length;
+	}
+
+	if (start < snapshot.length) {
+		parts.push(snapshot.slice(start));
+	}
+
+	return parts;
+}

--- a/web-ui/src/terminal/terminal-options.test.ts
+++ b/web-ui/src/terminal/terminal-options.test.ts
@@ -16,7 +16,7 @@ describe("createKanbanTerminalOptions", () => {
 		expect(options.cursorBlink).toBe(false);
 		expect(options.cursorInactiveStyle).toBe("outline");
 		expect(options.cursorStyle).toBe("block");
-		expect(options.scrollback).toBe(10_000);
+		expect(options.scrollback).toBe(1_000);
 		expect(options.macOptionIsMeta).toBe(true);
 		expect(options.windowOptions).toEqual({
 			getCellSizePixels: true,

--- a/web-ui/src/terminal/terminal-options.ts
+++ b/web-ui/src/terminal/terminal-options.ts
@@ -13,6 +13,18 @@ const TERMINAL_WORD_SEPARATOR = " ()[]{}',\"`";
 const TERMINAL_FONT_FAMILY =
 	"'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";
 
+/**
+ * Browser xterm scrollback.
+ *
+ * Must stay in sync with the server-side `TERMINAL_SCROLLBACK` in
+ * `src/terminal/terminal-state-mirror.ts`. On every task switch the browser
+ * receives a full `restore` snapshot and does `terminal.reset()` +
+ * `terminal.write(snapshot)`. A 10,000-line scrollback made this write block
+ * the main thread for ~60s during long agent runs (#581). 1,000 lines keeps
+ * recent output visible while capping the restore cost at ~10x smaller.
+ */
+const TERMINAL_SCROLLBACK = 1_000;
+
 export function createKanbanTerminalOptions({
 	cursorColor,
 	isMacPlatform,
@@ -38,7 +50,7 @@ export function createKanbanTerminalOptions({
 		rightClickSelectsWord: false,
 		scrollOnEraseInDisplay: true,
 		scrollOnUserInput: true,
-		scrollback: 10_000,
+		scrollback: TERMINAL_SCROLLBACK,
 		smoothScrollDuration: 0,
 		theme: {
 			background: terminalBackgroundColor,

--- a/web-ui/src/terminal/terminal-options.ts
+++ b/web-ui/src/terminal/terminal-options.ts
@@ -14,14 +14,12 @@ const TERMINAL_FONT_FAMILY =
 	"'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";
 
 /**
- * Browser xterm scrollback.
+ * Browser display cap for the last 1,000 lines.
  *
- * Must stay in sync with the server-side `TERMINAL_SCROLLBACK` in
- * `src/terminal/terminal-state-mirror.ts`. On every task switch the browser
- * receives a full `restore` snapshot and does `terminal.reset()` +
- * `terminal.write(snapshot)`. A 10,000-line scrollback made this write block
- * the main thread for ~60s during long agent runs (#581). 1,000 lines keeps
- * recent output visible while capping the restore cost at ~10x smaller.
+ * This is the room the client needs to hold a full 1k restore snapshot.
+ * It is not a second restore-size cap, and it does not have to match the
+ * server buffer in order to shrink the payload. Restore is a cached full
+ * serialize applied in 16 KiB writes; warm reconnects can skip reset.
  */
 const TERMINAL_SCROLLBACK = 1_000;
 


### PR DESCRIPTION
## Context

When a user switches tasks, the server sends a restore snapshot of the headless terminal. The browser writes that snapshot in one step. A 10,000-line buffer blocked the UI for about 60 seconds. The same path also grew RSS toward the OOM in #273.

#583 caps the buffer at 1,000 lines. A later commit on that PR uses `serialize({ scrollback: 0 })`. That call keeps only the current screen. It removes lines above the viewport.

## Decision

Keep the 1,000-line cap from #583.

Do not ship viewport-only `serialize({ scrollback: 0 })`. Restore still sends the last 1,000 lines.

Add three controls:

1. Dirty cache. The server serializes the 1,000-line buffer only after output or resize. Later connections reuse the cached snapshot.
2. Chunked apply. The browser writes the snapshot in slices of about 16 KiB.
3. Restore generation. Each new PTY start increases `restoreGeneration`. If this viewer already applied that generation at the same cols and rows, it does not reset and it does not write again. It still sends `restore_complete`. If the server omits `restoreGeneration`, the viewer always applies the snapshot.

Parked terminals keep their sockets. A card switch on an already-open terminal does not restore. Restore runs on first open, on refresh, and after the socket dies.

## Domain words

- **Restore snapshot** — ANSI string of the 1,000-line buffer.
- **Restore generation** — integer that increases when that task PTY starts.
- **Dirty** — output or resize occurred after the last cached snapshot.
- **Warm skip** — this viewer already applied this generation at this cols and rows. It must not reset. It must not write the snapshot. It must still send `restore_complete`.

## Consequences

The last 1,000 lines stay scrollable. The UI does not block on a 10,000-line write. A warm client that already has the current PTY does not reset.

This PR does not add two-phase restore, lazy-load on scroll, a worker-thread serialize, or a raw PTY ring.

## Test plan

Automated:

- [x] `test/runtime/terminal/terminal-state-mirror.test.ts` — snapshot includes lines above the viewport. A second call with no output reuses the cache. Output or resize rebuilds the snapshot.
- [x] `web-ui` `restore-snapshot-chunks` — empty input returns no parts. One byte over 16 KiB returns two parts. Join of parts equals the input.
- [x] `web-ui` `restore-generation` — skip only when generation, cols, and rows match.
- [x] `ws-server` and session-manager — restore includes generation. The same session keeps that generation. A new PTY increases it.
- [x] `npm run check` — biome, typecheck, and tests. Two integration files timed out when they ran in parallel with the web-ui suite. They passed when they ran alone.
- [x] `npm --prefix web-ui` typecheck and tests
- [x] `npm run build`

Manual (after merge or local run):

1. Start a long task. Open it. Scroll the last 1,000 lines.
2. Switch cards. There is no flash if that terminal was already open.
3. Kill the WebSocket. Reconnect. There is no freeze. The screen is not stale if the PTY has the same generation.
4. Refresh. The last 1,000 lines replay in chunks. There is no hang of about 60 seconds.
5. Start a new PTY. The viewer applies a full restore because the generation changed.
6. Open a second browser tab on the same task. That tab does a cold restore from the server cache.

Fixes #581
Related: #583, #273