### PR TITLE
perf: use lightweight Codex hook entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "npx @biomejs/biome lint src test web-ui/src web-ui/tests vitest.config.ts web-ui/vite.config.ts web-ui/vitest.config.ts web-ui/playwright.config.ts",
     "format": "npx @biomejs/biome check --write .",
+    "perf:monitor": "node scripts/monitor-performance.mjs",
     "check": "npx @biomejs/biome check . && npm run typecheck && npm run test",
     "test": "vitest run",
     "test:fast": "vitest run test/runtime test/utilities",

--- a/packages/desktop/scripts/stage-cli.mjs
+++ b/packages/desktop/scripts/stage-cli.mjs
@@ -15,6 +15,7 @@ const repoRoot = resolve(desktopRoot, "../..");
 const distDir = resolve(repoRoot, "dist");
 const webUiIndex = resolve(distDir, "web-ui/index.html");
 const cliEntry = resolve(distDir, "cli.js");
+const codexHookEntry = resolve(distDir, "codex-hook.js");
 const stageDir = resolve(desktopRoot, "cli");
 
 function fail(message) {
@@ -29,6 +30,9 @@ if (!existsSync(distDir)) {
 }
 if (!existsSync(cliEntry)) {
 	fail(`${cliEntry} is missing.`);
+}
+if (!existsSync(codexHookEntry)) {
+	fail(`${codexHookEntry} is missing.`);
 }
 if (!existsSync(webUiIndex)) {
 	fail(

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -55,6 +55,14 @@ await Promise.all([
 		entryPoints: ["src/index.ts"],
 		outfile: "dist/index.js",
 	}),
+	// Lightweight Codex hook entrypoint. Keeping this separate from the main
+	// CLI avoids loading runtime telemetry and server dependencies per hook.
+	esbuild.build({
+		...shared,
+		entryPoints: ["src/codex-hook-cli.ts"],
+		outfile: "dist/codex-hook.js",
+		banner: { js: `#!/usr/bin/env node\n${cjsShimBanner}` },
+	}),
 ]);
 
-console.log("esbuild: bundled dist/cli.js and dist/index.js");
+console.log("esbuild: bundled dist/cli.js, dist/codex-hook.js, and dist/index.js");

--- a/scripts/monitor-performance.mjs
+++ b/scripts/monitor-performance.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_DURATION_MS = 30_000;
+const DEFAULT_INTERVAL_MS = 250;
+
+function parsePositiveNumber(value, optionName) {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`${optionName} must be a positive number.`);
+	}
+	return parsed;
+}
+
+function parseArguments(argv) {
+	const options = {
+		durationMs: DEFAULT_DURATION_MS,
+		intervalMs: DEFAULT_INTERVAL_MS,
+		outputPath: null,
+		pids: [],
+		quiet: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (argument === "--help" || argument === "-h") {
+			options.help = true;
+			continue;
+		}
+		if (argument === "--quiet") {
+			options.quiet = true;
+			continue;
+		}
+		const [name, inlineValue] = argument.split("=", 2);
+		const value = inlineValue ?? argv[++index];
+		if (!value) {
+			throw new Error(`${name} requires a value.`);
+		}
+		switch (name) {
+			case "--pid":
+				options.pids.push(Math.floor(parsePositiveNumber(value, name)));
+				break;
+			case "--duration":
+				options.durationMs = parsePositiveNumber(value, name) * 1_000;
+				break;
+			case "--interval":
+				options.intervalMs = parsePositiveNumber(value, name);
+				break;
+			case "--output":
+				options.outputPath = path.resolve(value);
+				break;
+			default:
+				throw new Error(`Unknown option: ${name}`);
+		}
+	}
+
+	return options;
+}
+
+function printHelp() {
+	process.stdout.write(`Usage: node scripts/monitor-performance.mjs [options]\n\n`);
+	process.stdout.write(`Options:\n`);
+	process.stdout.write(`  --pid <pid>       Monitor a Kanban runtime PID (repeatable)\n`);
+	process.stdout.write(`  --duration <sec>  Sampling duration (default: 30)\n`);
+	process.stdout.write(`  --interval <ms>   Sampling interval (default: 250)\n`);
+	process.stdout.write(`  --output <path>   JSON report path\n`);
+	process.stdout.write(`  --quiet           Suppress periodic sample output\n`);
+	process.stdout.write(`  --help            Show this help\n`);
+}
+
+function parseCpuTime(value) {
+	const dayParts = value.split("-");
+	const clock = dayParts.at(-1) ?? "0";
+	const days = dayParts.length === 2 ? Number(dayParts[0]) : 0;
+	const parts = clock.split(":").map(Number);
+	if (parts.some((part) => !Number.isFinite(part))) {
+		return 0;
+	}
+	const seconds = parts.pop() ?? 0;
+	const minutes = parts.pop() ?? 0;
+	const hours = parts.pop() ?? 0;
+	return days * 86_400 + hours * 3_600 + minutes * 60 + seconds;
+}
+
+function parseProcessTable(stdout) {
+	const processes = [];
+	for (const line of stdout.split("\n")) {
+		const match = line.match(
+			/^\s*(\d+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(.+)$/,
+		);
+		if (!match) {
+			continue;
+		}
+		processes.push({
+			pid: Number(match[1]),
+			ppid: Number(match[2]),
+			psCpuPercent: Number(match[3]),
+			memoryPercent: Number(match[4]),
+			rssBytes: Number(match[5]) * 1_024,
+			cpuSeconds: parseCpuTime(match[6]),
+			elapsed: match[7],
+			command: match[8],
+		});
+	}
+	return processes;
+}
+
+async function readProcesses() {
+	const { stdout } = await execFileAsync("ps", [
+		"-axo",
+		"pid=,ppid=,%cpu=,%mem=,rss=,time=,etime=,command=",
+	], { maxBuffer: 16 * 1024 * 1024 });
+	return parseProcessTable(stdout);
+}
+
+function isKanbanRuntime(command) {
+	return (
+		/(?:src\/cli\.ts|dist\/cli\.js)(?:\s|$)/.test(command) &&
+		!/(?:\shooks\s|\stask\s)/.test(command)
+	);
+}
+
+function isKanbanHook(command) {
+	return (
+		/(?:src\/codex-hook-cli\.ts|dist\/codex-hook\.js)(?:\s|$)/.test(command) ||
+		/(?:src\/cli\.ts|dist\/cli\.js)\s+hooks(?:\s|$)/.test(command)
+	);
+}
+
+function findRuntimePids(processes) {
+	return processes.filter((entry) => isKanbanRuntime(entry.command)).map((entry) => entry.pid);
+}
+
+function collectDescendantPids(processes, rootPids) {
+	const childrenByParent = new Map();
+	for (const entry of processes) {
+		const children = childrenByParent.get(entry.ppid) ?? [];
+		children.push(entry.pid);
+		childrenByParent.set(entry.ppid, children);
+	}
+
+	const descendants = new Set(rootPids);
+	const pending = [...rootPids];
+	while (pending.length > 0) {
+		const parentPid = pending.pop();
+		for (const childPid of childrenByParent.get(parentPid) ?? []) {
+			if (descendants.has(childPid)) {
+				continue;
+			}
+			descendants.add(childPid);
+			pending.push(childPid);
+		}
+	}
+	return descendants;
+}
+
+function categorizeProcess(entry, rootPids, processByPid, categoryByPid) {
+	const cachedCategory = categoryByPid.get(entry.pid);
+	if (cachedCategory) {
+		return cachedCategory;
+	}
+
+	let category;
+	if (rootPids.has(entry.pid)) {
+		category = "runtime";
+	} else if (isKanbanHook(entry.command)) {
+		category = "hook";
+	} else if (/(?:codex|claude|cline|opencode|gemini|kiro|droid)/i.test(entry.command)) {
+		category = "agent";
+	} else {
+		const parent = processByPid.get(entry.ppid);
+		const parentCategory = parent ? categorizeProcess(parent, rootPids, processByPid, categoryByPid) : null;
+		if (parentCategory === "hook") {
+			category = "hook";
+		} else if (parentCategory === "agent") {
+			category = "agent";
+		} else if (/(?:^|\/|\()(?:git)(?:\)|\s|$)/.test(entry.command)) {
+			category = "git";
+		} else if (/(?:node-pty|pty-host|login\s+-|\/bin\/(?:zsh|bash|fish))(?:\s|$)/.test(entry.command)) {
+			category = "terminal";
+		} else {
+			category = "other-child";
+		}
+	}
+
+	categoryByPid.set(entry.pid, category);
+	return category;
+}
+
+function getExecutableName(command) {
+	const executable = command.trim().split(/\s+/, 1)[0] ?? "unknown";
+	return path.basename(executable.replace(/^\(|\)$/g, "")) || "unknown";
+}
+
+function round(value, digits = 2) {
+	const scale = 10 ** digits;
+	return Math.round(value * scale) / scale;
+}
+
+function percentile(values, ratio) {
+	if (values.length === 0) {
+		return 0;
+	}
+	const sorted = [...values].sort((left, right) => left - right);
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * ratio))] ?? 0;
+}
+
+function summarize(samples, seenProcesses) {
+	const categories = new Set(samples.flatMap((sample) => Object.keys(sample.categories)));
+	const categorySummary = {};
+	for (const category of categories) {
+		const cpuValues = samples.map((sample) => sample.categories[category]?.cpuPercent ?? 0);
+		const rssValues = samples.map((sample) => sample.categories[category]?.rssBytes ?? 0);
+		categorySummary[category] = {
+			averageCpuPercent: round(cpuValues.reduce((sum, value) => sum + value, 0) / cpuValues.length),
+			p95CpuPercent: round(percentile(cpuValues, 0.95)),
+			maximumCpuPercent: round(Math.max(...cpuValues)),
+			averageRssMiB: round(rssValues.reduce((sum, value) => sum + value, 0) / rssValues.length / 1024 / 1024),
+			maximumRssMiB: round(Math.max(...rssValues) / 1024 / 1024),
+		};
+	}
+
+	const processCounts = {};
+	for (const processInfo of seenProcesses.values()) {
+		processCounts[processInfo.category] = (processCounts[processInfo.category] ?? 0) + 1;
+	}
+
+	return { categories: categorySummary, uniqueProcessesSeen: processCounts };
+}
+
+function defaultOutputPath() {
+	const timestamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+	return path.join(os.tmpdir(), "kanban-performance-reports", `kanban-performance-${timestamp}.json`);
+}
+
+function sleep(durationMs) {
+	return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function main() {
+	const options = parseArguments(process.argv.slice(2));
+	if (options.help) {
+		printHelp();
+		return;
+	}
+
+	const initialProcesses = await readProcesses();
+	const detectedPids = options.pids.length > 0 ? options.pids : findRuntimePids(initialProcesses);
+	if (detectedPids.length === 0) {
+		throw new Error("No Kanban runtime process found. Pass --pid with the runtime PID.");
+	}
+
+	const rootPids = new Set(detectedPids);
+	const samples = [];
+	const seenProcesses = new Map();
+	const previousCpuByPid = new Map();
+	let previousSampleTime = null;
+	const startedAt = new Date();
+	const deadline = performance.now() + options.durationMs;
+
+	process.stdout.write(
+		`Monitoring Kanban runtime PID${rootPids.size === 1 ? "" : "s"} ${[...rootPids].join(", ")} for ${options.durationMs / 1_000}s\n`,
+	);
+
+	while (performance.now() < deadline) {
+		const sampleStartedAt = performance.now();
+		const processes = await readProcesses();
+		const processByPid = new Map(processes.map((entry) => [entry.pid, entry]));
+		const descendantPids = collectDescendantPids(processes, rootPids);
+		const monitorPids = collectDescendantPids(processes, new Set([process.pid]));
+		const elapsedSeconds = previousSampleTime === null ? null : (sampleStartedAt - previousSampleTime) / 1_000;
+		const categories = {};
+		const categoryByPid = new Map();
+
+		for (const pid of descendantPids) {
+			if (monitorPids.has(pid)) {
+				continue;
+			}
+			const entry = processByPid.get(pid);
+			if (!entry) {
+				continue;
+			}
+			const category = categorizeProcess(entry, rootPids, processByPid, categoryByPid);
+			const previousCpuSeconds = previousCpuByPid.get(pid);
+			const measuredCpuPercent =
+				previousCpuSeconds === undefined || elapsedSeconds === null
+					? entry.psCpuPercent
+					: Math.max(0, ((entry.cpuSeconds - previousCpuSeconds) / elapsedSeconds) * 100);
+			previousCpuByPid.set(pid, entry.cpuSeconds);
+			const aggregate = categories[category] ?? { cpuPercent: 0, rssBytes: 0, processCount: 0 };
+			aggregate.cpuPercent += measuredCpuPercent;
+			aggregate.rssBytes += entry.rssBytes;
+			aggregate.processCount += 1;
+			categories[category] = aggregate;
+			if (!seenProcesses.has(pid)) {
+				seenProcesses.set(pid, {
+					pid,
+					ppid: entry.ppid,
+					category,
+					executable: getExecutableName(entry.command),
+				});
+			}
+		}
+
+		for (const aggregate of Object.values(categories)) {
+			aggregate.cpuPercent = round(aggregate.cpuPercent);
+		}
+		const sample = {
+			timestamp: new Date().toISOString(),
+			loadAverage: os.loadavg().map((value) => round(value)),
+			freeMemoryBytes: os.freemem(),
+			categories,
+		};
+		samples.push(sample);
+		previousSampleTime = sampleStartedAt;
+
+		if (!options.quiet && (samples.length === 1 || samples.length % Math.max(1, Math.round(1_000 / options.intervalMs)) === 0)) {
+			const runtime = categories.runtime ?? { cpuPercent: 0, rssBytes: 0 };
+			const childrenCpu = Object.entries(categories)
+				.filter(([category]) => category !== "runtime")
+				.reduce((sum, [, value]) => sum + value.cpuPercent, 0);
+			process.stdout.write(
+				`${sample.timestamp} runtime=${round(runtime.cpuPercent)}%/${round(runtime.rssBytes / 1024 / 1024)}MiB children=${round(childrenCpu)}%\n`,
+			);
+		}
+
+		const sampleDurationMs = performance.now() - sampleStartedAt;
+		await sleep(Math.max(0, options.intervalMs - sampleDurationMs));
+	}
+
+	const outputPath = options.outputPath ?? defaultOutputPath();
+	const report = {
+		metadata: {
+			startedAt: startedAt.toISOString(),
+			finishedAt: new Date().toISOString(),
+			durationMs: options.durationMs,
+			intervalMs: options.intervalMs,
+			logicalCpuCount: os.cpus().length,
+			platform: process.platform,
+			rootPids: [...rootPids],
+		},
+		summary: summarize(samples, seenProcesses),
+		processes: [...seenProcesses.values()],
+		samples,
+	};
+	await mkdir(path.dirname(outputPath), { recursive: true });
+	await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+	process.stdout.write(`\nSummary\n`);
+	for (const [category, values] of Object.entries(report.summary.categories)) {
+		process.stdout.write(
+			`${category.padEnd(12)} avg CPU ${String(values.averageCpuPercent).padStart(6)}%  p95 ${String(values.p95CpuPercent).padStart(6)}%  avg RSS ${String(values.averageRssMiB).padStart(8)} MiB\n`,
+		);
+	}
+	process.stdout.write(`Report: ${outputPath}\n`);
+}
+
+main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+	process.exitCode = 1;
+});

