### PR TITLE
feat(agents): add AG2 as a native Play agent

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -54,7 +54,7 @@ const PROJECT_CONFIG_PARENT_DIR = ".cline";
 const PROJECT_CONFIG_DIR = "kanban";
 const PROJECT_CONFIG_FILENAME = "config.json";
 const DEFAULT_AGENT_ID: RuntimeAgentId = "cline";
-const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = ["claude", "codex", "droid", "kiro"];
+const AUTO_SELECT_AGENT_PRIORITY: readonly RuntimeAgentId[] = ["claude", "codex", "droid", "kiro", "ag2"];
 const DEFAULT_AGENT_AUTONOMOUS_MODE_ENABLED = true;
 const DEFAULT_READY_FOR_REVIEW_NOTIFICATIONS_ENABLED = true;
 const DEFAULT_COMMIT_PROMPT_TEMPLATE = `You are in a worktree on a detached HEAD. When you are finished with the task, commit the working changes onto {{base_ref}}.
@@ -124,7 +124,8 @@ function normalizeAgentId(agentId: RuntimeAgentId | string | null | undefined): 
 			agentId === "opencode" ||
 			agentId === "droid" ||
 			agentId === "kiro" ||
-			agentId === "cline") &&
+			agentId === "cline" ||
+			agentId === "ag2") &&
 		isRuntimeAgentLaunchSupported(agentId)
 	) {
 		return agentId;

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -1,5 +1,23 @@
 import type { RuntimeAgentId } from "./api-contract";
 
+export type AgentUiSurface = "chat" | "terminal";
+export type AgentBackend = "cline-sdk" | "pty";
+export type AgentSessionKind = "long-lived" | "oneshot";
+export type AgentSlashSource = "none" | "cline-sdk" | "project-skills";
+export type AgentFollowUp = "sdk-send" | "pty-stdin" | "restart-pty-with-context";
+
+export interface RuntimeAgentCapabilities {
+	uiSurface: AgentUiSurface;
+	backend: AgentBackend;
+	sessionKind: AgentSessionKind;
+	autoRestart: boolean;
+	preserveChatAcrossRestarts: boolean;
+	slashSource: AgentSlashSource;
+	followUp: AgentFollowUp;
+	showModelPicker: boolean;
+	rejectFollowUpWhileRunning: boolean;
+}
+
 export interface RuntimeAgentCatalogEntry {
 	id: RuntimeAgentId;
 	label: string;
@@ -7,7 +25,44 @@ export interface RuntimeAgentCatalogEntry {
 	baseArgs: string[];
 	autonomousArgs: string[];
 	installUrl: string;
+	capabilities: RuntimeAgentCapabilities;
 }
+
+export const PTY_TUI_CAPABILITIES: RuntimeAgentCapabilities = {
+	uiSurface: "terminal",
+	backend: "pty",
+	sessionKind: "long-lived",
+	autoRestart: true,
+	preserveChatAcrossRestarts: false,
+	slashSource: "none",
+	followUp: "pty-stdin",
+	showModelPicker: false,
+	rejectFollowUpWhileRunning: false,
+};
+
+export const CLINE_SDK_CAPABILITIES: RuntimeAgentCapabilities = {
+	uiSurface: "chat",
+	backend: "cline-sdk",
+	sessionKind: "long-lived",
+	autoRestart: false,
+	preserveChatAcrossRestarts: true,
+	slashSource: "cline-sdk",
+	followUp: "sdk-send",
+	showModelPicker: true,
+	rejectFollowUpWhileRunning: false,
+};
+
+export const PTY_CHAT_CAPABILITIES: RuntimeAgentCapabilities = {
+	uiSurface: "chat",
+	backend: "pty",
+	sessionKind: "oneshot",
+	autoRestart: false,
+	preserveChatAcrossRestarts: true,
+	slashSource: "project-skills",
+	followUp: "restart-pty-with-context",
+	showModelPicker: false,
+	rejectFollowUpWhileRunning: true,
+};
 
 export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 	{
@@ -17,6 +72,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: ["--permission-mode", "auto"],
 		installUrl: "https://docs.anthropic.com/en/docs/claude-code/quickstart",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "codex",
@@ -25,6 +81,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: ["--dangerously-bypass-approvals-and-sandbox"],
 		installUrl: "https://github.com/openai/codex",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "cline",
@@ -33,6 +90,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: ["--auto-approve-all"],
 		installUrl: "https://github.com/cline/cline",
+		capabilities: CLINE_SDK_CAPABILITIES,
 	},
 	{
 		id: "opencode",
@@ -41,6 +99,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: [],
 		installUrl: "https://github.com/sst/opencode",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "droid",
@@ -49,6 +108,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: ["--auto", "high"],
 		installUrl: "https://docs.factory.ai/cli/getting-started/quickstart",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "kiro",
@@ -57,6 +117,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: ["chat"],
 		autonomousArgs: ["--trust-all-tools"],
 		installUrl: "https://kiro.dev",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "gemini",
@@ -65,6 +126,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: [],
 		autonomousArgs: ["--yolo"],
 		installUrl: "https://github.com/google-gemini/gemini-cli",
+		capabilities: PTY_TUI_CAPABILITIES,
 	},
 	{
 		id: "ag2",
@@ -73,6 +135,7 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		baseArgs: ["ag2-run"],
 		autonomousArgs: [],
 		installUrl: "https://github.com/ag2ai/ag2",
+		capabilities: PTY_CHAT_CAPABILITIES,
 	},
 ];
 
@@ -101,4 +164,19 @@ export function getRuntimeLaunchSupportedAgentCatalog(): RuntimeAgentCatalogEntr
 
 export function getRuntimeAgentCatalogEntry(agentId: RuntimeAgentId): RuntimeAgentCatalogEntry | null {
 	return RUNTIME_AGENT_CATALOG.find((entry) => entry.id === agentId) ?? null;
+}
+
+export function getAgentCapabilities(agentId: RuntimeAgentId | null | undefined): RuntimeAgentCapabilities | null {
+	if (!agentId) {
+		return null;
+	}
+	return getRuntimeAgentCatalogEntry(agentId)?.capabilities ?? PTY_TUI_CAPABILITIES;
+}
+
+export function isChatPanelAgent(agentId: RuntimeAgentId | null | undefined): boolean {
+	return getAgentCapabilities(agentId)?.uiSurface === "chat";
+}
+
+export function isClineSdkBackend(agentId: RuntimeAgentId | null | undefined): boolean {
+	return getAgentCapabilities(agentId)?.backend === "cline-sdk";
 }

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -66,6 +66,14 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		autonomousArgs: ["--yolo"],
 		installUrl: "https://github.com/google-gemini/gemini-cli",
 	},
+	{
+		id: "ag2",
+		label: "AG2",
+		binary: "mlx-agents",
+		baseArgs: ["ag2-run"],
+		autonomousArgs: [],
+		installUrl: "https://github.com/ag2ai/ag2",
+	},
 ];
 
 // Temporarily keep launch support scoped to the core agent set.
@@ -76,6 +84,7 @@ export const RUNTIME_LAUNCH_SUPPORTED_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"codex",
 	"droid",
 	"kiro",
+	"ag2",
 	// "opencode",
 	// "gemini",
 ];

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -71,7 +71,7 @@ export const runtimeSlashCommandsResponseSchema = z.object({
 });
 export type RuntimeSlashCommandsResponse = z.infer<typeof runtimeSlashCommandsResponseSchema>;
 
-export const runtimeAgentIdSchema = z.enum(["claude", "codex", "gemini", "opencode", "droid", "kiro", "cline"]);
+export const runtimeAgentIdSchema = z.enum(["claude", "codex", "gemini", "opencode", "droid", "kiro", "cline", "ag2"]);
 export type RuntimeAgentId = z.infer<typeof runtimeAgentIdSchema>;
 
 const runtimeBoardColumnIdEnum = z.enum(["backlog", "in_progress", "review", "trash"]);

--- a/src/core/graceful-shutdown.ts
+++ b/src/core/graceful-shutdown.ts
@@ -97,9 +97,23 @@ function normalizePath(path: string): string {
 	return path.replaceAll("\\", "/").toLowerCase();
 }
 
+function isTsxWrapperLaunch(argv: string[], execArgv: string[]): boolean {
+	return [...argv, ...execArgv].some((value) => {
+		if (value === "tsx") {
+			return true;
+		}
+		const normalized = normalizePath(value);
+		if (normalized.endsWith("/tsx") || normalized.endsWith("/tsx.js")) {
+			return true;
+		}
+		return normalized.includes("/tsx/") && normalized.endsWith("/cli.mjs");
+	});
+}
+
 export function shouldSuppressImmediateDuplicateShutdownSignals(options?: {
 	argv?: string[];
 	env?: NodeJS.ProcessEnv;
+	execArgv?: string[];
 }): boolean {
 	const env = options?.env ?? process.env;
 	if (typeof env.npm_execpath === "string" && env.npm_execpath.length > 0) {
@@ -107,6 +121,11 @@ export function shouldSuppressImmediateDuplicateShutdownSignals(options?: {
 	}
 
 	const argv = options?.argv ?? process.argv;
+	const execArgv = options?.execArgv ?? process.execArgv;
+	if (isTsxWrapperLaunch(argv, execArgv)) {
+		return true;
+	}
+
 	const entrypointPath = argv[1];
 	if (typeof entrypointPath !== "string" || entrypointPath.length === 0) {
 		return false;

--- a/src/prompts/append-system-prompt.ts
+++ b/src/prompts/append-system-prompt.ts
@@ -32,6 +32,7 @@ const APPEND_PROMPT_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"kiro",
 	"gemini",
 	"opencode",
+	"ag2",
 ];
 
 function isRuntimeAgentId(value: string): value is RuntimeAgentId {
@@ -66,6 +67,8 @@ function renderLinearSetupGuidanceForAgent(agentId: RuntimeAgentId | null): stri
 			return "- If Linear MCP is not available in the current agent (Droid), suggest running: `droid mcp add linear https://mcp.linear.app/mcp --type http`";
 		case "kiro":
 			return "- If Linear MCP is not available in the current agent (Kiro CLI), suggest running: `kiro-cli mcp add --name linear --url https://mcp.linear.app/mcp --scope global`";
+		case "ag2":
+			return "- If Linear MCP is not available in the current agent (AG2), continue without it unless the user asks to configure MCP outside this session.";
 		default:
 			return "- If Linear MCP is not available, provide setup instructions for the active agent only, then continue once OAuth is complete.";
 	}

--- a/src/server/runtime-state-hub.ts
+++ b/src/server/runtime-state-hub.ts
@@ -497,10 +497,16 @@ export function createRuntimeStateHub(deps: CreateRuntimeStateHubDependencies): 
 			if (terminalSummaryUnsubscribeByWorkspaceId.has(workspaceId)) {
 				return;
 			}
