### PR TITLE
fix(terminal): heartbeat viewer sockets so dead browsers can't pause the PTY

### DIFF
--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -39,6 +39,12 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * TERMINAL_WS_HEARTBEAT_INTERVAL_MS. Exposed so tests can use a short interval.
 	 */
 	heartbeatIntervalMs?: number;
+	/**
+	 * How long a backpressured viewer may go without acknowledging any output
+	 * before it is treated as unable to drain and disconnected. Defaults to
+	 * TERMINAL_WS_ACK_STALL_TIMEOUT_MS. Exposed so tests can use a short timeout.
+	 */
+	ackStallTimeoutMs?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -87,6 +93,13 @@ const OUTPUT_ACK_HIGH_WATER_MARK_BYTES = 100_000;
 const OUTPUT_ACK_LOW_WATER_MARK_BYTES = 5_000;
 const OUTPUT_RESUME_CHECK_INTERVAL_MS = 16;
 const TERMINAL_WS_HEARTBEAT_INTERVAL_MS = 30_000;
+// A backgrounded or suspended browser tab keeps answering protocol-level pings
+// (browsers pong from the network stack, without running JavaScript), so the
+// heartbeat above cannot detect it. But its renderer is frozen, so it never
+// sends output_ack, and a viewer that is already backpressured then holds
+// pauseOutput() on the shared PTY forever. Treat "no ack progress while paused"
+// as its own liveness signal and disconnect the viewer when it stalls.
+const TERMINAL_WS_ACK_STALL_TIMEOUT_MS = 20_000;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -178,6 +191,7 @@ export function createTerminalWebSocketBridge({
 	isTerminalControlWebSocketPath,
 	validateUpgradeSession,
 	heartbeatIntervalMs,
+	ackStallTimeoutMs,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -192,6 +206,7 @@ export function createTerminalWebSocketBridge({
 	const ioServer = new WebSocketServer({ noServer: true });
 	const controlServer = new WebSocketServer({ noServer: true });
 	const resolvedHeartbeatIntervalMs = heartbeatIntervalMs ?? TERMINAL_WS_HEARTBEAT_INTERVAL_MS;
+	const resolvedAckStallTimeoutMs = ackStallTimeoutMs ?? TERMINAL_WS_ACK_STALL_TIMEOUT_MS;
 	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
 	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
@@ -272,6 +287,10 @@ export function createTerminalWebSocketBridge({
 		let lastOutputSentAt = 0;
 		let outputPaused = false;
 		let resumeCheckTimer: ReturnType<typeof setTimeout> | null = null;
+		// Armed whenever this viewer is holding the PTY paused. Any acknowledged
+		// byte counts as progress and rearms it; expiry means the viewer is not
+		// draining at all and must not keep the shared PTY blocked.
+		let ackStallTimer: ReturnType<typeof setTimeout> | null = null;
 		// Same idea as VS Code terminal flow control: count output that has been sent
 		// but not yet acknowledged as committed by the terminal renderer. We also look
 		// at the websocket's own bufferedAmount so we catch both xterm lag and socket lag.
@@ -284,6 +303,29 @@ export function createTerminalWebSocketBridge({
 		const canResumeOutput = () =>
 			ws.bufferedAmount < OUTPUT_BUFFER_LOW_WATER_MARK_BYTES &&
 			unacknowledgedOutputBytes < OUTPUT_ACK_LOW_WATER_MARK_BYTES;
+
+		const clearAckStallTimer = () => {
+			if (ackStallTimer !== null) {
+				clearTimeout(ackStallTimer);
+				ackStallTimer = null;
+			}
+		};
+
+		const armAckStallTimer = () => {
+			clearAckStallTimer();
+			ackStallTimer = setTimeout(() => {
+				ackStallTimer = null;
+				if (!outputPaused || ws.readyState !== ws.OPEN) {
+					return;
+				}
+				// This viewer may still be answering pings, but it has acknowledged
+				// nothing for a full timeout while holding the PTY paused. Terminate
+				// it; the normal close handler releases its backpressure claim and
+				// resumes the PTY. A returning tab reconnects and gets a fresh restore.
+				ws.terminate();
+			}, resolvedAckStallTimeoutMs);
+			ackStallTimer.unref?.();
+		};
 
 		const clearResumeCheck = () => {
 			if (resumeCheckTimer !== null) {
@@ -305,6 +347,7 @@ export function createTerminalWebSocketBridge({
 			if (canResumeOutput()) {
 				outputPaused = false;
 				clearResumeCheck();
+				clearAckStallTimer();
 				streamState.backpressuredViewerIds.delete(clientId);
 				if (streamState.backpressuredViewerIds.size === 0) {
 					terminalManager.resumeOutput(taskId);
@@ -339,6 +382,7 @@ export function createTerminalWebSocketBridge({
 				if (!previouslyPaused) {
 					terminalManager.pauseOutput(taskId);
 				}
+				armAckStallTimer();
 				scheduleResumeCheck();
 			}
 		};
@@ -380,7 +424,13 @@ export function createTerminalWebSocketBridge({
 				}
 			},
 			acknowledgeOutput: (bytes: number) => {
-				unacknowledgedOutputBytes = Math.max(0, unacknowledgedOutputBytes - Math.max(0, Math.floor(bytes)));
+				const acknowledgedBytes = Math.max(0, Math.floor(bytes));
+				unacknowledgedOutputBytes = Math.max(0, unacknowledgedOutputBytes - acknowledgedBytes);
+				// A viewer that drains slowly is fine; a viewer that drains nothing is not.
+				// Rearm on progress so only a fully stalled renderer trips the watchdog.
+				if (acknowledgedBytes > 0 && outputPaused) {
+					armAckStallTimer();
+				}
 				checkResumeAfterBackpressure();
 			},
 			dispose: () => {
@@ -389,6 +439,7 @@ export function createTerminalWebSocketBridge({
 					outputFlushTimer = null;
 				}
 				clearResumeCheck();
+				clearAckStallTimer();
 				if (outputPaused) {
 					outputPaused = false;
 					streamState.backpressuredViewerIds.delete(clientId);

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage, Server } from "node:http";
 import type { Socket } from "node:net";
 
-import type { RawData, WebSocket } from "ws";
-import { WebSocketServer } from "ws";
+import type { RawData } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 
 import type { RuntimeTerminalWsServerMessage } from "../core/api-contract";
 import { parseTerminalWsClientMessage } from "../core/api-validation";
@@ -34,6 +34,11 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * @returns true if the request is authenticated, false otherwise.
 	 */
 	validateUpgradeSession?: (cookieHeader: string | undefined) => boolean;
+	/**
+	 * Interval between viewer liveness pings. Defaults to
+	 * TERMINAL_WS_HEARTBEAT_INTERVAL_MS. Exposed so tests can use a short interval.
+	 */
+	heartbeatIntervalMs?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -81,6 +86,7 @@ const OUTPUT_BUFFER_LOW_WATER_MARK_BYTES = Math.floor(OUTPUT_BUFFER_HIGH_WATER_M
 const OUTPUT_ACK_HIGH_WATER_MARK_BYTES = 100_000;
 const OUTPUT_ACK_LOW_WATER_MARK_BYTES = 5_000;
 const OUTPUT_RESUME_CHECK_INTERVAL_MS = 16;
+const TERMINAL_WS_HEARTBEAT_INTERVAL_MS = 30_000;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -125,12 +131,53 @@ function getTerminalClientId(url: URL): string {
 	return url.searchParams.get("clientId")?.trim() || "legacy";
 }
 
+// Browser viewer sockets can die without a clean close (laptop lid, dropped SSH
+// tunnel, killed browser). The ws library then keeps them OPEN indefinitely, and
+// while such a zombie viewer is backpressured it holds pauseOutput() on the shared
+// PTY forever, which blocks the agent process on its stdout writes.
+//
+// Ping every viewer periodically and terminate any socket that misses a pong. The
+// normal close handlers then run and release the viewer's backpressure claim.
+function startWebSocketHeartbeat(wss: WebSocketServer, intervalMs: number): () => void {
+	const aliveSockets = new WeakSet<WebSocket>();
+	const onConnection = (client: WebSocket) => {
+		aliveSockets.add(client);
+		client.on("pong", () => {
+			aliveSockets.add(client);
+		});
+	};
+	wss.on("connection", onConnection);
+	const timer = setInterval(() => {
+		for (const client of wss.clients) {
+			if (client.readyState !== WebSocket.OPEN) {
+				continue;
+			}
+			if (!aliveSockets.has(client)) {
+				client.terminate();
+				continue;
+			}
+			aliveSockets.delete(client);
+			try {
+				client.ping();
+			} catch {
+				client.terminate();
+			}
+		}
+	}, intervalMs);
+	timer.unref();
+	return () => {
+		clearInterval(timer);
+		wss.off("connection", onConnection);
+	};
+}
+
 export function createTerminalWebSocketBridge({
 	server,
 	resolveTerminalManager,
 	isTerminalIoWebSocketPath,
 	isTerminalControlWebSocketPath,
 	validateUpgradeSession,
+	heartbeatIntervalMs,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -144,6 +191,9 @@ export function createTerminalWebSocketBridge({
 
 	const ioServer = new WebSocketServer({ noServer: true });
 	const controlServer = new WebSocketServer({ noServer: true });
+	const resolvedHeartbeatIntervalMs = heartbeatIntervalMs ?? TERMINAL_WS_HEARTBEAT_INTERVAL_MS;
+	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
+	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
 	const getOrCreateTerminalStreamState = (connectionKey: string): TerminalStreamState => {
 		const existing = terminalStreamStates.get(connectionKey);
@@ -558,6 +608,8 @@ export function createTerminalWebSocketBridge({
 
 	return {
 		close: async () => {
+			stopIoHeartbeat();
+			stopControlHeartbeat();
 			for (const client of ioServer.clients) {
 				try {
 					client.terminate();

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -543,4 +543,155 @@ describe("createTerminalWebSocketBridge", () => {
 			});
 		}
 	});
+
+	it("releases PTY backpressure from a viewer that pongs but never acknowledges output", async () => {
+		// A backgrounded mobile tab is not a zombie socket: browsers answer ping
+		// frames from the network stack, so the heartbeat sees it as alive. But its
+		// renderer is frozen, so xterm never fires the write callback that sends
+		// output_ack. Without the ack-stall watchdog this viewer holds pauseOutput()
+		// on the shared PTY forever and the agent blocks on its next stdout write.
+		const stallManager = new FakeTerminalManager();
+		const stallServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const stallBridge = createTerminalWebSocketBridge({
+			server: stallServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? stallManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			// Long enough that the heartbeat cannot be what releases the PTY.
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 150,
+		});
+		stallServer.listen(0, "127.0.0.1");
+		await once(stallServer, "listening");
+		const stallAddress = stallServer.address() as AddressInfo | null;
+		if (!stallAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(stallAddress.port);
+		const stallUrl = `ws://127.0.0.1:${stallAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${stallUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=backgrounded`;
+			const controlUrl = `${stallUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=backgrounded`;
+
+			// Note: default autoPong. This viewer answers every ping, exactly like a
+			// real suspended tab, so the liveness heartbeat will never terminate it.
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			stallManager.emitOutput(TASK_ID, "x".repeat(120_000));
+			await waitForAssertion(() => {
+				expect(stallManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+			expect(stallManager.resumeOutput).not.toHaveBeenCalled();
+
+			// No output_ack is ever sent. The stall watchdog disconnects the viewer
+			// and the close path releases its claim on the shared PTY.
+			await waitForAssertion(() => {
+				expect(stallManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await waitForAssertion(() => {
+				expect(ioSocket?.socket.readyState).toBe(WebSocket.CLOSED);
+			}, 2_000);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await stallBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				stallServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("keeps a slow but progressing viewer connected while it drains", async () => {
+		// The watchdog must not punish a genuinely slow renderer. Partial acks are
+		// progress and rearm the timer, so only a fully stalled viewer is dropped.
+		const slowManager = new FakeTerminalManager();
+		const slowServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const slowBridge = createTerminalWebSocketBridge({
+			server: slowServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? slowManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 200,
+		});
+		slowServer.listen(0, "127.0.0.1");
+		await once(slowServer, "listening");
+		const slowAddress = slowServer.address() as AddressInfo | null;
+		if (!slowAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(slowAddress.port);
+		const slowUrl = `ws://127.0.0.1:${slowAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${slowUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+			const controlUrl = `${slowUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const totalBytes = 120_000;
+			slowManager.emitOutput(TASK_ID, "x".repeat(totalBytes));
+			await waitForAssertion(() => {
+				expect(slowManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+
+			// Dribble acks in over more than one watchdog period.
+			let acknowledged = 0;
+			while (acknowledged < totalBytes) {
+				const chunk = Math.min(20_000, totalBytes - acknowledged);
+				controlSocket.socket.send(JSON.stringify({ type: "output_ack", bytes: chunk }));
+				acknowledged += chunk;
+				await new Promise((resolve) => setTimeout(resolve, 60));
+			}
+
+			await waitForAssertion(() => {
+				expect(slowManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await slowBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				slowServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -464,4 +464,83 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(ioSocketB.socket);
 		await closeSocket(controlSocketB.socket);
 	});
+
+	it("terminates an unresponsive viewer and releases its PTY backpressure", async () => {
+		const heartbeatManager = new FakeTerminalManager();
+		const heartbeatServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const heartbeatBridge = createTerminalWebSocketBridge({
+			server: heartbeatServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? heartbeatManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 50,
+		});
+		heartbeatServer.listen(0, "127.0.0.1");
+		await once(heartbeatServer, "listening");
+		const heartbeatAddress = heartbeatServer.address() as AddressInfo | null;
+		if (!heartbeatAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(heartbeatAddress.port);
+		const heartbeatUrl = `ws://127.0.0.1:${heartbeatAddress.port}`;
+
+		let ioSocket: WebSocket | null = null;
+		let controlSocket: WebSocket | null = null;
+		try {
+			const ioUrl = `${heartbeatUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=zombie`;
+			const controlUrl = `${heartbeatUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=zombie`;
+
+			// Zombie viewer: connected, but never acks output and never replies to pings.
+			ioSocket = new WebSocket(ioUrl, { autoPong: false });
+			await once(ioSocket, "open");
+			controlSocket = new WebSocket(controlUrl, { autoPong: false });
+			// Register before "open" resolves: the server sends restore immediately.
+			const restoreReceived = new Promise<void>((resolve) => {
+				controlSocket?.on("message", (message) => {
+					const parsed = JSON.parse(rawDataToBuffer(message).toString("utf8")) as RuntimeTerminalWsServerMessage;
+					if (parsed.type === "restore") {
+						resolve();
+					}
+				});
+			});
+			await once(controlSocket, "open");
+			await restoreReceived;
+			controlSocket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const output = "x".repeat(120_000);
+			heartbeatManager.emitOutput(TASK_ID, output);
+			await waitForAssertion(() => {
+				expect(heartbeatManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+			expect(heartbeatManager.resumeOutput).not.toHaveBeenCalled();
+
+			// The heartbeat terminates the unresponsive sockets, and the close path
+			// releases the viewer's backpressure claim on the shared PTY.
+			await waitForAssertion(() => {
+				expect(heartbeatManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await waitForAssertion(() => {
+				expect(ioSocket?.readyState).toBe(WebSocket.CLOSED);
+			}, 2_000);
+		} finally {
+			for (const socket of [ioSocket, controlSocket]) {
+				if (socket && socket.readyState !== WebSocket.CLOSED) {
+					socket.terminate();
+				}
+			}
+			await heartbeatBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				heartbeatServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });


### PR DESCRIPTION
## Problem

Task agents (Claude Code, Codex, Grok, Pi, ...) run inside shared PTYs. The terminal WebSocket bridge pauses a PTY when a browser viewer falls behind (VS Code-style backpressure in `ws-server.ts`), and only resumes once every backpressured viewer catches up **or disconnects**.

If a viewer's TCP connection dies without a clean close — laptop lid, dropped SSH tunnel, killed browser — the `ws` library keeps the socket `OPEN` indefinitely (there is no ping/pong heartbeat anywhere). If that viewer is backpressured, it holds `pauseOutput()` on the shared PTY forever:

1. `pauseOutput()` → `PtySession.pause()` stops reading the pty master fd
2. the kernel pty buffer fills
3. the agent CLI blocks in `write(2)` — **a genuine hard pause of the agent process**

Observed symptom (remote SSH+tunnel deployment): all task agents freeze overnight once the last browser goes away, and resume exactly where they stopped the moment someone reconnects - the reconnect replaces/disposes the zombie viewer socket, which finally releases backpressure.

A second variant of the same stall exists even with a heartbeat: a **backgrounded/suspended mobile tab** stays socket-alive — browsers answer ping frames from the network stack without running JavaScript — so the heartbeat sees it as healthy. But its renderer is frozen, xterm never fires the write callback, and it never sends `output_ack`. Once backpressured, that viewer holds `pauseOutput()` on the shared PTY indefinitely and the agent blocks on its next stdout write.

## Fix

### 1. Liveness heartbeat (dead sockets)

Add a ping/pong heartbeat to the terminal `io` and `control` WebSocket servers:

- ping every viewer every 30s (`TERMINAL_WS_HEARTBEAT_INTERVAL_MS`, overridable for tests)
- terminate any viewer that misses a pong
- termination runs the existing `close` handlers, which release the viewer's backpressure claim → `resumeOutput()`

No changes to the backpressure protocol itself; healthy clients answer pings automatically, so this only affects dead sockets.

### 2. Ack-stall watchdog (alive but frozen viewers)

The heartbeat cannot detect the suspended-tab case above, so add a second watchdog armed while a viewer is holding the PTY paused:

- while a viewer is backpressured, it must acknowledge *some* output within `TERMINAL_WS_ACK_STALL_TIMEOUT_MS` (overridable via `ackStallTimeoutMs` for tests)
- any `output_ack` with progress rearms the timer, so a slow-but-draining viewer is never punished — only a fully stalled one
- expiry terminates the viewer; the normal close path releases its backpressure claim and resumes the PTY. A returning tab reconnects and gets a fresh restore.

## Testing

Regression tests in `test/runtime/terminal/ws-server.test.ts`:

- `terminates an unresponsive viewer and releases its PTY backpressure` — zombie viewer (`autoPong: false`) past the ack watermark is terminated by the heartbeat
- `releases PTY backpressure from a viewer that pongs but never acknowledges output` — viewer with default `autoPong` (exactly like a suspended mobile tab) is disconnected by the ack-stall watchdog with a 60s heartbeat, proving the heartbeat is not what releases the PTY
- `keeps a slow but progressing viewer connected while it drains` — dribbled partial acks spanning multiple watchdog periods keep the viewer connected

```
npx vitest run test/runtime/terminal/ws-server.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## Linked issues

Fixes #542 — specifically the "terminal IO stream is paused" theory in that report: a wedged/dead viewer holds the shared PTY paused because it never drains, acks, or disconnects. The heartbeat terminates dead sockets and the ack-stall watchdog terminates alive-but-frozen viewers (e.g. a backgrounded mobile tab that pongs but cannot ack), so the existing close path releases backpressure and resumes the PTY. If any instance of #542 turns out to be the alternative "detached listener" theory instead, that would be a separate bug not addressed here.

Scope note per the triage on #542/#581: this does **not** touch the task-switch snapshot/scrollback freeze tracked in #581 (addressed by #583 / #596). That freeze is renderer/serialize-bound; this one is a server-side PTY stall caused by zombie viewer sockets. The two fixes are independent and complementary.

Related: #285 — same class of bug on the runtime-state stream (`runtime-state-hub.ts`). That hub still has no heartbeat; it causes dead-client accumulation and wasted broadcasts rather than agent pauses, so it is deliberately out of scope here (one bug fix per PR), but the same `startWebSocketHeartbeat` helper would apply.
