### PR TITLE
fix(web-ui): keep Add Project mounted during project switch

### DIFF
--- a/web-ui/src/components/project-navigation-panel.test.tsx
+++ b/web-ui/src/components/project-navigation-panel.test.tsx
@@ -211,6 +211,18 @@ describe("ProjectNavigationPanel width persistence", () => {
 		expect(container.textContent).not.toContain("Report issue");
 	});
 
+	it("keeps the Add Project button rendered while the project list reloads after a switch", () => {
+		renderPanel({ isLoadingProjects: true });
+		expect(() => getButtonByText(container, "Add Project")).not.toThrow();
+	});
+
+	it("hides the Add Project button on initial load while projects are still being fetched", () => {
+		renderPanel({ projects: [], currentProjectId: null, isLoadingProjects: true });
+		expect(
+			Array.from(container.querySelectorAll("button")).some((button) => button.textContent === "Add Project"),
+		).toBe(false);
+	});
+
 	it("persists terminal tips dismissal", () => {
 		renderPanel({
 			activeSection: "agent",

--- a/web-ui/src/components/project-navigation-panel.tsx
+++ b/web-ui/src/components/project-navigation-panel.tsx
@@ -381,7 +381,7 @@ export function ProjectNavigationPanel({
 							/>
 						))}
 
-						{!isLoadingProjects ? (
+						{sortedProjects.length === 0 && isLoadingProjects ? null : (
 							<button
 								type="button"
 								className="kb-project-row flex cursor-pointer items-center gap-1.5 rounded-md text-text-secondary hover:text-text-primary"
@@ -392,7 +392,7 @@ export function ProjectNavigationPanel({
 								<Plus size={14} className="shrink-0" />
 								<span className="text-sm">Add Project</span>
 							</button>
-						) : null}
+						)}
 					</div>
 					<ShortcutsCard />
 					<ProjectSupportFooter


### PR DESCRIPTION
## Context

The Add Project button unmounts when the project list reloads. A project switch resets the snapshot flag, so the list looks like it is loading. The button flickers. Issue #343.

## Decision

Hide Add Project only when the list is empty and still loading. Keep the button mounted when projects are already present.

This matches the skeleton rule. It does not change the first-load hide.

## Consequences

- A project switch no longer flickers the button.
- The first load still hides the button behind skeletons.
- Two tests cover the switch path and the first-load path.

This re-implements the same fix as open PR #359 on current main. It does not push onto that branch.

fixes #343