-			const unsubscribe = manager.onSummary((summary) => {
+			const unsubscribeSummary = manager.onSummary((summary) => {
 				queueTaskSessionSummaryBroadcast(workspaceId, summary);
 			});
-			terminalSummaryUnsubscribeByWorkspaceId.set(workspaceId, unsubscribe);
+			const unsubscribeChat = manager.onChatMessage((taskId, message) => {
+				broadcastTaskChatMessage(workspaceId, taskId, message);
+			});
+			terminalSummaryUnsubscribeByWorkspaceId.set(workspaceId, () => {
+				unsubscribeSummary();
+				unsubscribeChat();
+			});
 		},
 		trackClineTaskSessionService: (workspaceId: string, workspacePath: string, service: ClineTaskSessionService) => {
 			if (clineSummaryUnsubscribeByWorkspaceId.has(workspaceId)) {

--- a/src/skills/project-skills.ts
+++ b/src/skills/project-skills.ts
@@ -1,0 +1,102 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { RuntimeSlashCommand } from "../core/api-contract";
+
+const SKILL_ROOTS = [".cline/skills", ".cursor/skills", ".agents/skills"] as const;
+const SKIP_DIR_NAMES = new Set([".git", "node_modules"]);
+
+function stripQuotes(val: string): string {
+	let trimmed = val.trim();
+	if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+		trimmed = trimmed.slice(1, -1).trim();
+	}
+	return trimmed;
+}
+
+function parseSkillFrontmatter(content: string, skillMdPath: string): { name: string; description: string } | null {
+	if (!content.startsWith("---")) {
+		return null;
+	}
+	const rest = content.slice(3);
+	const endIndex = rest.indexOf("\n---");
+	if (endIndex < 0) {
+		return null;
+	}
+	const frontmatter = rest.slice(0, endIndex);
+
+	const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+	if (!descMatch) {
+		return null;
+	}
+	const description = stripQuotes(descMatch[1]);
+	if (!description) {
+		return null;
+	}
+
+	const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+	const folderName = basename(dirname(skillMdPath));
+	const name = nameMatch ? stripQuotes(nameMatch[1]) || folderName : folderName;
+
+	return { name, description };
+}
+
+function findSkillMdFiles(dir: string): string[] {
+	const results: string[] = [];
+	if (!existsSync(dir)) {
+		return results;
+	}
+
+	try {
+		const entries = readdirSync(dir, { withFileTypes: true });
+		entries.sort((a, b) => a.name.localeCompare(b.name));
+
+		for (const entry of entries) {
+			if (SKIP_DIR_NAMES.has(entry.name)) {
+				continue;
+			}
+			const fullPath = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				results.push(...findSkillMdFiles(fullPath));
+			} else if (entry.isFile() && entry.name === "SKILL.md") {
+				results.push(fullPath);
+			}
+		}
+	} catch {
+		// Ignore filesystem errors during walk
+	}
+
+	return results;
+}
+
+export function listProjectSkillSlashCommands(root: string): RuntimeSlashCommand[] {
+	const commands: RuntimeSlashCommand[] = [];
+	const seen = new Set<string>();
+
+	for (const relDir of SKILL_ROOTS) {
+		const baseDir = join(root, relDir);
+		const skillFiles = findSkillMdFiles(baseDir);
+
+		for (const skillMdPath of skillFiles) {
+			try {
+				const content = readFileSync(skillMdPath, "utf8");
+				const parsed = parseSkillFrontmatter(content, skillMdPath);
+				if (!parsed) {
+					continue;
+				}
+				if (seen.has(parsed.name)) {
+					continue;
+				}
+				seen.add(parsed.name);
+				commands.push({
+					name: parsed.name,
+					instructions: "",
+					description: parsed.description,
+				});
+			} catch {
+				// Ignore read errors
+			}
+		}
+	}
+
+	return commands;
+}

--- a/src/terminal/ag2-chat-stream.ts
+++ b/src/terminal/ag2-chat-stream.ts
@@ -1,0 +1,83 @@
+import type { RuntimeTaskChatMessage } from "../core/api-contract";
+
+export const AG2_CHAT_PREFIX = "AG2_CHAT ";
+const AG2_CLI_NOISE = /^\[(?:ag2|kanban-hook|tool)\]/u;
+
+const CHAT_ROLES = new Set(["user", "assistant", "system", "tool", "reasoning", "status"]);
+
+export interface Ag2ChatConsumeResult {
+	buffer: string;
+	messages: RuntimeTaskChatMessage[];
+	passthrough: string;
+}
+
+function parseChatPayload(raw: string): RuntimeTaskChatMessage | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return null;
+	}
+	const record = parsed as Record<string, unknown>;
+	const id = typeof record.id === "string" ? record.id.trim() : "";
+	const role = typeof record.role === "string" ? record.role : "";
+	const content = typeof record.content === "string" ? record.content : "";
+	if (!id || !CHAT_ROLES.has(role) || content.length === 0) {
+		return null;
+	}
+	const createdAt =
+		typeof record.createdAt === "number" && Number.isFinite(record.createdAt) ? record.createdAt : Date.now();
+	const meta =
+		record.meta && typeof record.meta === "object" && !Array.isArray(record.meta)
+			? (record.meta as RuntimeTaskChatMessage["meta"])
+			: null;
+	return {
+		id,
+		role: role as RuntimeTaskChatMessage["role"],
+		content,
+		createdAt,
+		meta,
+	};
+}
+
+export function consumeAg2ChatOutput(buffer: string, chunk: string): Ag2ChatConsumeResult {
+	const combined = `${buffer}${chunk}`;
+	const lines = combined.split(/\r?\n/u);
+	const hasTrailingNewline = /[\r\n]$/u.test(combined);
+	let incomplete = "";
+	if (!hasTrailingNewline) {
+		incomplete = lines.pop() ?? "";
+	} else if (lines.at(-1) === "") {
+		lines.pop();
+	}
+	const messages: RuntimeTaskChatMessage[] = [];
+	const passthroughParts: string[] = [];
+
+	for (const line of lines) {
+		if (line.startsWith(AG2_CHAT_PREFIX)) {
+			const message = parseChatPayload(line.slice(AG2_CHAT_PREFIX.length));
+			if (message) {
+				messages.push(message);
+			}
+			continue;
+		}
+		if (AG2_CLI_NOISE.test(line)) {
+			continue;
+		}
+		passthroughParts.push(line);
+	}
+
+	let passthrough = passthroughParts.join("\n");
+	if (passthroughParts.length > 0 && hasTrailingNewline) {
+		passthrough += "\n";
+	}
+
+	return {
+		buffer: incomplete,
+		messages,
+		passthrough,
+	};
+}

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -1429,6 +1429,31 @@ const clineAdapter: AgentSessionAdapter = {
 	},
 };
 
+const ag2Adapter: AgentSessionAdapter = {
+	async prepare(input) {
+		const env: Record<string, string | undefined> = {};
+		const hooks = resolveHookContext(input);
+		if (hooks) {
+			Object.assign(
+				env,
+				createHookRuntimeEnv({
+					taskId: hooks.taskId,
+					workspaceId: hooks.workspaceId,
+				}),
+			);
+		}
+		const args = ["ag2-run", input.prompt, "--workspace", input.cwd, "--role", "supervisor", "--ensure-server"];
+		if (input.taskId) {
+			args.push("--task-id", input.taskId);
+		}
+		return {
+			binary: input.binary ?? "mlx-agents",
+			args,
+			env,
+		};
+	},
+};
+
 const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	claude: claudeAdapter,
 	codex: codexAdapter,
@@ -1437,6 +1462,7 @@ const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	droid: droidAdapter,
 	kiro: kiroAdapter,
 	cline: clineAdapter,
