### PR TITLE
fix(web-ui): show Fetch, Pull, and Push on mobile

### DIFF
--- a/web-ui/src/components/top-bar.test.tsx
+++ b/web-ui/src/components/top-bar.test.tsx
@@ -3,6 +3,14 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TopBar } from "@/components/top-bar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { resetWorkspaceMetadataStore, setHomeGitSummary } from "@/stores/workspace-metadata-store";
+
+const isMobileMock = vi.hoisted(() => ({ current: false }));
+
+vi.mock("@/hooks/use-is-mobile", () => ({
+	useIsMobile: () => isMobileMock.current,
+}));
 
 function findButtonByText(container: HTMLElement, text: string): HTMLButtonElement | null {
 	return (Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.trim() === text) ??
@@ -21,6 +29,8 @@ describe("TopBar script shortcut onboarding", () => {
 	let previousActEnvironment: boolean | undefined;
 
 	beforeEach(() => {
+		isMobileMock.current = false;
+		resetWorkspaceMetadataStore();
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
 			.IS_REACT_ACT_ENVIRONMENT;
 		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -34,6 +44,8 @@ describe("TopBar script shortcut onboarding", () => {
 			root.unmount();
 		});
 		container.remove();
+		resetWorkspaceMetadataStore();
+		isMobileMock.current = false;
 		if (previousActEnvironment === undefined) {
 			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
 		} else {
@@ -130,5 +142,147 @@ describe("TopBar script shortcut onboarding", () => {
 		});
 
 		expect(onOpenSettings).toHaveBeenCalledTimes(1);
+	});
+});
+
+const HOME_GIT_SUMMARY = {
+	currentBranch: "main",
+	upstreamBranch: "origin/main",
+	changedFiles: 0,
+	additions: 0,
+	deletions: 0,
+	aheadCount: 2,
+	behindCount: 1,
+};
+
+function renderTopBarWithGit(root: Root, overrides: Record<string, unknown> = {}): void {
+	act(() => {
+		root.render(
+			<TooltipProvider>
+				<TopBar
+					openTargetOptions={[]}
+					selectedOpenTargetId="vscode"
+					onSelectOpenTarget={() => {}}
+					onOpenWorkspace={() => {}}
+					canOpenWorkspace={false}
+					isOpeningWorkspace={false}
+					showHomeGitSummary
+					onGitFetch={vi.fn()}
+					onGitPull={vi.fn()}
+					onGitPush={vi.fn()}
+					{...overrides}
+				/>
+			</TooltipProvider>,
+		);
+	});
+}
+
+describe("TopBar mobile git actions", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let previousActEnvironment: boolean | undefined;
+
+	beforeEach(() => {
+		isMobileMock.current = true;
+		resetWorkspaceMetadataStore();
+		setHomeGitSummary(HOME_GIT_SUMMARY);
+		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+			.IS_REACT_ACT_ENVIRONMENT;
+		(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		resetWorkspaceMetadataStore();
+		isMobileMock.current = false;
+		if (previousActEnvironment === undefined) {
+			delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+		} else {
+			(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+				previousActEnvironment;
+		}
+	});
+
+	it("exposes fetch, pull, and push in a mobile overflow menu", async () => {
+		const onGitFetch = vi.fn();
+		const onGitPull = vi.fn();
+		const onGitPush = vi.fn();
+		renderTopBarWithGit(root, { onGitFetch, onGitPull, onGitPush });
+
+		expect(container.querySelector('[aria-label="Fetch from upstream"]')).toBeNull();
+		const menuTrigger = container.querySelector('[aria-label="Git sync actions"]');
+		expect(menuTrigger).toBeInstanceOf(HTMLButtonElement);
+
+		await act(async () => {
+			menuTrigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(menuTrigger as HTMLButtonElement).click();
+		});
+
+		const fetchItem = Array.from(document.body.querySelectorAll("[role='menuitem']")).find((item) =>
+			item.textContent?.includes("Fetch"),
+		);
+		const pullItem = Array.from(document.body.querySelectorAll("[role='menuitem']")).find((item) =>
+			item.textContent?.includes("Pull"),
+		);
+		const pushItem = Array.from(document.body.querySelectorAll("[role='menuitem']")).find((item) =>
+			item.textContent?.includes("Push"),
+		);
+		expect(fetchItem).toBeTruthy();
+		expect(pullItem?.textContent).toContain("1");
+		expect(pushItem?.textContent).toContain("2");
+
+		await act(async () => {
+			fetchItem?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(fetchItem as HTMLElement).click();
+		});
+		expect(onGitFetch).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			menuTrigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(menuTrigger as HTMLButtonElement).click();
+		});
+		const pullItemAgain = Array.from(document.body.querySelectorAll("[role='menuitem']")).find((item) =>
+			item.textContent?.includes("Pull"),
+		);
+		await act(async () => {
+			pullItemAgain?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(pullItemAgain as HTMLElement).click();
+		});
+		expect(onGitPull).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			menuTrigger?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(menuTrigger as HTMLButtonElement).click();
+		});
+		const pushItemAgain = Array.from(document.body.querySelectorAll("[role='menuitem']")).find((item) =>
+			item.textContent?.includes("Push"),
+		);
+		await act(async () => {
+			pushItemAgain?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+			(pushItemAgain as HTMLElement).click();
+		});
+		expect(onGitPush).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides mobile git actions when the home git summary is missing", () => {
+		resetWorkspaceMetadataStore();
+		renderTopBarWithGit(root);
+		expect(container.querySelector('[aria-label="Git sync actions"]')).toBeNull();
+		expect(container.querySelector('[aria-label="Fetch from upstream"]')).toBeNull();
+	});
+
+	it("keeps desktop fetch, pull, and push inline", () => {
+		isMobileMock.current = false;
+		renderTopBarWithGit(root);
+		expect(container.querySelector('[aria-label="Git sync actions"]')).toBeNull();
+		expect(container.querySelector('[aria-label="Fetch from upstream"]')).toBeInstanceOf(HTMLButtonElement);
+		expect(container.querySelector('[aria-label="Pull from upstream"]')).toBeInstanceOf(HTMLButtonElement);
+		expect(container.querySelector('[aria-label="Push to upstream"]')).toBeInstanceOf(HTMLButtonElement);
 	});
 });

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -1,3 +1,4 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as RadixPopover from "@radix-ui/react-popover";
 import {
 	ArrowDown,
@@ -8,6 +9,7 @@ import {
 	ChevronDown,
 	CircleArrowDown,
 	Command,
+	Ellipsis,
 	GitBranch,
 	Menu,
 	Play,
@@ -166,6 +168,71 @@ function GitBranchStatusControl({
 	);
 }
 
+function HomeGitSyncMenu({
+	pullCount,
+	pushCount,
+	runningGitAction,
+	onGitFetch,
+	onGitPull,
+	onGitPush,
+}: {
+	pullCount: number;
+	pushCount: number;
+	runningGitAction?: RuntimeGitSyncAction | null;
+	onGitFetch?: () => void;
+	onGitPull?: () => void;
+	onGitPush?: () => void;
+}): React.ReactElement {
+	return (
+		<DropdownMenu.Root>
+			<DropdownMenu.Trigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					icon={<Ellipsis size={16} />}
+					aria-label="Git sync actions"
+					className={MOBILE_TOUCH_TARGET}
+				/>
+			</DropdownMenu.Trigger>
+			<DropdownMenu.Portal>
+				<DropdownMenu.Content
+					side="bottom"
+					align="end"
+					sideOffset={4}
+					className="z-50 min-w-[160px] rounded-md border border-border-bright bg-surface-1 p-1 shadow-lg"
+				>
+					<DropdownMenu.Item
+						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						disabled={runningGitAction === "fetch"}
+						onSelect={onGitFetch}
+					>
+						{runningGitAction === "fetch" ? <Spinner size={14} /> : <CircleArrowDown size={16} />}
+						Fetch
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						disabled={runningGitAction === "pull"}
+						onSelect={onGitPull}
+					>
+						{runningGitAction === "pull" ? <Spinner size={14} /> : <ArrowDown size={14} />}
+						<span>Pull</span>
+						<span className="text-text-tertiary">{pullCount}</span>
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						disabled={runningGitAction === "push"}
+						onSelect={onGitPush}
+					>
+						{runningGitAction === "push" ? <Spinner size={14} /> : <ArrowUp size={14} />}
+						<span>Push</span>
+						<span className="text-text-tertiary">{pushCount}</span>
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Portal>
+		</DropdownMenu.Root>
+	);
+}
+
 function TopBarGitStatusSection({
 	showHomeGitSummary,
 	selectedTaskId,
@@ -176,6 +243,7 @@ function TopBarGitStatusSection({
 	onGitFetch,
 	onGitPull,
 	onGitPush,
+	layout = "inline",
 }: {
 	showHomeGitSummary: boolean;
 	selectedTaskId: string | null;
@@ -186,6 +254,7 @@ function TopBarGitStatusSection({
 	onGitFetch?: () => void;
 	onGitPull?: () => void;
 	onGitPush?: () => void;
+	layout?: "inline" | "menu";
 }): React.ReactElement | null {
 	const homeGitSummary = useHomeGitSummaryValue();
 	const taskWorkspaceInfo = useTaskWorkspaceInfoValue(selectedTaskId, selectedTaskBaseRef);
@@ -195,6 +264,18 @@ function TopBarGitStatusSection({
 		const branchLabel = homeGitSummary.currentBranch ?? "detached HEAD";
 		const pullCount = homeGitSummary.behindCount ?? 0;
 		const pushCount = homeGitSummary.aheadCount ?? 0;
+		if (layout === "menu") {
+			return (
+				<HomeGitSyncMenu
+					pullCount={pullCount}
+					pushCount={pushCount}
+					runningGitAction={runningGitAction}
+					onGitFetch={onGitFetch}
+					onGitPull={onGitPull}
+					onGitPush={onGitPush}
+				/>
+			);
+		}
 		const pullTooltip =
 			pullCount > 0
 				? `Pull ${pullCount} commit${pullCount === 1 ? "" : "s"} from upstream into your local branch.`
@@ -255,6 +336,10 @@ function TopBarGitStatusSection({
 				</div>
 			</>
 		);
+	}
+
+	if (layout === "menu") {
+		return null;
 	}
 
 	if (selectedTaskId && (taskWorkspaceInfo || taskWorkspaceSnapshot)) {
@@ -645,9 +730,21 @@ export function TopBar({
 						</>
 					) : null}
 
-					{/* Mobile: inline run + terminal buttons (icon-only) */}
+					{/* Mobile: git overflow + inline run + terminal buttons (icon-only) */}
 					{isMobile ? (
 						<>
+							{!hideProjectDependentActions ? (
+								<TopBarGitStatusSection
+									layout="menu"
+									showHomeGitSummary={showHomeGitSummary === true}
+									selectedTaskId={selectedTaskId ?? null}
+									selectedTaskBaseRef={selectedTaskBaseRef ?? null}
+									runningGitAction={runningGitAction}
+									onGitFetch={onGitFetch}
+									onGitPull={onGitPull}
+									onGitPush={onGitPush}
+								/>
+							) : null}
 							{!hideProjectDependentActions && onRunShortcut && selectedShortcut ? (
 								<Button
 									variant="ghost"

--- a/web-ui/src/components/top-bar.tsx
+++ b/web-ui/src/components/top-bar.tsx
@@ -45,6 +45,8 @@ type SettingsSection = "shortcuts";
 type CreateShortcutResult = { ok: boolean; message?: string };
 
 const MOBILE_TOUCH_TARGET = "min-w-[44px] min-h-[44px]";
+const HOME_GIT_MENU_ITEM_CLASS =
+	"flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50";
 
 function getWorkspacePathSegments(path: string): string[] {
 	return path
@@ -202,7 +204,7 @@ function HomeGitSyncMenu({
 					className="z-50 min-w-[160px] rounded-md border border-border-bright bg-surface-1 p-1 shadow-lg"
 				>
 					<DropdownMenu.Item
-						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						className={HOME_GIT_MENU_ITEM_CLASS}
 						disabled={runningGitAction === "fetch"}
 						onSelect={onGitFetch}
 					>
@@ -210,7 +212,7 @@ function HomeGitSyncMenu({
 						Fetch
 					</DropdownMenu.Item>
 					<DropdownMenu.Item
-						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						className={HOME_GIT_MENU_ITEM_CLASS}
 						disabled={runningGitAction === "pull"}
 						onSelect={onGitPull}
 					>
@@ -219,7 +221,7 @@ function HomeGitSyncMenu({
 						<span className="text-text-tertiary">{pullCount}</span>
 					</DropdownMenu.Item>
 					<DropdownMenu.Item
-						className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] text-text-primary outline-none data-[disabled]:cursor-not-allowed data-[highlighted]:bg-surface-3 data-[disabled]:opacity-50"
+						className={HOME_GIT_MENU_ITEM_CLASS}
 						disabled={runningGitAction === "push"}
 						onSelect={onGitPush}
 					>


### PR DESCRIPTION
## Context

Fetch, Pull, and Push hide below 768px. The leftover overflow menu from the mobile shell is gone. Those actions only live on the desktop git row.

Users cannot sync the project from a phone. Issue #548.

## Decision

Add a mobile overflow menu on the top bar. The menu shows Fetch, Pull, and Push when the home git summary is present. Desktop inline buttons stay as they are.

## Consequences

- Mobile users can fetch, pull, and push from the overflow menu.
- The menu is hidden when the home git summary is missing, same as desktop.
- Tests cover mobile menu actions and the desktop inline path.

fixes #548