--- a/src/codex-hook-cli.ts
+++ b/src/codex-hook-cli.ts
@@ -1,0 +1,83 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { RuntimeHookEvent } from "./core/api-contract";
+import { type HookCommandMetadataOptionValues, runCodexHookSubcommand } from "./commands/hooks";
+
+const VALID_EVENTS = new Set<RuntimeHookEvent>(["to_review", "to_in_progress", "activity"]);
+const OPTION_KEYS = {
+	"--activity-text": "activityText",
+	"--event": "event",
+	"--final-message": "finalMessage",
+	"--hook-event-name": "hookEventName",
+	"--metadata-base64": "metadataBase64",
+	"--notification-type": "notificationType",
+	"--source": "source",
+	"--tool-name": "toolName",
+} as const;
+
+interface ParsedCodexHookArguments {
+	event: RuntimeHookEvent;
+	options: HookCommandMetadataOptionValues;
+	payload: string | undefined;
+}
+
+function requireOptionValue(name: string, value: string | undefined): string {
+	if (value === undefined || value.length === 0) {
+		throw new Error(`${name} requires a value.`);
+	}
+	return value;
+}
+
+export function parseCodexHookArguments(argv: string[]): ParsedCodexHookArguments {
+	const values: HookCommandMetadataOptionValues & { event?: string } = {};
+	let payload: string | undefined;
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (!argument) {
+			continue;
+		}
+		if (!argument.startsWith("--")) {
+			if (payload !== undefined) {
+				throw new Error("Only one hook payload argument is supported.");
+			}
+			payload = argument;
+			continue;
+		}
+
+		const separatorIndex = argument.indexOf("=");
+		const name = separatorIndex === -1 ? argument : argument.slice(0, separatorIndex);
+		if (!(name in OPTION_KEYS)) {
+			throw new Error(`Unknown option: ${name}`);
+		}
+		const inlineValue = separatorIndex === -1 ? undefined : argument.slice(separatorIndex + 1);
+		const value = requireOptionValue(name, inlineValue ?? argv[++index]);
+		const key = OPTION_KEYS[name as keyof typeof OPTION_KEYS];
+		values[key] = value;
+	}
+
+	if (!values.event || !VALID_EVENTS.has(values.event as RuntimeHookEvent)) {
+		throw new Error("--event must be one of: to_review, to_in_progress, activity.");
+	}
+	const { event, ...options } = values;
+	return {
+		event: event as RuntimeHookEvent,
+		options,
+		payload,
+	};
+}
+
+async function main(): Promise<void> {
+	try {
+		const parsed = parseCodexHookArguments(process.argv.slice(2));
+		await runCodexHookSubcommand(parsed.event, parsed.options, parsed.payload);
+	} catch {
+		process.stdout.write("{}\n");
+	}
+}
+
+const invokedEntrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedEntrypoint === import.meta.url) {
+	void main();
+}

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -35,7 +35,7 @@ interface HooksIngestArgs {
 	payload?: Record<string, unknown> | null;
 }
 