+	ag2: ag2Adapter,
 };
 
 export async function prepareAgentLaunch(input: AgentAdapterLaunchInput): Promise<PreparedAgentLaunch> {

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import type {
 	RuntimeAgentId,
 	RuntimeHookEvent,
+	RuntimeTaskChatMessage,
 	RuntimeTaskImage,
 	RuntimeTaskSessionSummary,
 } from "../core/api-contract";
@@ -14,6 +15,7 @@ import { quoteShellArg } from "../core/shell";
 import { lockedFileSystem } from "../fs/locked-file-system";
 import { resolveHomeAgentAppendSystemPrompt } from "../prompts/append-system-prompt";
 import { getRuntimeHomePath } from "../state/workspace-state";
+import { consumeAg2ChatOutput } from "./ag2-chat-stream";
 import { configureCodexHooks, hasCodexConfigOverride } from "./codex-hook-config";
 import { createHookRuntimeEnv } from "./hook-runtime-context";
 import {
@@ -47,6 +49,12 @@ export type AgentOutputTransitionDetector = (
 
 export type AgentOutputTransitionInspectionPredicate = (summary: RuntimeTaskSessionSummary) => boolean;
 
+export interface AgentOutputChatResult {
+	buffer: string;
+	messages: RuntimeTaskChatMessage[];
+	passthrough: string;
+}
+
 export interface PreparedAgentLaunch {
 	binary?: string;
 	args: string[];
@@ -55,6 +63,8 @@ export interface PreparedAgentLaunch {
 	deferredStartupInput?: string;
 	detectOutputTransition?: AgentOutputTransitionDetector;
 	shouldInspectOutputForTransition?: AgentOutputTransitionInspectionPredicate;
+	consumeOutput?: (buffer: string, chunk: string) => AgentOutputChatResult;
+	buildFollowUpPrompt?: (prior: RuntimeTaskChatMessage[], text: string) => string;
 }
 
 interface HookContext {
@@ -71,6 +81,8 @@ interface HookCommandMetadata {
 
 interface AgentSessionAdapter {
 	prepare(input: AgentAdapterLaunchInput): Promise<PreparedAgentLaunch>;
+	consumeOutput?: (buffer: string, chunk: string) => AgentOutputChatResult;
+	buildFollowUpPrompt?: (prior: RuntimeTaskChatMessage[], text: string) => string;
 }
 
 function escapeForTemplateLiteral(value: string): string {
@@ -1429,7 +1441,20 @@ const clineAdapter: AgentSessionAdapter = {
 	},
 };
 
+function buildPtyChatFollowUpPrompt(prior: RuntimeTaskChatMessage[], text: string): string {
+	const snippets = prior
+		.filter((message) => message.role === "user" || message.role === "assistant")
+		.slice(-4)
+		.map((message) => `${message.role}: ${message.content.slice(0, 800)}`);
+	if (snippets.length === 0) {
+		return text;
+	}
+	return `Prior conversation:\n${snippets.join("\n\n")}\n\nFollow-up from the user:\n${text}`;
+}
+
 const ag2Adapter: AgentSessionAdapter = {
+	consumeOutput: consumeAg2ChatOutput,
+	buildFollowUpPrompt: buildPtyChatFollowUpPrompt,
 	async prepare(input) {
 		const env: Record<string, string | undefined> = {};
 		const hooks = resolveHookContext(input);
@@ -1450,6 +1475,8 @@ const ag2Adapter: AgentSessionAdapter = {
 			binary: input.binary ?? "mlx-agents",
 			args,
 			env,
+			consumeOutput: consumeAg2ChatOutput,
+			buildFollowUpPrompt: buildPtyChatFollowUpPrompt,
 		};
 	},
 };
@@ -1465,13 +1492,27 @@ const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	ag2: ag2Adapter,
 };
 
+export function buildAgentFollowUpPrompt(
+	agentId: RuntimeAgentId,
+	prior: RuntimeTaskChatMessage[],
+	text: string,
+): string {
+	return ADAPTERS[agentId].buildFollowUpPrompt?.(prior, text) ?? text;
+}
+
 export async function prepareAgentLaunch(input: AgentAdapterLaunchInput): Promise<PreparedAgentLaunch> {
 	const preparedPrompt = await prepareTaskPromptWithImages({
 		prompt: input.prompt,
 		images: input.images,
 	});
-	return await ADAPTERS[input.agentId].prepare({
+	const adapter = ADAPTERS[input.agentId];
+	const launch = await adapter.prepare({
 		...input,
 		prompt: preparedPrompt,
 	});
+	return {
+		...launch,
+		consumeOutput: launch.consumeOutput ?? adapter.consumeOutput,
+		buildFollowUpPrompt: launch.buildFollowUpPrompt ?? adapter.buildFollowUpPrompt,
+	};
 }

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -1,6 +1,8 @@
 // PTY-backed runtime for non-Cline task sessions and the workspace shell terminal.
 // It owns process lifecycle, terminal protocol filtering, and summary updates
 // for command-driven agents such as Claude Code, Codex, Gemini, and shell sessions.
+
+import { getAgentCapabilities, getRuntimeAgentCatalogEntry } from "../core/agent-catalog";
 import type {
 	RuntimeTaskChatMessage,
 	RuntimeTaskHookActivity,
@@ -10,7 +12,6 @@ import type {
 	RuntimeTaskSessionSummary,
 	RuntimeTaskTurnCheckpoint,
 } from "../core/api-contract";
-import { consumeAg2ChatOutput } from "./ag2-chat-stream";
 import {
 	type AgentAdapterLaunchInput,
 	type AgentOutputTransitionDetector,
@@ -264,6 +265,15 @@ export class TerminalSessionManager implements TerminalSessionService {
 		this.upsertChatMessage(entry, message);
 	}
 
+	clearChatMessages(taskId: string): void {
+		const entry = this.entries.get(taskId);
+		if (!entry) {
+			return;
+		}
+		entry.chatMessages = [];
+		entry.chatLineBuffer = "";
+	}
+
 	hydrateFromRecord(record: Record<string, RuntimeTaskSessionSummary>): void {
 		for (const [taskId, summary] of Object.entries(record)) {
 			this.entries.set(taskId, {
@@ -323,8 +333,10 @@ export class TerminalSessionManager implements TerminalSessionService {
 			request: cloneStartTaskSessionRequest(request),
 		};
 		if (entry.active && isActiveState(entry.summary.state)) {
-			if (request.agentId === "ag2" && request.prompt.trim().length > 0) {
-				throw new Error("AG2 is still running. Wait for it to finish, then send.");
+			const capabilities = getAgentCapabilities(request.agentId);
+			if (capabilities?.rejectFollowUpWhileRunning && request.prompt.trim().length > 0) {
+				const label = getRuntimeAgentCatalogEntry(request.agentId)?.label ?? request.agentId;
+				throw new Error(`${label} is still running. Wait for it to finish, then send.`);
 			}
 			return cloneSummary(entry.summary);
 		}
@@ -336,7 +348,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		}
 		entry.terminalStateMirror?.dispose();
 		entry.terminalStateMirror = null;
-		if (request.agentId !== "ag2") {
+		if (!getAgentCapabilities(request.agentId)?.preserveChatAcrossRestarts) {
 			entry.chatMessages = [];
 		}
 		entry.chatLineBuffer = "";
@@ -398,8 +410,8 @@ export class TerminalSessionManager implements TerminalSessionService {
 						return;
 					}
 					let displayChunk = filteredChunk;
-					if (request.agentId === "ag2") {
-						const consumed = consumeAg2ChatOutput(entry.chatLineBuffer, filteredChunk.toString("utf8"));
+					if (launch.consumeOutput) {
+						const consumed = launch.consumeOutput(entry.chatLineBuffer, filteredChunk.toString("utf8"));
 						entry.chatLineBuffer = consumed.buffer;
 						for (const message of consumed.messages) {
 							this.upsertChatMessage(entry, message);
@@ -1031,9 +1043,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		if (wasSuppressed) {
 			return false;
 		}
-		// AG2 is a one-shot `mlx-agents ag2-run` PTY, not a long-lived TUI.
-		// Restarting it after a clean exit re-runs the whole supervisor loop.
-		if (entry.summary.agentId === "ag2") {
+		if (!getAgentCapabilities(entry.summary.agentId)?.autoRestart) {
 			return false;
 		}
 		if (entry.listeners.size === 0 || entry.restartRequest?.kind !== "task") {

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -2,6 +2,7 @@
 // It owns process lifecycle, terminal protocol filtering, and summary updates
 // for command-driven agents such as Claude Code, Codex, Gemini, and shell sessions.
 import type {
+	RuntimeTaskChatMessage,
 	RuntimeTaskHookActivity,
 	RuntimeTaskImage,
 	RuntimeTaskSessionReviewReason,
@@ -9,6 +10,7 @@ import type {
 	RuntimeTaskSessionSummary,
 	RuntimeTaskTurnCheckpoint,
 } from "../core/api-contract";
+import { consumeAg2ChatOutput } from "./ag2-chat-stream";
 import {
 	type AgentAdapterLaunchInput,
 	type AgentOutputTransitionDetector,
@@ -73,6 +75,8 @@ interface SessionEntry {
 	suppressAutoRestartOnExit: boolean;
 	autoRestartTimestamps: number[];
 	pendingAutoRestart: Promise<void> | null;
+	chatMessages: RuntimeTaskChatMessage[];
+	chatLineBuffer: string;
 }
 
 export interface StartTaskSessionRequest {
@@ -205,6 +209,7 @@ function hasCodexStartupUiRendered(text: string): boolean {
 export class TerminalSessionManager implements TerminalSessionService {
 	private readonly entries = new Map<string, SessionEntry>();
 	private readonly summaryListeners = new Set<(summary: RuntimeTaskSessionSummary) => void>();
+	private readonly chatListeners = new Set<(taskId: string, message: RuntimeTaskChatMessage) => void>();
 
 	private trySendDeferredCodexStartupInput(taskId: string): boolean {
 		const entry = this.entries.get(taskId);
@@ -242,6 +247,23 @@ export class TerminalSessionManager implements TerminalSessionService {
 		};
 	}
 
+	onChatMessage(listener: (taskId: string, message: RuntimeTaskChatMessage) => void): () => void {
+		this.chatListeners.add(listener);
+		return () => {
+			this.chatListeners.delete(listener);
+		};
+	}
+
+	listChatMessages(taskId: string): RuntimeTaskChatMessage[] {
+		const entry = this.entries.get(taskId);
+		return entry ? entry.chatMessages.map((message) => ({ ...message })) : [];
+	}
+
+	appendChatMessage(taskId: string, message: RuntimeTaskChatMessage): void {
+		const entry = this.ensureEntry(taskId);
+		this.upsertChatMessage(entry, message);
+	}
+
 	hydrateFromRecord(record: Record<string, RuntimeTaskSessionSummary>): void {
 		for (const [taskId, summary] of Object.entries(record)) {
 			this.entries.set(taskId, {
@@ -254,6 +276,8 @@ export class TerminalSessionManager implements TerminalSessionService {
 				suppressAutoRestartOnExit: false,
 				autoRestartTimestamps: [],
 				pendingAutoRestart: null,
+				chatMessages: [],
+				chatLineBuffer: "",
 			});
 		}
 	}
@@ -299,6 +323,9 @@ export class TerminalSessionManager implements TerminalSessionService {
 			request: cloneStartTaskSessionRequest(request),
 		};
 		if (entry.active && isActiveState(entry.summary.state)) {
+			if (request.agentId === "ag2" && request.prompt.trim().length > 0) {
+				throw new Error("AG2 is still running. Wait for it to finish, then send.");
+			}
 			return cloneSummary(entry.summary);
 		}
 
@@ -309,6 +336,10 @@ export class TerminalSessionManager implements TerminalSessionService {
 		}
 		entry.terminalStateMirror?.dispose();
 		entry.terminalStateMirror = null;
+		if (request.agentId !== "ag2") {
+			entry.chatMessages = [];
+		}
+		entry.chatLineBuffer = "";
 
 		const cols = Number.isFinite(request.cols) && (request.cols ?? 0) > 0 ? Math.floor(request.cols ?? 0) : 120;
 		const rows = Number.isFinite(request.rows) && (request.rows ?? 0) > 0 ? Math.floor(request.rows ?? 0) : 40;
@@ -366,13 +397,26 @@ export class TerminalSessionManager implements TerminalSessionService {
 					if (filteredChunk.byteLength === 0) {
 						return;
 					}
-					entry.terminalStateMirror?.applyOutput(filteredChunk);
+					let displayChunk = filteredChunk;
+					if (request.agentId === "ag2") {
+						const consumed = consumeAg2ChatOutput(entry.chatLineBuffer, filteredChunk.toString("utf8"));
+						entry.chatLineBuffer = consumed.buffer;
+						for (const message of consumed.messages) {
+							this.upsertChatMessage(entry, message);
+						}
+						if (consumed.passthrough.length === 0) {
+							updateSummary(entry, { lastOutputAt: now() });
+							return;
+						}
+						displayChunk = Buffer.from(consumed.passthrough, "utf8");
+					}
+					entry.terminalStateMirror?.applyOutput(displayChunk);
 
 					const needsDecodedOutput =
 						entry.active.workspaceTrustBuffer !== null ||
 						(entry.active.detectOutputTransition !== null &&
 							(entry.active.shouldInspectOutputForTransition?.(entry.summary) ?? true));
-					const data = needsDecodedOutput ? filteredChunk.toString("utf8") : "";
+					const data = needsDecodedOutput ? displayChunk.toString("utf8") : "";
 
 					if (entry.active.workspaceTrustBuffer !== null) {
 						entry.active.workspaceTrustBuffer += data;
@@ -439,7 +483,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 					}
 
 					for (const taskListener of entry.listeners.values()) {
-						taskListener.onOutput?.(filteredChunk);
+						taskListener.onOutput?.(displayChunk);
 					}
 				},
 				onExit: (event) => {
@@ -974,6 +1018,8 @@ export class TerminalSessionManager implements TerminalSessionService {
 			suppressAutoRestartOnExit: false,
 			autoRestartTimestamps: [],
 			pendingAutoRestart: null,
+			chatMessages: [],
+			chatLineBuffer: "",
 		};
 		this.entries.set(taskId, created);
 		return created;
@@ -983,6 +1029,11 @@ export class TerminalSessionManager implements TerminalSessionService {
 		const wasSuppressed = entry.suppressAutoRestartOnExit;
 		entry.suppressAutoRestartOnExit = false;
 		if (wasSuppressed) {
+			return false;
+		}
+		// AG2 is a one-shot `mlx-agents ag2-run` PTY, not a long-lived TUI.
+		// Restarting it after a clean exit re-runs the whole supervisor loop.
+		if (entry.summary.agentId === "ag2") {
 			return false;
 		}
 		if (entry.listeners.size === 0 || entry.restartRequest?.kind !== "task") {
@@ -1035,6 +1086,19 @@ export class TerminalSessionManager implements TerminalSessionService {
 		const snapshot = cloneSummary(summary);
 		for (const listener of this.summaryListeners) {
 			listener(snapshot);
+		}
+	}
+
+	private upsertChatMessage(entry: SessionEntry, message: RuntimeTaskChatMessage): void {
+		const existingIndex = entry.chatMessages.findIndex((current) => current.id === message.id);
+		if (existingIndex >= 0) {
+			entry.chatMessages[existingIndex] = message;
+		} else {
+			entry.chatMessages.push(message);
+		}
+		const snapshot = { ...message };
+		for (const listener of this.chatListeners) {
+			listener(entry.summary.taskId, snapshot);
 		}
 	}
 }

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -397,6 +397,16 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		getTaskChatMessages: async (workspaceScope, input) => {
 			try {
 				const body = parseTaskChatMessagesRequest(input);
+				const scopedRuntimeConfig = workspaceScope ? await deps.loadScopedRuntimeConfig(workspaceScope) : null;
+				const terminalManager = workspaceScope ? await deps.getScopedTerminalManager(workspaceScope) : null;
+				const terminalSummary = terminalManager?.getSummary?.(body.taskId) ?? null;
+				const effectiveAgentId = terminalSummary?.agentId ?? scopedRuntimeConfig?.selectedAgentId ?? null;
+				if (effectiveAgentId === "ag2") {
+					return {
+						ok: true,
+						messages: terminalManager?.listChatMessages?.(body.taskId) ?? [],
+					};
+				}
 				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				const summary = clineTaskSessionService.getSummary(body.taskId);
 				const messages = await clineTaskSessionService.loadTaskSessionMessages(body.taskId);
@@ -406,8 +416,7 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						messages,
 					};
 				}
-				const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
-				const ptyMessages = terminalManager.listChatMessages?.(body.taskId) ?? [];
+				const ptyMessages = terminalManager?.listChatMessages?.(body.taskId) ?? [];
 				if (ptyMessages.length > 0) {
 					return {
 						ok: true,

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -17,6 +17,7 @@ import { updateGlobalRuntimeConfig, updateRuntimeConfig } from "../config/runtim
 import type {
 	RuntimeCommandRunResponse,
 	RuntimeRunUpdateResponse,
+	RuntimeTaskChatMessage,
 	RuntimeUpdateStatusResponse,
 } from "../core/api-contract";
 import {
@@ -44,6 +45,7 @@ import {
 import { isHomeAgentSessionId } from "../core/home-agent-session";
 import { resolveTaskTitle } from "../core/task-title.js";
 import { openInBrowser } from "../server/browser";
+import { listProjectSkillSlashCommands } from "../skills/project-skills";
 import { buildRuntimeConfigResponse, resolveAgentCommand } from "../terminal/agent-registry";
 import type { TerminalSessionManager } from "../terminal/session-manager";
 import { resolveTaskCwd } from "../workspace/task-worktree";
@@ -89,6 +91,17 @@ async function resolveExistingTaskCwdOrEnsure(options: {
 			ensure: true,
 		});
 	}
+}
+
+function buildAg2FollowUpPrompt(prior: RuntimeTaskChatMessage[], text: string): string {
+	const snippets = prior
+		.filter((message) => message.role === "user" || message.role === "assistant")
+		.slice(-4)
+		.map((message) => `${message.role}: ${message.content.slice(0, 800)}`);
+	if (snippets.length === 0) {
+		return text;
+	}
+	return `Prior conversation:\n${snippets.join("\n\n")}\n\nFollow-up from the user:\n${text}`;
 }
 
 export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrpcContext["runtimeApi"] {
@@ -387,16 +400,24 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				const summary = clineTaskSessionService.getSummary(body.taskId);
 				const messages = await clineTaskSessionService.loadTaskSessionMessages(body.taskId);
-				if (!summary && messages.length === 0) {
+				if (summary || messages.length > 0) {
 					return {
-						ok: false,
-						messages: [],
-						error: "Task chat session is not available.",
+						ok: true,
+						messages,
+					};
+				}
+				const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
+				const ptyMessages = terminalManager.listChatMessages?.(body.taskId) ?? [];
+				if (ptyMessages.length > 0) {
+					return {
+						ok: true,
+						messages: ptyMessages,
 					};
 				}
 				return {
-					ok: true,
-					messages,
+					ok: false,
+					messages: [],
+					error: "Task chat session is not available.",
 				};
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
@@ -409,8 +430,19 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		},
 		getClineSlashCommands: async (workspaceScope) => {
 			if (!workspaceScope) {
+				return { commands: [] };
+			}
+			const scopedRuntimeConfig = await deps.loadScopedRuntimeConfig(workspaceScope);
+			if (scopedRuntimeConfig.selectedAgentId === "ag2") {
 				return {
-					commands: [],
+					commands: [
+						{
+							name: "clear",
+							instructions: "",
+							description: "Start a fresh chat session and clear prior context.",
+						},
+						...listProjectSkillSlashCommands(workspaceScope.workspacePath),
+					],
 				};
 			}
 			const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
@@ -487,16 +519,24 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				const body = parseTaskChatCancelRequest(input);
 				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				const summary = await clineTaskSessionService.cancelTaskTurn(body.taskId);
-				if (!summary) {
+				if (summary) {
 					return {
-						ok: false,
-						summary: null,
-						error: "Task chat session turn is not running.",
+						ok: true,
+						summary,
+					};
+				}
+				const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
+				const ptySummary = terminalManager.stopTaskSession?.(body.taskId) ?? null;
+				if (ptySummary) {
+					return {
+						ok: true,
+						summary: ptySummary,
 					};
 				}
 				return {
-					ok: true,
-					summary,
+					ok: false,
+					summary: null,
+					error: "Task chat session turn is not running.",
 				};
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
@@ -606,40 +646,87 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					requestedMode,
 					body.images,
 				);
+				if (!summary && !isHomeAgentSessionId(body.taskId)) {
+					const reboundSummary = await clineTaskSessionService.rebindPersistedTaskSession(body.taskId);
+					if (reboundSummary) {
+						summary = await clineTaskSessionService.sendTaskSessionInput(
+							body.taskId,
+							body.text,
+							requestedMode,
+							body.images,
+						);
+					}
+				}
 				if (!summary) {
-					if (!isHomeAgentSessionId(body.taskId)) {
-						const reboundSummary = await clineTaskSessionService.rebindPersistedTaskSession(body.taskId);
-						if (reboundSummary) {
-							summary = await clineTaskSessionService.sendTaskSessionInput(
-								body.taskId,
-								body.text,
-								requestedMode,
-								body.images,
-							);
-						}
-						if (!summary) {
+					const scopedRuntimeConfig = await deps.loadScopedRuntimeConfig(workspaceScope);
+					const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
+					const ptyAgent =
+						terminalManager.getSummary?.(body.taskId)?.agentId ?? scopedRuntimeConfig.selectedAgentId;
+					if (ptyAgent === "ag2") {
+						const resolved = resolveAgentCommand({ ...scopedRuntimeConfig, selectedAgentId: "ag2" });
+						if (!resolved) {
 							return {
 								ok: false,
 								summary: null,
-								error: "Task chat session is not running.",
+								error: "AG2 is not installed. mlx-agents must be on PATH.",
 							};
 						}
-					} else {
-						const clineLaunchConfig = await clineProviderService.resolveLaunchConfig();
-						summary = await clineTaskSessionService.startTaskSession({
-							taskId: body.taskId,
-							cwd: workspaceScope.workspacePath,
-							prompt: body.text,
-							images: body.images,
-							resumeFromPersistence: true,
-							providerId: clineLaunchConfig.providerId,
-							modelId: clineLaunchConfig.modelId,
-							mode: requestedMode,
-							apiKey: clineLaunchConfig.apiKey,
-							baseUrl: clineLaunchConfig.baseUrl,
-							reasoningEffort: clineLaunchConfig.reasoningEffort,
+						const prior = terminalManager.listChatMessages(body.taskId);
+						const prompt = buildAg2FollowUpPrompt(prior, body.text);
+						terminalManager.appendChatMessage(body.taskId, {
+							id: `ag2-user-${Date.now()}`,
+							role: "user",
+							content: body.text,
+							createdAt: Date.now(),
+							meta: null,
 						});
+						const taskCwd = isHomeAgentSessionId(body.taskId)
+							? workspaceScope.workspacePath
+							: await resolveExistingTaskCwdOrEnsure({
+									cwd: workspaceScope.workspacePath,
+									taskId: body.taskId,
+									baseRef: "HEAD",
+								});
+						summary = await terminalManager.startTaskSession({
+							taskId: body.taskId,
+							agentId: "ag2",
+							binary: resolved.binary,
+							args: resolved.args,
+							autonomousModeEnabled: scopedRuntimeConfig.agentAutonomousModeEnabled,
+							cwd: taskCwd,
+							prompt,
+							images: body.images,
+							cols: 120,
+							rows: 40,
+							workspaceId: workspaceScope.workspaceId,
+						});
+						return {
+							ok: true,
+							summary,
+							message: terminalManager.listChatMessages(body.taskId).at(-1) ?? null,
+						};
 					}
+					if (!isHomeAgentSessionId(body.taskId)) {
+						return {
+							ok: false,
+							summary: null,
+							error: "Task chat session is not running.",
+						};
+					}
+					const clineLaunchConfig = await clineProviderService.resolveLaunchConfig();
+					summary = await clineTaskSessionService.startTaskSession({
+						taskId: body.taskId,
+						cwd: workspaceScope.workspacePath,
+						prompt: body.text,
+						images: body.images,
+						resumeFromPersistence: true,
+						providerId: clineLaunchConfig.providerId,
+						modelId: clineLaunchConfig.modelId,
+						mode: requestedMode,
+						apiKey: clineLaunchConfig.apiKey,
+						baseUrl: clineLaunchConfig.baseUrl,
+						reasoningEffort: clineLaunchConfig.reasoningEffort,
+					});
 				}
 				const latestMessage = clineTaskSessionService.listMessages(body.taskId).at(-1) ?? null;
 				return {

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -14,10 +14,11 @@ import { isClineClearSlashCommand } from "../cline-sdk/cline-slash-commands";
 import type { ClineTaskSessionService } from "../cline-sdk/cline-task-session-service";
 import type { RuntimeConfigState } from "../config/runtime-config";
 import { updateGlobalRuntimeConfig, updateRuntimeConfig } from "../config/runtime-config";
+import { getAgentCapabilities, getRuntimeAgentCatalogEntry, isClineSdkBackend } from "../core/agent-catalog";
 import type {
+	RuntimeAgentId,
 	RuntimeCommandRunResponse,
 	RuntimeRunUpdateResponse,
-	RuntimeTaskChatMessage,
 	RuntimeUpdateStatusResponse,
 } from "../core/api-contract";
 import {
@@ -47,6 +48,7 @@ import { resolveTaskTitle } from "../core/task-title.js";
 import { openInBrowser } from "../server/browser";
 import { listProjectSkillSlashCommands } from "../skills/project-skills";
 import { buildRuntimeConfigResponse, resolveAgentCommand } from "../terminal/agent-registry";
+import { buildAgentFollowUpPrompt } from "../terminal/agent-session-adapters";
 import type { TerminalSessionManager } from "../terminal/session-manager";
 import { resolveTaskCwd } from "../workspace/task-worktree";
 import { captureTaskTurnCheckpoint } from "../workspace/turn-checkpoints";
@@ -93,15 +95,12 @@ async function resolveExistingTaskCwdOrEnsure(options: {
 	}
 }
 
-function buildAg2FollowUpPrompt(prior: RuntimeTaskChatMessage[], text: string): string {
-	const snippets = prior
-		.filter((message) => message.role === "user" || message.role === "assistant")
-		.slice(-4)
-		.map((message) => `${message.role}: ${message.content.slice(0, 800)}`);
-	if (snippets.length === 0) {
-		return text;
-	}
-	return `Prior conversation:\n${snippets.join("\n\n")}\n\nFollow-up from the user:\n${text}`;
+function resolveChatAgentId(
+	terminalManager: TerminalSessionManager | null | undefined,
+	selectedAgentId: RuntimeAgentId | null | undefined,
+	taskId: string,
+): RuntimeAgentId | null {
+	return terminalManager?.getSummary?.(taskId)?.agentId ?? selectedAgentId ?? null;
 }
 
 export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrpcContext["runtimeApi"] {
@@ -213,7 +212,7 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					? (terminalManager.getSummary(body.taskId)?.agentId ?? null)
 					: null;
 				const effectiveAgentId = previousTerminalAgentId ?? body.agentId ?? scopedRuntimeConfig.selectedAgentId;
-				let useClinePath = effectiveAgentId === "cline";
+				let useClinePath = isClineSdkBackend(effectiveAgentId);
 				const shouldProbePersistedClineSession =
 					body.resumeFromTrash && !useClinePath && previousTerminalAgentId === null;
 				if (shouldProbePersistedClineSession) {
@@ -401,7 +400,8 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				const terminalManager = workspaceScope ? await deps.getScopedTerminalManager(workspaceScope) : null;
 				const terminalSummary = terminalManager?.getSummary?.(body.taskId) ?? null;
 				const effectiveAgentId = terminalSummary?.agentId ?? scopedRuntimeConfig?.selectedAgentId ?? null;
-				if (effectiveAgentId === "ag2") {
+				const capabilities = getAgentCapabilities(effectiveAgentId);
+				if (capabilities?.uiSurface === "chat" && capabilities.backend === "pty") {
 					return {
 						ok: true,
 						messages: terminalManager?.listChatMessages?.(body.taskId) ?? [],
@@ -442,7 +442,8 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 				return { commands: [] };
 			}
 			const scopedRuntimeConfig = await deps.loadScopedRuntimeConfig(workspaceScope);
-			if (scopedRuntimeConfig.selectedAgentId === "ag2") {
+			const slashSource = getAgentCapabilities(scopedRuntimeConfig.selectedAgentId)?.slashSource;
+			if (slashSource === "project-skills") {
 				return {
 					commands: [
 						{
@@ -454,6 +455,9 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					],
 				};
 			}
+			if (slashSource === "none") {
+				return { commands: [] };
+			}
 			const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 			return {
 				commands: await clineTaskSessionService.listSlashCommands(workspaceScope.workspacePath),
@@ -462,6 +466,15 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		reloadTaskChatSession: async (workspaceScope, input) => {
 			try {
 				const body = parseTaskChatReloadRequest(input);
+				const scopedRuntimeConfig = workspaceScope ? await deps.loadScopedRuntimeConfig(workspaceScope) : null;
+				const terminalManager = workspaceScope ? await deps.getScopedTerminalManager(workspaceScope) : null;
+				const agentId = resolveChatAgentId(terminalManager, scopedRuntimeConfig?.selectedAgentId, body.taskId);
+				if (getAgentCapabilities(agentId)?.backend === "pty") {
+					return {
+						ok: true,
+						summary: terminalManager?.getSummary?.(body.taskId) ?? null,
+					};
+				}
 				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				let summary = await clineTaskSessionService.reloadTaskSession(body.taskId);
 				if (!summary && isHomeAgentSessionId(body.taskId)) {
@@ -501,6 +514,23 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		abortTaskChatTurn: async (workspaceScope, input) => {
 			try {
 				const body = parseTaskChatAbortRequest(input);
+				const scopedRuntimeConfig = workspaceScope ? await deps.loadScopedRuntimeConfig(workspaceScope) : null;
+				const terminalManager = workspaceScope ? await deps.getScopedTerminalManager(workspaceScope) : null;
+				const agentId = resolveChatAgentId(terminalManager, scopedRuntimeConfig?.selectedAgentId, body.taskId);
+				if (getAgentCapabilities(agentId)?.backend === "pty") {
+					const summary = terminalManager?.stopTaskSession?.(body.taskId) ?? null;
+					if (!summary) {
+						return {
+							ok: false,
+							summary: null,
+							error: "Task chat session is not running.",
+						};
+					}
+					return {
+						ok: true,
+						summary,
+					};
+				}
 				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				const summary = await clineTaskSessionService.abortTaskSession(body.taskId);
 				if (!summary) {
@@ -638,8 +668,22 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 		sendTaskChatMessage: async (workspaceScope, input) => {
 			try {
 				const body = parseTaskChatSendRequest(input);
-				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
+				const scopedRuntimeConfig = await deps.loadScopedRuntimeConfig(workspaceScope);
+				const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
+				const ptyAgent = resolveChatAgentId(terminalManager, scopedRuntimeConfig.selectedAgentId, body.taskId);
+				const capabilities = getAgentCapabilities(ptyAgent);
+
 				if (isClineClearSlashCommand(body.text)) {
+					if (capabilities?.slashSource === "project-skills") {
+						terminalManager.clearChatMessages(body.taskId);
+						deps.broadcastTaskChatCleared?.(workspaceScope.workspaceId, body.taskId);
+						return {
+							ok: true,
+							summary: terminalManager.getSummary(body.taskId),
+							message: null,
+						};
+					}
+					const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 					const summary = await clineTaskSessionService.clearTaskSession(body.taskId);
 					deps.broadcastTaskChatCleared?.(workspaceScope.workspaceId, body.taskId);
 					return {
@@ -648,6 +692,54 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 						message: null,
 					};
 				}
+
+				if (capabilities?.followUp === "restart-pty-with-context" && ptyAgent) {
+					const catalog = getRuntimeAgentCatalogEntry(ptyAgent);
+					const resolved = resolveAgentCommand({ ...scopedRuntimeConfig, selectedAgentId: ptyAgent });
+					if (!resolved) {
+						return {
+							ok: false,
+							summary: null,
+							error: `${catalog?.label ?? ptyAgent} is not installed. ${catalog?.binary ?? "the agent binary"} must be on PATH.`,
+						};
+					}
+					const prior = terminalManager.listChatMessages(body.taskId);
+					const prompt = buildAgentFollowUpPrompt(ptyAgent, prior, body.text);
+					terminalManager.appendChatMessage(body.taskId, {
+						id: `${ptyAgent}-user-${Date.now()}`,
+						role: "user",
+						content: body.text,
+						createdAt: Date.now(),
+						meta: null,
+					});
+					const taskCwd = isHomeAgentSessionId(body.taskId)
+						? workspaceScope.workspacePath
+						: await resolveExistingTaskCwdOrEnsure({
+								cwd: workspaceScope.workspacePath,
+								taskId: body.taskId,
+								baseRef: "HEAD",
+							});
+					const summary = await terminalManager.startTaskSession({
+						taskId: body.taskId,
+						agentId: ptyAgent,
+						binary: resolved.binary,
+						args: resolved.args,
+						autonomousModeEnabled: scopedRuntimeConfig.agentAutonomousModeEnabled,
+						cwd: taskCwd,
+						prompt,
+						images: body.images,
+						cols: 120,
+						rows: 40,
+						workspaceId: workspaceScope.workspaceId,
+					});
+					return {
+						ok: true,
+						summary,
+						message: terminalManager.listChatMessages(body.taskId).at(-1) ?? null,
+					};
+				}
+
+				const clineTaskSessionService = await deps.getScopedClineTaskSessionService(workspaceScope);
 				const requestedMode = body.mode;
 				let summary = await clineTaskSessionService.sendTaskSessionInput(
 					body.taskId,
@@ -667,54 +759,6 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					}
 				}
 				if (!summary) {
-					const scopedRuntimeConfig = await deps.loadScopedRuntimeConfig(workspaceScope);
-					const terminalManager = await deps.getScopedTerminalManager(workspaceScope);
-					const ptyAgent =
-						terminalManager.getSummary?.(body.taskId)?.agentId ?? scopedRuntimeConfig.selectedAgentId;
-					if (ptyAgent === "ag2") {
-						const resolved = resolveAgentCommand({ ...scopedRuntimeConfig, selectedAgentId: "ag2" });
-						if (!resolved) {
-							return {
-								ok: false,
-								summary: null,
-								error: "AG2 is not installed. mlx-agents must be on PATH.",
-							};
-						}
-						const prior = terminalManager.listChatMessages(body.taskId);
-						const prompt = buildAg2FollowUpPrompt(prior, body.text);
-						terminalManager.appendChatMessage(body.taskId, {
-							id: `ag2-user-${Date.now()}`,
-							role: "user",
-							content: body.text,
-							createdAt: Date.now(),
-							meta: null,
-						});
-						const taskCwd = isHomeAgentSessionId(body.taskId)
-							? workspaceScope.workspacePath
-							: await resolveExistingTaskCwdOrEnsure({
-									cwd: workspaceScope.workspacePath,
-									taskId: body.taskId,
-									baseRef: "HEAD",
-								});
-						summary = await terminalManager.startTaskSession({
-							taskId: body.taskId,
-							agentId: "ag2",
-							binary: resolved.binary,
-							args: resolved.args,
-							autonomousModeEnabled: scopedRuntimeConfig.agentAutonomousModeEnabled,
-							cwd: taskCwd,
-							prompt,
-							images: body.images,
-							cols: 120,
-							rows: 40,
-							workspaceId: workspaceScope.workspaceId,
-						});
-						return {
-							ok: true,
-							summary,
-							message: terminalManager.listChatMessages(body.taskId).at(-1) ?? null,
-						};
-					}
 					if (!isHomeAgentSessionId(body.taskId)) {
 						return {
 							ok: false,

--- a/src/workspace/task-worktree.ts
+++ b/src/workspace/task-worktree.ts
@@ -1,4 +1,4 @@
-import { access, lstat, mkdir, readdir, readFile, rm, symlink } from "node:fs/promises";
+import { access, cp, lstat, mkdir, readdir, readFile, rm, symlink } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 
 import type {
@@ -62,6 +62,24 @@ async function pathExists(path: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+export const PROJECT_SKILL_TREES = [".agents", ".cline/skills", ".cursor/skills", ".clinerules"] as const;
+
+export async function copyProjectSkillTrees(repoPath: string, worktreePath: string): Promise<string[]> {
+	const copied: string[] = [];
+	for (const relativePath of PROJECT_SKILL_TREES) {
+		const sourcePath = join(repoPath, relativePath);
+		if (!(await pathExists(sourcePath))) {
+			continue;
+		}
+		const targetPath = join(worktreePath, relativePath);
+		await rm(targetPath, { recursive: true, force: true });
+		await mkdir(dirname(targetPath), { recursive: true });
+		await cp(sourcePath, targetPath, { recursive: true });
+		copied.push(relativePath);
+	}
+	return copied;
 }
 
 function isMissingInitialCommitError(message: string): boolean {
@@ -386,6 +404,7 @@ async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: stri
 			isDirectory: sourceStat.isDirectory(),
 		});
 	}
+	await copyProjectSkillTrees(repoPath, worktreePath);
 }
 
 async function initializeSubmodulesIfNeeded(worktreePath: string): Promise<void> {

--- a/test/runtime/config/runtime-config.test.ts
+++ b/test/runtime/config/runtime-config.test.ts
@@ -73,6 +73,7 @@ describe.sequential("runtime-config auto agent selection", () => {
 		expect(pickBestInstalledAgentIdFromDetected(["droid", "gemini", "cline"])).toBe("droid");
 		expect(pickBestInstalledAgentIdFromDetected(["gemini", "cline"])).toBeNull();
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "codex", "cline"])).toBe("claude");
+		expect(pickBestInstalledAgentIdFromDetected(["mlx-agents"])).toBe("ag2");
 		expect(pickBestInstalledAgentIdFromDetected(["claude", "droid"])).toBe("claude");
 		expect(pickBestInstalledAgentIdFromDetected(["cline"])).toBeNull();
 		expect(pickBestInstalledAgentIdFromDetected([])).toBeNull();

--- a/test/runtime/core/agent-catalog.test.ts
+++ b/test/runtime/core/agent-catalog.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getAgentCapabilities,
+	isChatPanelAgent,
+	isClineSdkBackend,
+	PTY_TUI_CAPABILITIES,
+	RUNTIME_AGENT_CATALOG,
+} from "../../../src/core/agent-catalog";
+
+describe("agent catalog capabilities", () => {
+	it("gives TUI CLIs a long-lived PTY terminal surface", () => {
+		for (const id of ["claude", "codex", "droid", "kiro", "gemini", "opencode"] as const) {
+			expect(getAgentCapabilities(id)).toEqual(PTY_TUI_CAPABILITIES);
+			expect(isChatPanelAgent(id)).toBe(false);
+			expect(isClineSdkBackend(id)).toBe(false);
+		}
+	});
+
+	it("routes Cline through the in-process SDK chat panel", () => {
+		expect(getAgentCapabilities("cline")).toMatchObject({
+			uiSurface: "chat",
+			backend: "cline-sdk",
+			slashSource: "cline-sdk",
+			followUp: "sdk-send",
+			showModelPicker: true,
+		});
+		expect(isChatPanelAgent("cline")).toBe(true);
+		expect(isClineSdkBackend("cline")).toBe(true);
+	});
+
+	it("routes AG2 as a one-shot PTY chat agent without Cline hydrate", () => {
+		expect(getAgentCapabilities("ag2")).toMatchObject({
+			uiSurface: "chat",
+			backend: "pty",
+			sessionKind: "oneshot",
+			autoRestart: false,
+			preserveChatAcrossRestarts: true,
+			slashSource: "project-skills",
+			followUp: "restart-pty-with-context",
+			showModelPicker: false,
+			rejectFollowUpWhileRunning: true,
+		});
+		expect(isChatPanelAgent("ag2")).toBe(true);
+		expect(isClineSdkBackend("ag2")).toBe(false);
+	});
+
+	it("requires every catalog row to declare capabilities", () => {
+		for (const entry of RUNTIME_AGENT_CATALOG) {
+			expect(entry.capabilities).toEqual(getAgentCapabilities(entry.id));
+		}
+	});
+});

--- a/test/runtime/graceful-shutdown.test.ts
+++ b/test/runtime/graceful-shutdown.test.ts
@@ -168,6 +168,22 @@ describe("shouldSuppressImmediateDuplicateShutdownSignals", () => {
 			}),
 		).toBe(false);
 	});
+
+	it("enables duplicate suppression for tsx wrapper launches", () => {
+		expect(
+			shouldSuppressImmediateDuplicateShutdownSignals({
+				argv: ["/usr/local/bin/node", "/repo/node_modules/tsx/dist/cli.mjs", "/repo/src/cli.ts"],
+				env: {},
+			}),
+		).toBe(true);
+		expect(
+			shouldSuppressImmediateDuplicateShutdownSignals({
+				argv: ["/usr/local/bin/node", "/repo/src/cli.ts"],
+				env: {},
+				execArgv: ["--import", "tsx"],
+			}),
+		).toBe(true);
+	});
 });
 
 describe("getExitCodeForSignal", () => {

--- a/test/runtime/skills/project-skills.test.ts
+++ b/test/runtime/skills/project-skills.test.ts
@@ -1,0 +1,41 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { listProjectSkillSlashCommands } from "../../../src/skills/project-skills";
+
+describe("listProjectSkillSlashCommands", () => {
+	const cleanups: Array<() => Promise<void>> = [];
+	afterEach(async () => {
+		await Promise.all(cleanups.splice(0).map((fn) => fn()));
+	});
+
+	it("lists nested skills and prefers .cline over .agents", async () => {
+		const root = await mkdtemp(join(tmpdir(), "kanban-skill-list-"));
+		cleanups.push(async () => {
+			await rm(root, { recursive: true, force: true });
+		});
+		await mkdir(join(root, ".cline", "skills", "shared"), { recursive: true });
+		await mkdir(join(root, ".agents", "skills", "shared"), { recursive: true });
+		await mkdir(join(root, ".agents", "skills", "docs", "mdcp-doc-only"), { recursive: true });
+		await writeFile(
+			join(root, ".cline", "skills", "shared", "SKILL.md"),
+			"---\nname: shared\ndescription: From cline\n---\n",
+		);
+		await writeFile(
+			join(root, ".agents", "skills", "shared", "SKILL.md"),
+			"---\nname: shared\ndescription: From agents\n---\n",
+		);
+		await writeFile(
+			join(root, ".agents", "skills", "docs", "mdcp-doc-only", "SKILL.md"),
+			"---\nname: mdcp-doc-only\ndescription: Author MDCP shards.\ndisable-model-invocation: true\n---\n",
+		);
+		const commands = listProjectSkillSlashCommands(root);
+		const shared = commands.find((command) => command.name === "shared");
+		const mdcp = commands.find((command) => command.name === "mdcp-doc-only");
+		expect(shared?.description).toBe("From cline");
+		expect(mdcp?.description).toBe("Author MDCP shards.");
+	});
+});

--- a/test/runtime/task-worktree-skill-copy.test.ts
+++ b/test/runtime/task-worktree-skill-copy.test.ts
@@ -1,0 +1,38 @@
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { copyProjectSkillTrees } from "../../src/workspace/task-worktree";
+
+describe("copyProjectSkillTrees", () => {
+	const cleanups: Array<() => Promise<void>> = [];
+
+	afterEach(async () => {
+		await Promise.all(cleanups.splice(0).map((fn) => fn()));
+	});
+
+	it("copies skill trees as real directories, overwriting stale worktree copies", async () => {
+		const root = await mkdtemp(join(tmpdir(), "kanban-skill-copy-"));
+		cleanups.push(async () => {
+			await rm(root, { recursive: true, force: true });
+		});
+		const repo = join(root, "repo");
+		const worktree = join(root, "worktree");
+		await mkdir(join(repo, ".cline", "skills", "boot"), { recursive: true });
+		await mkdir(join(repo, ".agents", "skills", "mdcp"), { recursive: true });
+		await writeFile(join(repo, ".cline", "skills", "boot", "SKILL.md"), "parent boot\n");
+		await writeFile(join(repo, ".agents", "skills", "mdcp", "SKILL.md"), "parent mdcp\n");
+		await mkdir(join(worktree, ".cline", "skills", "boot"), { recursive: true });
+		await writeFile(join(worktree, ".cline", "skills", "boot", "SKILL.md"), "stale\n");
+
+		const copied = await copyProjectSkillTrees(repo, worktree);
+
+		expect(copied.sort()).toEqual([".agents", ".cline/skills"]);
+		expect(await readFile(join(worktree, ".cline", "skills", "boot", "SKILL.md"), "utf8")).toBe("parent boot\n");
+		expect(await readFile(join(worktree, ".agents", "skills", "mdcp", "SKILL.md"), "utf8")).toBe("parent mdcp\n");
+		const st = await lstat(join(worktree, ".agents"));
+		expect(st.isSymbolicLink()).toBe(false);
+	});
+});

--- a/test/runtime/terminal/ag2-chat-stream.test.ts
+++ b/test/runtime/terminal/ag2-chat-stream.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { consumeAg2ChatOutput } from "../../../src/terminal/ag2-chat-stream";
+
+describe("consumeAg2ChatOutput", () => {
+	it("parses complete AG2_CHAT lines and leaves other output for the PTY", () => {
+		const result = consumeAg2ChatOutput(
+			"",
+			'hello\nAG2_CHAT {"id":"r1","role":"reasoning","content":"planning","createdAt":1}\nworld\n',
+		);
+
+		expect(result.messages).toEqual([
+			{
+				id: "r1",
+				role: "reasoning",
+				content: "planning",
+				createdAt: 1,
+				meta: null,
+			},
+		]);
+		expect(result.passthrough).toBe("hello\nworld\n");
+		expect(result.buffer).toBe("");
+	});
+
+	it("holds a partial trailing line in the buffer", () => {
+		const first = consumeAg2ChatOutput("", 'AG2_CHAT {"id":"a1","role":"assistant","content":"ok"');
+		expect(first.messages).toEqual([]);
+		expect(first.passthrough).toBe("");
+
+		const second = consumeAg2ChatOutput(first.buffer, ',"createdAt":2}\n');
+		expect(second.messages).toEqual([
+			{
+				id: "a1",
+				role: "assistant",
+				content: "ok",
+				createdAt: 2,
+				meta: null,
+			},
+		]);
+		expect(second.buffer).toBe("");
+	});
+
+	it("ignores malformed AG2_CHAT payloads", () => {
+		const result = consumeAg2ChatOutput("", 'AG2_CHAT {not-json}\nAG2_CHAT {"role":"assistant"}\n');
+		expect(result.messages).toEqual([]);
+		expect(result.passthrough).toBe("");
+	});
+
+	it("drops AG2 CLI banners so the native chat panel is the only UI", () => {
+		const result = consumeAg2ChatOutput(
+			"",
+			"[ag2] start role=supervisor\n[kanban-hook] to_in_progress\n[tool] list_dir .\nkeep this error\n",
+		);
+		expect(result.passthrough).toBe("keep this error\n");
+		expect(result.messages).toEqual([]);
+	});
+});

--- a/test/runtime/terminal/agent-registry.test.ts
+++ b/test/runtime/terminal/agent-registry.test.ts
@@ -47,7 +47,7 @@ describe("agent-registry", () => {
 		const detected = detectInstalledCommands();
 
 		expect(detected).toEqual(["claude"]);
-		expect(commandDiscoveryMocks.isBinaryAvailableOnPath).toHaveBeenCalledTimes(8);
+		expect(commandDiscoveryMocks.isBinaryAvailableOnPath).toHaveBeenCalledTimes(9);
 	});
 
 	it("treats shell-only agents as unavailable", () => {
@@ -78,12 +78,13 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(true);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro", "ag2"]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "droid")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "kiro")?.defaultArgs).toEqual(["chat"]);
+		expect(response.agents.find((agent) => agent.id === "ag2")?.defaultArgs).toEqual(["ag2-run"]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.installed).toBe(true);
 	});
 
@@ -106,7 +107,7 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(false);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro", "ag2"]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);
@@ -117,6 +118,7 @@ describe("buildRuntimeConfigResponse", () => {
 		expect(response.agents.find((agent) => agent.id === "codex")?.command).toBe("codex");
 		expect(response.agents.find((agent) => agent.id === "droid")?.command).toBe("droid");
 		expect(response.agents.find((agent) => agent.id === "kiro")?.command).toBe("kiro-cli chat");
+		expect(response.agents.find((agent) => agent.id === "ag2")?.command).toBe("mlx-agents ag2-run");
 	});
 
 	it("sets debug mode from runtime environment variables", () => {

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -810,4 +810,29 @@ describe("prepareAgentLaunch hook strategies", () => {
 		});
 		expect(kiroLaunch.args).toContain("--trust-all-tools");
 	});
+
+	it("launches AG2 via mlx-agents ag2-run with Kanban hook env", async () => {
+		setupTempHome();
+		const launch = await prepareAgentLaunch({
+			taskId: "2ceb2",
+			agentId: "ag2",
+			binary: "mlx-agents",
+			args: [],
+			cwd: "/tmp/worktree",
+			prompt: "Create KANBAN-SMOKE.txt with ok",
+			workspaceId: "workspace-1",
+		});
+		expect(launch.binary ?? "mlx-agents").toBe("mlx-agents");
+		expect(launch.args[0]).toBe("ag2-run");
+		expect(launch.args).toContain("Create KANBAN-SMOKE.txt with ok");
+		expect(launch.args).toContain("--workspace");
+		expect(launch.args).toContain("/tmp/worktree");
+		expect(launch.args).toContain("--role");
+		expect(launch.args).toContain("supervisor");
+		expect(launch.args).toContain("--task-id");
+		expect(launch.args).toContain("2ceb2");
+		expect(launch.args).toContain("--ensure-server");
+		expect(launch.env.KANBAN_HOOK_TASK_ID).toBe("2ceb2");
+		expect(launch.env.KANBAN_HOOK_WORKSPACE_ID).toBe("workspace-1");
+	});
 });

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -834,5 +834,8 @@ describe("prepareAgentLaunch hook strategies", () => {
 		expect(launch.args).toContain("--ensure-server");
 		expect(launch.env.KANBAN_HOOK_TASK_ID).toBe("2ceb2");
 		expect(launch.env.KANBAN_HOOK_WORKSPACE_ID).toBe("workspace-1");
+		expect(launch.consumeOutput).toEqual(expect.any(Function));
+		expect(launch.buildFollowUpPrompt).toEqual(expect.any(Function));
+		expect(launch.buildFollowUpPrompt?.([], "next turn")).toBe("next turn");
 	});
 });

--- a/test/runtime/terminal/session-manager-auto-restart.test.ts
+++ b/test/runtime/terminal/session-manager-auto-restart.test.ts
@@ -83,6 +83,40 @@ describe("TerminalSessionManager auto-restart", () => {
 		expect(manager.getSummary("task-1")?.pid).toBe(222);
 	});
 
+	it("does not restart an attached AG2 session after a clean exit", async () => {
+		const spawnedSessions: Array<ReturnType<typeof createMockPtySession>> = [];
+		ptySessionSpawnMock.mockImplementation((request: MockSpawnRequest) => {
+			const session = createMockPtySession(111, request);
+			spawnedSessions.push(session);
+			return session;
+		});
+
+		const manager = new TerminalSessionManager();
+		manager.attach("task-ag2", {
+			onState: vi.fn(),
+			onOutput: vi.fn(),
+			onExit: vi.fn(),
+		});
+
+		await manager.startTaskSession({
+			taskId: "task-ag2",
+			agentId: "ag2",
+			binary: "mlx-agents",
+			args: ["ag2-run"],
+			cwd: "/tmp/task-ag2",
+			prompt: "Create KANBAN-SMOKE.txt with ok",
+		});
+
+		expect(ptySessionSpawnMock).toHaveBeenCalledTimes(1);
+		spawnedSessions[0]?.triggerExit(0);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(ptySessionSpawnMock).toHaveBeenCalledTimes(1);
+		expect(manager.getSummary("task-ag2")?.state).toBe("awaiting_review");
+		expect(manager.getSummary("task-ag2")?.pid).toBeNull();
+	});
+
 	it("does not restart an attached agent session after an explicit stop", async () => {
 		const spawnedSessions: Array<ReturnType<typeof createMockPtySession>> = [];
 		ptySessionSpawnMock.mockImplementation((request: MockSpawnRequest) => {

--- a/test/runtime/terminal/session-manager-chat.test.ts
+++ b/test/runtime/terminal/session-manager-chat.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+const prepareAgentLaunchMock = vi.hoisted(() => vi.fn());
+const ptySessionSpawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/terminal/agent-session-adapters.js", () => ({
+	prepareAgentLaunch: prepareAgentLaunchMock,
+}));
+
+vi.mock("../../../src/terminal/pty-session.js", () => ({
+	PtySession: {
+		spawn: ptySessionSpawnMock,
+	},
+}));
+
+import { TerminalSessionManager } from "../../../src/terminal/session-manager";
+
+interface MockSpawnRequest {
+	onData?: (chunk: Buffer) => void;
+	onExit?: (event: { exitCode: number | null; signal?: number }) => void;
+}
+
+function createMockPtySession(pid: number, request: MockSpawnRequest) {
+	return {
+		pid,
+		write: vi.fn(),
+		resize: vi.fn(),
+		pause: vi.fn(),
+		resume: vi.fn(),
+		stop: vi.fn(),
+		wasInterrupted: vi.fn(() => false),
+		triggerData: (chunk: string | Buffer) => {
+			request.onData?.(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8"));
+		},
+		triggerExit: (exitCode: number | null) => {
+			request.onExit?.({ exitCode });
+		},
+	};
+}
+
+describe("TerminalSessionManager chat consumeOutput", () => {
+	it("upserts chat messages from launch.consumeOutput for any agent id", async () => {
+		prepareAgentLaunchMock.mockImplementation(async (input: { args: string[]; binary?: string }) => ({
+			binary: input.binary,
+			args: [...input.args],
+			env: {},
+			consumeOutput: (_buffer: string, _chunk: string) => ({
+				buffer: "",
+				messages: [
+					{
+						id: "from-hook",
+						role: "assistant" as const,
+						content: "parsed from protocol",
+						createdAt: 1,
+						meta: null,
+					},
+				],
+				passthrough: "",
+			}),
+		}));
+		const spawnedSessions: Array<ReturnType<typeof createMockPtySession>> = [];
+		ptySessionSpawnMock.mockImplementation((request: MockSpawnRequest) => {
+			const session = createMockPtySession(111, request);
+			spawnedSessions.push(session);
+			return session;
+		});
+
+		const manager = new TerminalSessionManager();
+		await manager.startTaskSession({
+			taskId: "task-chat",
+			agentId: "claude",
+			binary: "claude",
+			args: [],
+			cwd: "/tmp/task-chat",
+			prompt: "hello",
+		});
+
+		spawnedSessions[0]?.triggerData("AG2_CHAT {}\n");
+		expect(manager.listChatMessages("task-chat")).toEqual([
+			{
+				id: "from-hook",
+				role: "assistant",
+				content: "parsed from protocol",
+				createdAt: 1,
+				meta: null,
+			},
+		]);
+	});
+});

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -243,6 +243,7 @@ function createClineTaskSessionServiceMock() {
 		listMessages: vi.fn<(...args: unknown[]) => unknown[]>(() => []),
 		loadTaskSessionMessages: vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []),
 		applyTurnCheckpoint: vi.fn<(...args: unknown[]) => RuntimeTaskSessionSummary | null>(() => null),
+		listSlashCommands: vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []),
 		dispose: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
 	};
 }
@@ -1422,6 +1423,96 @@ describe("createRuntimeApi startTaskSession", () => {
 		);
 		expect(cancelResponse.ok).toBe(true);
 		expect(clineTaskSessionService.cancelTaskTurn).toHaveBeenCalledWith("task-1");
+	});
+
+	it("starts a new AG2 PTY turn when the chat composer sends a follow-up", async () => {
+		const summary = createSummary({ agentId: "ag2", pid: 99, state: "awaiting_review" });
+		agentRegistryMocks.resolveAgentCommand.mockReturnValue({
+			agentId: "ag2",
+			label: "AG2",
+			command: "mlx-agents ag2-run",
+			binary: "mlx-agents",
+			args: ["ag2-run"],
+		});
+		taskWorktreeMocks.resolveTaskCwd.mockResolvedValue("/tmp/repo");
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+			listChatMessages: vi.fn(() => []),
+			appendChatMessage: vi.fn(),
+			startTaskSession: vi.fn(async () => summary),
+		};
+		const clineTaskSessionService = createClineTaskSessionServiceMock();
+		clineTaskSessionService.sendTaskSessionInput.mockResolvedValue(null);
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const sendResponse = await api.sendTaskChatMessage(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-ag2", text: "now summarize the architecture" },
+		);
+
+		expect(sendResponse.ok).toBe(true);
+		expect(terminalManager.appendChatMessage).toHaveBeenCalledWith(
+			"task-ag2",
+			expect.objectContaining({
+				role: "user",
+				content: "now summarize the architecture",
+			}),
+		);
+		expect(terminalManager.startTaskSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				taskId: "task-ag2",
+				agentId: "ag2",
+				prompt: "now summarize the architecture",
+			}),
+		);
+		expect(clineTaskSessionService.startTaskSession).not.toHaveBeenCalled();
+	});
+
+	it("lists AG2 slash skills from the project path without the Cline SDK", async () => {
+		const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const root = await mkdtemp(join(tmpdir(), "kanban-ag2-slash-"));
+		try {
+			await mkdir(join(root, ".cline", "skills", "boot-coder"), { recursive: true });
+			await writeFile(
+				join(root, ".cline", "skills", "boot-coder", "SKILL.md"),
+				"---\nname: boot-coder\ndescription: Boot the coder profile.\n---\n",
+			);
+			const clineTaskSessionService = createClineTaskSessionServiceMock();
+			const api = createTestRuntimeApi({
+				getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+				loadScopedRuntimeConfig: vi.fn(async () => ({
+					...createRuntimeConfigState(),
+					selectedAgentId: "ag2" as const,
+				})),
+				setActiveRuntimeConfig: vi.fn(),
+				getScopedTerminalManager: vi.fn(async () => ({}) as never),
+				getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
+				resolveInteractiveShellCommand: vi.fn(),
+				runCommand: vi.fn(),
+			});
+			const response = await api.getClineSlashCommands({
+				workspaceId: "workspace-1",
+				workspacePath: root,
+			});
+			expect(response.commands.some((command) => command.name === "boot-coder")).toBe(true);
+			expect(response.commands.some((command) => command.name === "clear")).toBe(true);
+			expect(clineTaskSessionService.listSlashCommands).not.toHaveBeenCalled();
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 
 	it("handles clear slash commands without sending them to the model", async () => {

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -1620,6 +1620,80 @@ describe("createRuntimeApi startTaskSession", () => {
 		expect(clineTaskSessionService.loadTaskSessionMessages).toHaveBeenCalledWith("task-1");
 	});
 
+	it("loads AG2 chat from the PTY without hydrating a Cline session host", async () => {
+		const ptyMessages = [
+			{
+				id: "ag2-assistant",
+				role: "assistant" as const,
+				content: "hello from AG2",
+				createdAt: 1,
+			},
+		];
+		const terminalManager = {
+			getSummary: vi.fn(() => createSummary({ agentId: "ag2", state: "idle", pid: null })),
+			listChatMessages: vi.fn(() => ptyMessages),
+		};
+		const getScopedClineTaskSessionService = vi.fn(async () => {
+			throw new Error("Cline session host should not start for AG2 chat history");
+		});
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService,
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.getTaskChatMessages(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-1" },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			messages: ptyMessages,
+		});
+		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
+	});
+
+	it("returns an empty AG2 chat for a new task instead of a missing-session error", async () => {
+		const terminalManager = {
+			getSummary: vi.fn(() => null),
+			listChatMessages: vi.fn(() => []),
+		};
+		const getScopedClineTaskSessionService = vi.fn(async () => {
+			throw new Error("Cline session host should not start for a new AG2 task");
+		});
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService,
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.getTaskChatMessages(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "new-task" },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			messages: [],
+		});
+		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
+	});
+
 	it("reloads a chat session through the Cline task session service", async () => {
 		const summary = createSummary({ agentId: "cline", pid: null });
 		const clineTaskSessionService = createClineTaskSessionServiceMock();

--- a/test/runtime/trpc/runtime-api.test.ts
+++ b/test/runtime/trpc/runtime-api.test.ts
@@ -1380,7 +1380,10 @@ describe("createRuntimeApi startTaskSession", () => {
 
 		const api = createTestRuntimeApi({
 			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
-			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "cline" as const,
+			})),
 			setActiveRuntimeConfig: vi.fn(),
 			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
 			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
@@ -1477,6 +1480,7 @@ describe("createRuntimeApi startTaskSession", () => {
 			}),
 		);
 		expect(clineTaskSessionService.startTaskSession).not.toHaveBeenCalled();
+		expect(clineTaskSessionService.sendTaskSessionInput).not.toHaveBeenCalled();
 	});
 
 	it("lists AG2 slash skills from the project path without the Cline SDK", async () => {
@@ -1694,6 +1698,107 @@ describe("createRuntimeApi startTaskSession", () => {
 		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
 	});
 
+	it("aborts a PTY chat turn by stopping the terminal session", async () => {
+		const summary = createSummary({ agentId: "ag2", pid: 42, state: "running" });
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+			stopTaskSession: vi.fn(() => summary),
+		};
+		const getScopedClineTaskSessionService = vi.fn(async () => {
+			throw new Error("Cline session host should not start for PTY chat abort");
+		});
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService,
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.abortTaskChatTurn(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-ag2" },
+		);
+
+		expect(response).toEqual({ ok: true, summary });
+		expect(terminalManager.stopTaskSession).toHaveBeenCalledWith("task-ag2");
+		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
+	});
+
+	it("reloads a PTY chat session without starting a Cline host", async () => {
+		const summary = createSummary({ agentId: "ag2", pid: null, state: "idle" });
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+		};
+		const getScopedClineTaskSessionService = vi.fn(async () => {
+			throw new Error("Cline session host should not start for PTY chat reload");
+		});
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService,
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+		});
+
+		const response = await api.reloadTaskChatSession(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-ag2" },
+		);
+
+		expect(response).toEqual({ ok: true, summary });
+		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
+	});
+
+	it("clears PTY chat for project-skills slash without the Cline SDK", async () => {
+		const summary = createSummary({ agentId: "ag2", pid: null, state: "idle" });
+		const terminalManager = {
+			getSummary: vi.fn(() => summary),
+			clearChatMessages: vi.fn(),
+		};
+		const getScopedClineTaskSessionService = vi.fn(async () => {
+			throw new Error("Cline session host should not start for PTY /clear");
+		});
+		const broadcastTaskChatCleared = vi.fn();
+		const api = createTestRuntimeApi({
+			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "ag2" as const,
+			})),
+			setActiveRuntimeConfig: vi.fn(),
+			getScopedTerminalManager: vi.fn(async () => terminalManager as never),
+			getScopedClineTaskSessionService,
+			resolveInteractiveShellCommand: vi.fn(),
+			runCommand: vi.fn(),
+			broadcastTaskChatCleared,
+		});
+
+		const response = await api.sendTaskChatMessage(
+			{ workspaceId: "workspace-1", workspacePath: "/tmp/repo" },
+			{ taskId: "task-ag2", text: "  /clear  " },
+		);
+
+		expect(response).toEqual({
+			ok: true,
+			summary,
+			message: null,
+		});
+		expect(terminalManager.clearChatMessages).toHaveBeenCalledWith("task-ag2");
+		expect(broadcastTaskChatCleared).toHaveBeenCalledWith("workspace-1", "task-ag2");
+		expect(getScopedClineTaskSessionService).not.toHaveBeenCalled();
+	});
+
 	it("reloads a chat session through the Cline task session service", async () => {
 		const summary = createSummary({ agentId: "cline", pid: null });
 		const clineTaskSessionService = createClineTaskSessionServiceMock();
@@ -1701,7 +1806,10 @@ describe("createRuntimeApi startTaskSession", () => {
 
 		const api = createTestRuntimeApi({
 			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
-			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "cline" as const,
+			})),
 			setActiveRuntimeConfig: vi.fn(),
 			getScopedTerminalManager: vi.fn(async () => ({}) as never),
 			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),
@@ -1736,7 +1844,10 @@ describe("createRuntimeApi startTaskSession", () => {
 
 		const api = createTestRuntimeApi({
 			getActiveWorkspaceId: vi.fn(() => "workspace-1"),
-			loadScopedRuntimeConfig: vi.fn(async () => createRuntimeConfigState()),
+			loadScopedRuntimeConfig: vi.fn(async () => ({
+				...createRuntimeConfigState(),
+				selectedAgentId: "cline" as const,
+			})),
 			setActiveRuntimeConfig: vi.fn(),
 			getScopedTerminalManager: vi.fn(async () => ({}) as never),
 			getScopedClineTaskSessionService: vi.fn(async () => clineTaskSessionService as never),

--- a/web-ui/src/components/card-detail-view.test.tsx
+++ b/web-ui/src/components/card-detail-view.test.tsx
@@ -392,6 +392,129 @@ describe("CardDetailView", () => {
 		expect(onCloseGitHistory).toHaveBeenCalledTimes(1);
 	});
 
+	it("renders native chat panel for a new ag2 task before a session agentId is recorded", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					selectedAgentId="ag2"
+					sessionSummary={{
+						taskId: "task-1",
+						state: "idle",
+						agentId: null,
+						workspacePath: null,
+						pid: null,
+						startedAt: null,
+						updatedAt: Date.now(),
+						lastOutputAt: null,
+						reviewReason: null,
+						exitCode: null,
+						lastHookAt: null,
+						latestHookActivity: null,
+						warningMessage: null,
+					}}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		expect(container.querySelector('[data-testid="cline-agent-chat-panel"]')).toBeInstanceOf(HTMLDivElement);
+		expect(mockAgentTerminalPanel).not.toHaveBeenCalled();
+	});
+
+	it("renders native chat panel for ag2 agent instead of the PTY terminal", async () => {
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					selectedAgentId="ag2"
+					sessionSummary={{
+						taskId: "task-1",
+						state: "running",
+						agentId: "ag2",
+						workspacePath: null,
+						pid: null,
+						startedAt: null,
+						updatedAt: Date.now(),
+						lastOutputAt: null,
+						reviewReason: null,
+						exitCode: null,
+						lastHookAt: null,
+						latestHookActivity: null,
+						warningMessage: null,
+					}}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		expect(container.querySelector('[data-testid="cline-agent-chat-panel"]')).toBeInstanceOf(HTMLDivElement);
+		expect(mockAgentTerminalPanel).not.toHaveBeenCalled();
+	});
+
+	it("wires composer send for ag2 so follow-up messages stay enabled", async () => {
+		const onSendClineChatMessage = vi.fn(async () => ({ ok: true }));
+		await act(async () => {
+			root.render(
+				<CardDetailView
+					selection={createSelection()}
+					currentProjectId="workspace-1"
+					selectedAgentId="ag2"
+					sessionSummary={{
+						taskId: "task-1",
+						state: "awaiting_review",
+						agentId: "ag2",
+						workspacePath: null,
+						pid: null,
+						startedAt: null,
+						updatedAt: Date.now(),
+						lastOutputAt: null,
+						reviewReason: null,
+						exitCode: 0,
+						lastHookAt: null,
+						latestHookActivity: null,
+						warningMessage: null,
+					}}
+					taskSessions={{}}
+					onSessionSummary={() => {}}
+					onCardSelect={() => {}}
+					onTaskDragEnd={() => {}}
+					onMoveToTrash={() => {}}
+					onSendClineChatMessage={onSendClineChatMessage}
+					bottomTerminalOpen={false}
+					bottomTerminalTaskId={null}
+					bottomTerminalSummary={null}
+					onBottomTerminalClose={() => {}}
+				/>,
+			);
+		});
+
+		expect(mockClineAgentChatPanel).toHaveBeenCalledWith(
+			expect.objectContaining({
+				onSendMessage: onSendClineChatMessage,
+				composerPlaceholder: "Message AG2",
+			}),
+		);
+	});
+
 	it("renders native chat panel for cline agent", async () => {
 		await act(async () => {
 			root.render(

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -17,7 +17,7 @@ import { ResizableBottomPane } from "@/resize/resizable-bottom-pane";
 import { ResizeHandle } from "@/resize/resize-handle";
 import { useCardDetailLayout } from "@/resize/use-card-detail-layout";
 import { useResizeDrag } from "@/resize/use-resize-drag";
-import { isNativeChatPanelAgent } from "@/runtime/native-agent";
+import { getChatComposerPlaceholder, isNativeChatPanelAgent, shouldShowClineModelPicker } from "@/runtime/native-agent";
 import type {
 	RuntimeAgentId,
 	RuntimeClineReasoningEffort,
@@ -639,8 +639,8 @@ export function CardDetailView({
 			taskColumnId={selection.column.id}
 			defaultMode="act"
 			showComposerModeToggle={false}
-			showClineModelPicker={effectiveTaskAgentId === "cline"}
-			composerPlaceholder={effectiveTaskAgentId === "ag2" ? "Message AG2" : undefined}
+			showClineModelPicker={shouldShowClineModelPicker(effectiveTaskAgentId)}
+			composerPlaceholder={getChatComposerPlaceholder(effectiveTaskAgentId)}
 			workspaceId={currentProjectId}
 			runtimeConfig={runtimeConfig}
 			taskClineSettings={selection.card.clineSettings}

--- a/web-ui/src/components/card-detail-view.tsx
+++ b/web-ui/src/components/card-detail-view.tsx
@@ -17,7 +17,7 @@ import { ResizableBottomPane } from "@/resize/resizable-bottom-pane";
 import { ResizeHandle } from "@/resize/resize-handle";
 import { useCardDetailLayout } from "@/resize/use-card-detail-layout";
 import { useResizeDrag } from "@/resize/use-resize-drag";
-import { isNativeClineAgentSelected } from "@/runtime/native-agent";
+import { isNativeChatPanelAgent } from "@/runtime/native-agent";
 import type {
 	RuntimeAgentId,
 	RuntimeClineReasoningEffort,
@@ -513,7 +513,7 @@ export function CardDetailView({
 	const showMoveToTrashActions = selection.column.id === "review" || selection.column.id === "in_progress";
 	const isTaskTerminalEnabled = selection.column.id === "in_progress" || selection.column.id === "review";
 	const effectiveTaskAgentId = sessionSummary?.agentId ?? selection.card.agentId ?? selectedAgentId;
-	const showClineAgentChatPanel = isNativeClineAgentSelected(effectiveTaskAgentId);
+	const showClineAgentChatPanel = isNativeChatPanelAgent(effectiveTaskAgentId);
 	const availablePaths = useMemo(() => {
 		if (!runtimeFiles || runtimeFiles.length === 0) {
 			return [];
@@ -639,13 +639,15 @@ export function CardDetailView({
 			taskColumnId={selection.column.id}
 			defaultMode="act"
 			showComposerModeToggle={false}
+			showClineModelPicker={effectiveTaskAgentId === "cline"}
+			composerPlaceholder={effectiveTaskAgentId === "ag2" ? "Message AG2" : undefined}
 			workspaceId={currentProjectId}
 			runtimeConfig={runtimeConfig}
 			taskClineSettings={selection.card.clineSettings}
 			taskHasExplicitClineSettings={hasExplicitTaskClineSettings}
 			onClineSettingsSaved={onClineSettingsSaved}
 			onTaskClineSettingsChanged={onTaskClineSettingsChanged}
-			onSendMessage={onSendClineChatMessage}
+			onSendMessage={isNativeChatPanelAgent(effectiveTaskAgentId) ? onSendClineChatMessage : undefined}
 			onCancelTurn={onCancelClineChatTurn}
 			onLoadMessages={onLoadClineChatMessages}
 			incomingMessages={streamedClineChatMessages}

--- a/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
+++ b/web-ui/src/components/detail-panels/cline-agent-chat-panel.tsx
@@ -78,6 +78,7 @@ export interface ClineAgentChatPanelProps {
 		modelId: string;
 		reasoningEffort: RuntimeClineReasoningEffort | "";
 	}) => void;
+	showClineModelPicker?: boolean;
 	onSendMessage?: (
 		taskId: string,
 		text: string,
@@ -107,6 +108,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 			defaultMode = "act",
 			composerPlaceholder = "Ask Cline to add, edit, start, or link tasks",
 			showComposerModeToggle = true,
+			showClineModelPicker = true,
 			workspaceId = null,
 			runtimeConfig = null,
 			taskClineSettings,
@@ -443,6 +445,7 @@ export const ClineAgentChatPanel = React.forwardRef<ClineAgentChatPanelHandle, C
 						canCancel={canCancel}
 						onSend={handleComposerSend}
 						onCancel={handleCancelTurn}
+						showModelPicker={showClineModelPicker}
 						modelOptions={modelOptions}
 						recommendedModelIds={modelPickerOptions.recommendedModelIds}
 						pinSelectedModelToTop={modelPickerOptions.shouldPinSelectedModelToTop}

--- a/web-ui/src/components/detail-panels/cline-chat-composer.tsx
+++ b/web-ui/src/components/detail-panels/cline-chat-composer.tsx
@@ -66,6 +66,7 @@ export function ClineChatComposer({
 	isModelLoading = false,
 	isModelSaving = false,
 	modelPickerDisabled = false,
+	showModelPicker = true,
 	isSending = false,
 	warningMessage = null,
 	attachmentWarningMessage = null,
@@ -96,6 +97,7 @@ export function ClineChatComposer({
 	isModelLoading?: boolean;
 	isModelSaving?: boolean;
 	modelPickerDisabled?: boolean;
+	showModelPicker?: boolean;
 	isSending?: boolean;
 	warningMessage?: string | null;
 	attachmentWarningMessage?: string | null;
@@ -492,22 +494,24 @@ export function ClineChatComposer({
 				<TaskImageStrip images={images} onRemoveImage={handleRemoveImage} className="mt-2" />
 			) : null}
 			<div className="mt-2 flex min-w-0 items-center gap-2">
-				<div className="min-w-0 shrink overflow-hidden">
-					<ClineChatModelSelector
-						modelOptions={modelOptions}
-						recommendedModelIds={recommendedModelIds}
-						pinSelectedModelToTop={pinSelectedModelToTop}
-						selectedModelId={selectedModelId}
-						selectedModelButtonText={selectedModelButtonText}
-						onSelectModel={onSelectModel}
-						reasoningEnabledModelIds={reasoningEnabledModelIds}
-						selectedReasoningEffort={selectedReasoningEffort}
-						onSelectReasoningEffort={onSelectReasoningEffort}
-						disabled={modelPickerDisabled}
-						isModelLoading={isModelLoading}
-						isModelSaving={isModelSaving}
-					/>
-				</div>
+				{showModelPicker ? (
+					<div className="min-w-0 shrink overflow-hidden">
+						<ClineChatModelSelector
+							modelOptions={modelOptions}
+							recommendedModelIds={recommendedModelIds}
+							pinSelectedModelToTop={pinSelectedModelToTop}
+							selectedModelId={selectedModelId}
+							selectedModelButtonText={selectedModelButtonText}
+							onSelectModel={onSelectModel}
+							reasoningEnabledModelIds={reasoningEnabledModelIds}
+							selectedReasoningEffort={selectedReasoningEffort}
+							onSelectReasoningEffort={onSelectReasoningEffort}
+							disabled={modelPickerDisabled}
+							isModelLoading={isModelLoading}
+							isModelSaving={isModelSaving}
+						/>
+					</div>
+				) : null}
 				<div className="ml-auto flex shrink-0 items-center gap-2">
 					{showModeToggle ? (
 						<Tooltip

--- a/web-ui/src/components/runtime-settings-dialog.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.tsx
@@ -92,7 +92,7 @@ const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string }>
 
 export type RuntimeSettingsSection = "shortcuts";
 
-const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro", "ag2"];
 
 type SettingsNavId = "general" | "cline" | "git-prompts" | "notifications" | "appearance" | "project";
 

--- a/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
+++ b/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
@@ -83,7 +83,7 @@ export const TASK_START_ONBOARDING_SLIDES: OnboardingSlide[] = [
 	},
 ];
 
-const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const ONBOARDING_AGENT_IDS: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro", "ag2"];
 const FALLBACK_ONBOARDING_SLIDE: OnboardingSlide = {
 	kind: "agent-selection",
 	title: "",

--- a/web-ui/src/hooks/runtime-disconnected-fallback.test.tsx
+++ b/web-ui/src/hooks/runtime-disconnected-fallback.test.tsx
@@ -1,0 +1,37 @@
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { RuntimeDisconnectedFallback } from "@/hooks/runtime-disconnected-fallback";
+
+async function render(root: Root, node: ReactElement): Promise<void> {
+	await act(async () => {
+		root.render(node);
+	});
+}
+
+describe("RuntimeDisconnectedFallback", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(async () => {
+		await act(async () => {
+			root.unmount();
+		});
+		container.remove();
+	});
+
+	it("tells the user Kanban disconnected, not to run the Cline CLI", async () => {
+		await render(root, <RuntimeDisconnectedFallback />);
+
+		expect(container.textContent).toContain("Disconnected from Kanban");
+		expect(container.textContent).toMatch(/reload this tab/i);
+		expect(container.textContent).not.toMatch(/cline/i);
+	});
+});

--- a/web-ui/src/hooks/runtime-disconnected-fallback.tsx
+++ b/web-ui/src/hooks/runtime-disconnected-fallback.tsx
@@ -15,8 +15,8 @@ export function RuntimeDisconnectedFallback(): ReactElement {
 		>
 			<div className="flex flex-col items-center justify-center gap-3 py-12 text-text-tertiary">
 				<AlertCircle size={48} />
-				<h3 className="font-semibold text-text-primary">Disconnected from Cline</h3>
-				<p className="text-text-secondary">Run cline again in your terminal, then reload this tab.</p>
+				<h3 className="font-semibold text-text-primary">Disconnected from Kanban</h3>
+				<p className="text-text-secondary">Restart the Kanban runtime, then reload this tab.</p>
 			</div>
 		</div>
 	);

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { showAppToast } from "@/components/app-toaster";
 import { type UseGitHistoryDataResult, useGitHistoryData } from "@/components/git-history/use-git-history-data";
 import { buildTaskGitActionPrompt, type TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
-import { isNativeClineAgentSelected } from "@/runtime/native-agent";
+import { isNativeChatPanelAgent } from "@/runtime/native-agent";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
 import type { RuntimeConfigResponse, RuntimeGitSyncAction, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
 import { findCardSelection } from "@/state/board-state";
@@ -214,9 +214,7 @@ export function useGitActions({
 		return next;
 	}, [taskGitActionLoadingByTaskId]);
 
-	const shouldUseClineChatForTaskGitActions = isNativeClineAgentSelected(
-		runtimeProjectConfig?.selectedAgentId ?? null,
-	);
+	const shouldUseClineChatForTaskGitActions = isNativeChatPanelAgent(runtimeProjectConfig?.selectedAgentId ?? null);
 
 	const runTaskGitAction = useCallback(
 		async (taskId: string, action: TaskGitAction, source: TaskGitActionSource) => {

--- a/web-ui/src/hooks/use-home-agent-session.ts
+++ b/web-ui/src/hooks/use-home-agent-session.ts
@@ -254,6 +254,9 @@ export function useHomeAgentSession({
 		if (!currentProjectId || !descriptor || descriptor.panelMode !== "chat") {
 			return;
 		}
+		if (!runtimeProjectConfig || !isNativeClineAgentSelected(runtimeProjectConfig.selectedAgentId)) {
+			return;
+		}
 
 		const previousVersion = previousClineSessionContextVersionByWorkspaceRef.current.get(currentProjectId);
 		previousClineSessionContextVersionByWorkspaceRef.current.set(currentProjectId, clineSessionContextVersion);
@@ -291,7 +294,14 @@ export function useHomeAgentSession({
 		return () => {
 			cancelled = true;
 		};
-	}, [clineSessionContextVersion, currentProjectId, descriptor, sessionSummaries, upsertSessionSummary]);
+	}, [
+		clineSessionContextVersion,
+		currentProjectId,
+		descriptor,
+		runtimeProjectConfig,
+		sessionSummaries,
+		upsertSessionSummary,
+	]);
 
 	useEffect(() => {
 		if (!currentProjectId || !descriptor || descriptor.panelMode !== "terminal") {

--- a/web-ui/src/hooks/use-home-agent-session.ts
+++ b/web-ui/src/hooks/use-home-agent-session.ts
@@ -8,7 +8,11 @@ import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { notifyError } from "@/components/app-toaster";
-import { getRuntimeClineProviderSettings, isNativeClineAgentSelected } from "@/runtime/native-agent";
+import {
+	getRuntimeClineProviderSettings,
+	isNativeChatPanelAgent,
+	isNativeClineAgentSelected,
+} from "@/runtime/native-agent";
 import { estimateTaskSessionGeometry } from "@/runtime/task-session-geometry";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
 import type { RuntimeConfigResponse, RuntimeGitRepositoryInfo, RuntimeTaskSessionSummary } from "@/runtime/types";
@@ -140,6 +144,12 @@ export function useHomeAgentSession({
 		if (isNativeClineAgentSelected(runtimeProjectConfig.selectedAgentId)) {
 			panelMode = "chat";
 			descriptorKey = buildClineDescriptor(runtimeProjectConfig);
+		} else if (isNativeChatPanelAgent(runtimeProjectConfig.selectedAgentId)) {
+			if (!runtimeProjectConfig.effectiveCommand) {
+				return null;
+			}
+			panelMode = "chat";
+			descriptorKey = buildTerminalDescriptor(runtimeProjectConfig);
 		} else {
 			if (!runtimeProjectConfig.effectiveCommand) {
 				return null;

--- a/web-ui/src/hooks/use-home-sidebar-agent-panel.tsx
+++ b/web-ui/src/hooks/use-home-sidebar-agent-panel.tsx
@@ -12,7 +12,7 @@ import { selectNewestTaskSessionSummary } from "@/hooks/home-sidebar-agent-panel
 import { useClineChatRuntimeActions } from "@/hooks/use-cline-chat-runtime-actions";
 import { useHomeAgentSession } from "@/hooks/use-home-agent-session";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { selectLatestTaskChatMessageForTask } from "@/runtime/native-agent";
+import { isNativeChatPanelAgent, selectLatestTaskChatMessageForTask } from "@/runtime/native-agent";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
 import type {
 	RuntimeConfigResponse,
@@ -159,14 +159,21 @@ export function useHomeSidebarAgentPanel({
 				summary={homeAgentPanelSummary ?? createIdleTaskSession(taskId)}
 				defaultMode="act"
 				showComposerModeToggle={false}
+				showClineModelPicker={runtimeProjectConfig.selectedAgentId === "cline"}
 				workspaceId={currentProjectId}
 				runtimeConfig={runtimeProjectConfig}
-				onSendMessage={handleSendHomeClineChatMessage}
+				onSendMessage={
+					isNativeChatPanelAgent(runtimeProjectConfig.selectedAgentId) ? handleSendHomeClineChatMessage : undefined
+				}
 				onCancelTurn={handleCancelHomeClineChatTurn}
 				onLoadMessages={handleLoadHomeClineChatMessages}
 				incomingMessage={latestHomeTaskChatMessage}
 				incomingMessages={homeTaskChatMessages}
-				composerPlaceholder="Ask Cline to add, edit, start, or link tasks"
+				composerPlaceholder={
+					runtimeProjectConfig.selectedAgentId === "ag2"
+						? "Message AG2"
+						: "Ask Cline to add, edit, start, or link tasks"
+				}
 			/>
 		);
 	}

--- a/web-ui/src/hooks/use-home-sidebar-agent-panel.tsx
+++ b/web-ui/src/hooks/use-home-sidebar-agent-panel.tsx
@@ -12,7 +12,12 @@ import { selectNewestTaskSessionSummary } from "@/hooks/home-sidebar-agent-panel
 import { useClineChatRuntimeActions } from "@/hooks/use-cline-chat-runtime-actions";
 import { useHomeAgentSession } from "@/hooks/use-home-agent-session";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { isNativeChatPanelAgent, selectLatestTaskChatMessageForTask } from "@/runtime/native-agent";
+import {
+	getChatComposerPlaceholder,
+	isNativeChatPanelAgent,
+	selectLatestTaskChatMessageForTask,
+	shouldShowClineModelPicker,
+} from "@/runtime/native-agent";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
 import type {
 	RuntimeConfigResponse,
@@ -159,7 +164,7 @@ export function useHomeSidebarAgentPanel({
 				summary={homeAgentPanelSummary ?? createIdleTaskSession(taskId)}
 				defaultMode="act"
 				showComposerModeToggle={false}
-				showClineModelPicker={runtimeProjectConfig.selectedAgentId === "cline"}
+				showClineModelPicker={shouldShowClineModelPicker(runtimeProjectConfig.selectedAgentId)}
 				workspaceId={currentProjectId}
 				runtimeConfig={runtimeProjectConfig}
 				onSendMessage={
@@ -170,9 +175,8 @@ export function useHomeSidebarAgentPanel({
 				incomingMessage={latestHomeTaskChatMessage}
 				incomingMessages={homeTaskChatMessages}
 				composerPlaceholder={
-					runtimeProjectConfig.selectedAgentId === "ag2"
-						? "Message AG2"
-						: "Ask Cline to add, edit, start, or link tasks"
+					getChatComposerPlaceholder(runtimeProjectConfig.selectedAgentId) ??
+					"Ask Cline to add, edit, start, or link tasks"
 				}
 			/>
 		);

--- a/web-ui/src/runtime/native-agent.test.ts
+++ b/web-ui/src/runtime/native-agent.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getTaskAgentNavbarHint,
 	isClineProviderAuthenticated,
+	isNativeChatPanelAgent,
 	isNativeClineAgentSelected,
 	isTaskAgentSetupSatisfied,
 	selectLatestTaskChatMessageForTask,
@@ -85,6 +86,14 @@ describe("native-agent helpers", () => {
 	it("treats cline as the native chat agent", () => {
 		expect(isNativeClineAgentSelected("cline")).toBe(true);
 		expect(isNativeClineAgentSelected("codex")).toBe(false);
+		expect(isNativeClineAgentSelected("ag2")).toBe(false);
+	});
+
+	it("shows the native chat panel for AG2 without taking the Cline SDK path", () => {
+		expect(isNativeChatPanelAgent("ag2")).toBe(true);
+		expect(isNativeChatPanelAgent("cline")).toBe(true);
+		expect(isNativeChatPanelAgent("claude")).toBe(false);
+		expect(isNativeChatPanelAgent("codex")).toBe(false);
 	});
 
 	it("treats selected cline as task-ready when cline authentication is configured", () => {

--- a/web-ui/src/runtime/native-agent.test.ts
+++ b/web-ui/src/runtime/native-agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	getChatComposerPlaceholder,
 	getTaskAgentNavbarHint,
 	isClineProviderAuthenticated,
 	isNativeChatPanelAgent,
@@ -94,6 +95,12 @@ describe("native-agent helpers", () => {
 		expect(isNativeChatPanelAgent("cline")).toBe(true);
 		expect(isNativeChatPanelAgent("claude")).toBe(false);
 		expect(isNativeChatPanelAgent("codex")).toBe(false);
+	});
+
+	it("builds the chat composer placeholder from the catalog label", () => {
+		expect(getChatComposerPlaceholder("ag2")).toBe("Message AG2");
+		expect(getChatComposerPlaceholder("cline")).toBeUndefined();
+		expect(getChatComposerPlaceholder("claude")).toBeUndefined();
 	});
 
 	it("treats selected cline as task-ready when cline authentication is configured", () => {

--- a/web-ui/src/runtime/native-agent.ts
+++ b/web-ui/src/runtime/native-agent.ts
@@ -1,4 +1,10 @@
-import { isRuntimeAgentLaunchSupported } from "@runtime-agent-catalog";
+import {
+	getAgentCapabilities,
+	getRuntimeAgentCatalogEntry,
+	isChatPanelAgent,
+	isClineSdkBackend,
+	isRuntimeAgentLaunchSupported,
+} from "@runtime-agent-catalog";
 import type {
 	RuntimeAgentId,
 	RuntimeClineProviderSettings,
@@ -8,11 +14,26 @@ import type {
 } from "@/runtime/types";
 
 export function isNativeClineAgentSelected(agentId: RuntimeAgentId | null | undefined): boolean {
-	return agentId === "cline";
+	return isClineSdkBackend(agentId);
 }
 
 export function isNativeChatPanelAgent(agentId: RuntimeAgentId | null | undefined): boolean {
-	return agentId === "cline" || agentId === "ag2";
+	return isChatPanelAgent(agentId);
+}
+
+export function shouldShowClineModelPicker(agentId: RuntimeAgentId | null | undefined): boolean {
+	return getAgentCapabilities(agentId)?.showModelPicker === true;
+}
+
+export function getChatComposerPlaceholder(agentId: RuntimeAgentId | null | undefined): string | undefined {
+	if (!isChatPanelAgent(agentId) || !agentId) {
+		return undefined;
+	}
+	if (getAgentCapabilities(agentId)?.backend === "cline-sdk") {
+		return undefined;
+	}
+	const label = getRuntimeAgentCatalogEntry(agentId)?.label;
+	return label ? `Message ${label}` : undefined;
 }
 
 export function getRuntimeClineProviderSettings(

--- a/web-ui/src/runtime/native-agent.ts
+++ b/web-ui/src/runtime/native-agent.ts
@@ -11,6 +11,10 @@ export function isNativeClineAgentSelected(agentId: RuntimeAgentId | null | unde
 	return agentId === "cline";
 }
 
+export function isNativeChatPanelAgent(agentId: RuntimeAgentId | null | undefined): boolean {
+	return agentId === "cline" || agentId === "ag2";
+}
+
 export function getRuntimeClineProviderSettings(
 	config: Pick<RuntimeConfigResponse, "clineProviderSettings"> | null | undefined,
 ): RuntimeClineProviderSettings {


### PR DESCRIPTION
## Summary
- Add first-class Play agent `ag2` that launches `mlx-agents ag2-run` as a PTY (same path as Claude/Droid, not the in-process Cline SDK).
- Catalog/UI: label **AG2**, binary `mlx-agents`, launch-supported; Settings and onboarding pickers include `ag2` last. Auto-select still prefers Claude first.
- Inject `KANBAN_HOOK_TASK_ID` / `KANBAN_HOOK_WORKSPACE_ID` so AG2 can emit `to_in_progress` / `activity` / `to_review`.

Fixes #600

## Test plan
- [x] `vitest run test/runtime/terminal/agent-session-adapters.test.ts` — AG2 argv (`ag2-run`, `--workspace`, `--role supervisor`, `--ensure-server`, `--task-id`) and hook env
- [x] `vitest run test/runtime/terminal/agent-registry.test.ts test/runtime/config/runtime-config.test.ts` — catalog id, `mlx-agents` detection → `ag2`
- [ ] `npm run check`
- [ ] `npm run build`
- [ ] Manual: with `mlx-agents` on PATH, Play → select **AG2** → start a task; card moves in progress / review via hooks

## Notes
CONTRIBUTING: issue first for new CLI agents (#600). This is agent compatibility, not a product-feature expansion.