-interface HookCommandMetadataOptionValues {
+export interface HookCommandMetadataOptionValues {
 	source?: string;
 	activityText?: string;
 	toolName?: string;
@@ -531,7 +531,7 @@ function mapGeminiHookEvent(eventName: string): RuntimeHookEvent | null {
 	return null;
 }
 
-async function runCodexHookSubcommand(
+export async function runCodexHookSubcommand(
 	event: RuntimeHookEvent,
 	options: HookCommandMetadataOptionValues,
 	payloadArg: string | undefined,

--- a/src/core/kanban-command.ts
+++ b/src/core/kanban-command.ts
@@ -1,7 +1,20 @@
+import { basename, dirname, join } from "node:path";
+
 export interface RuntimeInvocationContext {
 	execPath: string;
 	argv: string[];
 	execArgv?: string[];
+}
+
+function resolveCodexHookEntrypoint(entrypoint: string): string | null {
+	const entrypointBasename = basename(entrypoint).toLowerCase();
+	if (entrypointBasename === "cli.ts") {
+		return join(dirname(entrypoint), "codex-hook-cli.ts");
+	}
+	if (entrypointBasename === "cli.js") {
+		return join(dirname(entrypoint), "codex-hook.js");
+	}
+	return null;
 }
 
 function resolveNodeCommandPrefix(context: RuntimeInvocationContext): string[] {
@@ -63,4 +76,21 @@ export function buildKanbanCommandParts(
 	},
 ): string[] {
 	return [...resolveKanbanCommandParts(context), ...args];
+}
+
+export function buildKanbanCodexHookCommandParts(
+	args: string[],
+	context: RuntimeInvocationContext = {
+		execPath: process.execPath,
+		argv: process.argv,
+		execArgv: process.execArgv,
+	},
+): string[] {
+	const commandParts = resolveKanbanCommandParts(context);
+	const entrypoint = commandParts.at(-1);
+	const hookEntrypoint = entrypoint ? resolveCodexHookEntrypoint(entrypoint) : null;
+	if (!hookEntrypoint) {
+		return [...commandParts, "hooks", "codex-hook", ...args];
+	}
+	return [...commandParts.slice(0, -1), hookEntrypoint, ...args];
 }

--- a/src/terminal/codex-hook-config.ts
+++ b/src/terminal/codex-hook-config.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type { RuntimeHookEvent } from "../core/api-contract";
-import { buildKanbanCommandParts } from "../core/kanban-command";
+import { buildKanbanCodexHookCommandParts } from "../core/kanban-command";
 import { quoteShellArg } from "../core/shell";
 
 const CODEX_HOOK_TIMEOUT_SECONDS = 5;
@@ -57,7 +57,7 @@ function addCodexConfigOverrideBeforeSubcommand(args: string[], key: string, val
 }
 
 function buildCodexHookCommand(event: RuntimeHookEvent): string {
-	return buildKanbanCommandParts(["hooks", "codex-hook", "--event", event, "--source", "codex"])
+	return buildKanbanCodexHookCommandParts(["--event", event, "--source", "codex"])
 		.map(quoteShellArg)
 		.join(" ");
 }

--- a/test/runtime/codex-hook-cli.test.ts
+++ b/test/runtime/codex-hook-cli.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCodexHookArguments } from "../../src/codex-hook-cli";
+
+describe("parseCodexHookArguments", () => {
+	it("parses generated hook options and payload", () => {
+		expect(
+			parseCodexHookArguments([
+				'{"hook_event_name":"PreToolUse"}',
+				"--event",
+				"activity",
+				"--source=codex",
+				"--tool-name",
+				"exec_command",
+			]),
+		).toEqual({
+			event: "activity",
+			options: {
+				source: "codex",
+				toolName: "exec_command",
+			},
+			payload: '{"hook_event_name":"PreToolUse"}',
+		});
+	});
+
+	it("rejects invalid events", () => {
+		expect(() => parseCodexHookArguments(["--event", "unknown"])).toThrow(
+			"--event must be one of: to_review, to_in_progress, activity.",
+		);
+	});
+});

--- a/test/runtime/kanban-command.test.ts
+++ b/test/runtime/kanban-command.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildKanbanCommandParts, resolveKanbanCommandParts } from "../../src/core/kanban-command";
+import {
+	buildKanbanCodexHookCommandParts,
+	buildKanbanCommandParts,
+	resolveKanbanCommandParts,
+} from "../../src/core/kanban-command";
 
 describe("resolveKanbanCommandParts", () => {
 	it("resolves node plus script entrypoint", () => {
@@ -45,5 +49,47 @@ describe("buildKanbanCommandParts", () => {
 				argv: ["/usr/local/bin/node", "/tmp/.npx/321/node_modules/kanban/dist/cli.js"],
 			}),
 		).toEqual(["/usr/local/bin/node", "/tmp/.npx/321/node_modules/kanban/dist/cli.js", "hooks", "ingest"]);
+	});
+});
+
+describe("buildKanbanCodexHookCommandParts", () => {
+	it("uses the lightweight bundled hook beside the packaged CLI", () => {
+		expect(
+			buildKanbanCodexHookCommandParts(["--event", "activity"], {
+				execPath: "/usr/local/bin/node",
+				argv: ["/usr/local/bin/node", "/tmp/node_modules/kanban/dist/cli.js"],
+			}),
+		).toEqual([
+			"/usr/local/bin/node",
+			"/tmp/node_modules/kanban/dist/codex-hook.js",
+			"--event",
+			"activity",
+		]);
+	});
+
+	it("uses the lightweight source hook while running through tsx", () => {
+		expect(
+			buildKanbanCodexHookCommandParts(["--event", "activity"], {
+				execPath: "/usr/local/bin/node",
+				execArgv: ["--import", "tsx"],
+				argv: ["/usr/local/bin/node", "/repo/src/cli.ts"],
+			}),
+		).toEqual([
+			"/usr/local/bin/node",
+			"--import",
+			"tsx",
+			"/repo/src/codex-hook-cli.ts",
+			"--event",
+			"activity",
+		]);
+	});
+
+	it("falls back to the main CLI for opaque executable launches", () => {
+		expect(
+			buildKanbanCodexHookCommandParts(["--event", "activity"], {
+				execPath: "/usr/local/bin/kanban",
+				argv: ["/usr/local/bin/kanban"],
+			}),
+		).toEqual(["/usr/local/bin/kanban", "hooks", "codex-hook", "--event", "activity"]);
 	});
 });

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -83,6 +83,7 @@ afterEach(() => {
 describe("prepareAgentLaunch hook strategies", () => {
 	it("configures Codex hooks without legacy notify", async () => {
 		setupTempHome();
+		setKanbanProcessContext();
 		const launch = await prepareAgentLaunch({
 			taskId: "task-1",
 			agentId: "codex",
@@ -98,7 +99,8 @@ describe("prepareAgentLaunch hook strategies", () => {
 
 		const launchCommand = [launch.binary ?? "", ...launch.args].join(" ");
 		expect(launchCommand).toContain("codex");
-		expect(launchCommand).toContain("codex-hook");
+		expect(launchCommand).toContain("codex-hook.js");
+		expect(launchCommand).not.toContain("dist/cli.js hooks codex-hook");
 		expect(launchCommand).toContain("hooks.UserPromptSubmit");
 		expect(launchCommand).toContain("hooks.Stop");
 		expect(launchCommand).toContain("hooks.PermissionRequest");


### PR DESCRIPTION
## Summary

- route Codex lifecycle hooks through a dedicated lightweight entrypoint instead of booting the full Kanban CLI for every hook
- preserve the existing main-CLI fallback for opaque executable launches
- build and desktop-stage the new `dist/codex-hook.js` artifact
- add a reusable process monitor for runtime, hook, Git, agent, and terminal resource usage

## Root cause

Every Codex `PreToolUse` and `PostToolUse` hook launched the full Kanban CLI through `tsx`. That transitively loaded runtime telemetry, Sentry, and server dependencies for each tool call, causing repeated high-memory Node processes and contention during normal agent activity.

Observed before the change:

- individual hooks: 409-445 MiB RSS and 0.78-1.99s
- contended full-CLI load: 418 MiB RSS and 5.38s
- 25s trace: 20 hook processes, 125% average CPU, 540% peak CPU, 899 MiB combined peak RSS
- trivial tool commands: 2.5-6.3s end-to-end

With the dedicated entrypoint:

- source hook: 0.39-0.60s and about 104 MiB RSS
- bundled hook: 0.11-0.12s and about 67 MiB RSS
- roughly 84% lower peak RSS for the production hook path

## Validation

- backend and web TypeScript checks pass
- lint passes
- fast suite passes: 54 files / 554 tests
- focused hook tests pass: 34 tests
- production build passes and emits the 839 KiB hook bundle alongside the 16 MiB main CLI
- desktop staging includes and validates `codex-hook.js`
- local production smoke test on port 3499: UI HTTP 200, passcode endpoint HTTP 200, title `Kanban`, performance monitor collected samples, and shutdown completed cleanly

## Follow-up work

The investigation also found two independent performance areas that are intentionally not included here: very large diff rendering can create hundreds of thousands of DOM nodes, and workspace metadata polling can spawn a high volume of Git processes. Those should be addressed separately to keep this change focused.
