### PR TITLE
fix(terminal): bound viewer backpressure so a slow browser cannot block the agent PTY

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -1177,6 +1177,7 @@ export const runtimeTerminalWsRestoreMessageSchema = z.object({
 	snapshot: z.string(),
 	cols: z.number().int().positive().nullable().optional(),
 	rows: z.number().int().positive().nullable().optional(),
+	restoreGeneration: z.number().int().positive().optional(),
 });
 export type RuntimeTerminalWsRestoreMessage = z.infer<typeof runtimeTerminalWsRestoreMessageSchema>;
 

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -67,6 +67,7 @@ interface SessionEntry {
 	summary: RuntimeTaskSessionSummary;
 	active: ActiveProcessState | null;
 	terminalStateMirror: TerminalStateMirror | null;
+	restoreGeneration: number;
 	listenerIdCounter: number;
 	listeners: Map<number, TerminalSessionListener>;
 	restartRequest: RestartableSessionRequest | null;
@@ -248,6 +249,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 				summary: cloneSummary(summary),
 				active: null,
 				terminalStateMirror: null,
+				restoreGeneration: 0,
 				listenerIdCounter: 1,
 				listeners: new Map(),
 				restartRequest: null,
@@ -289,7 +291,11 @@ export class TerminalSessionManager implements TerminalSessionService {
 		if (!entry?.terminalStateMirror) {
 			return null;
 		}
-		return await entry.terminalStateMirror.getSnapshot();
+		const snapshot = await entry.terminalStateMirror.getSnapshot();
+		return {
+			...snapshot,
+			restoreGeneration: entry.restoreGeneration,
+		};
 	}
 
 	async startTaskSession(request: StartTaskSessionRequest): Promise<RuntimeTaskSessionSummary> {
@@ -528,6 +534,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		};
 		entry.active = active;
 		entry.terminalStateMirror = terminalStateMirror;
+		entry.restoreGeneration += 1;
 
 		const startedAt = now();
 		updateSummary(entry, {
@@ -681,6 +688,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 		};
 		entry.active = active;
 		entry.terminalStateMirror = terminalStateMirror;
+		entry.restoreGeneration += 1;
 
 		updateSummary(entry, {
 			state: "running",
@@ -968,6 +976,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			summary: createDefaultSummary(taskId),
 			active: null,
 			terminalStateMirror: null,
+			restoreGeneration: 0,
 			listenerIdCounter: 1,
 			listeners: new Map(),
 			restartRequest: null,

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -4,7 +4,17 @@ import headlessTerminalModule from "@xterm/headless";
 const { SerializeAddon } = serializeAddonModule as typeof import("@xterm/addon-serialize");
 const { Terminal } = headlessTerminalModule as typeof import("@xterm/headless");
 
-const TERMINAL_SCROLLBACK = 10_000;
+/**
+ * Server-side headless terminal scrollback.
+ *
+ * Kept deliberately small because the entire buffer is serialized via
+ * `serializeAddon.serialize()` and shipped over the WebSocket on every
+ * viewer connect (task switch). A 10,000-line buffer caused ~60s main-thread
+ * freezes (#581) and RSS spikes toward OOM (#273) during long agent runs.
+ * 1,000 lines is enough to show recent output while keeping the restore
+ * snapshot ~10x smaller.
+ */
+const TERMINAL_SCROLLBACK = 1_000;
 
 export interface TerminalRestoreSnapshot {
 	snapshot: string;

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -18,6 +18,7 @@ export interface TerminalRestoreSnapshot {
 	snapshot: string;
 	cols: number;
 	rows: number;
+	restoreGeneration?: number;
 }
 
 interface TerminalStateMirrorOptions {

--- a/src/terminal/terminal-state-mirror.ts
+++ b/src/terminal/terminal-state-mirror.ts
@@ -5,14 +5,12 @@ const { SerializeAddon } = serializeAddonModule as typeof import("@xterm/addon-s
 const { Terminal } = headlessTerminalModule as typeof import("@xterm/headless");
 
 /**
- * Server-side headless terminal scrollback.
+ * Server-side headless terminal buffer cap (1,000 lines).
  *
- * Kept deliberately small because the entire buffer is serialized via
- * `serializeAddon.serialize()` and shipped over the WebSocket on every
- * viewer connect (task switch). A 10,000-line buffer caused ~60s main-thread
- * freezes (#581) and RSS spikes toward OOM (#273) during long agent runs.
- * 1,000 lines is enough to show recent output while keeping the restore
- * snapshot ~10x smaller.
+ * Restore serves a cached full `serialize()` of this buffer, not a viewport-only
+ * slice. Output and resize mark the cache dirty; connect does not serialize on
+ * every keystroke. A 10,000-line buffer caused ~60s main-thread freezes (#581)
+ * and RSS spikes toward OOM (#273) during long agent runs.
  */
 const TERMINAL_SCROLLBACK = 1_000;
 
@@ -30,6 +28,8 @@ export class TerminalStateMirror {
 	private readonly terminal: InstanceType<typeof Terminal>;
 	private readonly serializeAddon = new SerializeAddon();
 	private operationQueue: Promise<void> = Promise.resolve();
+	private snapshotDirty = true;
+	private cachedSnapshot: TerminalRestoreSnapshot | null = null;
 
 	constructor(cols: number, rows: number, options: TerminalStateMirrorOptions = {}) {
 		this.terminal = new Terminal({
@@ -50,6 +50,7 @@ export class TerminalStateMirror {
 			() =>
 				new Promise<void>((resolve) => {
 					this.terminal.write(chunkCopy, () => {
+						this.snapshotDirty = true;
 						resolve();
 					});
 				}),
@@ -62,16 +63,23 @@ export class TerminalStateMirror {
 		}
 		this.enqueueOperation(() => {
 			this.terminal.resize(cols, rows);
+			this.snapshotDirty = true;
 		});
 	}
 
 	async getSnapshot(): Promise<TerminalRestoreSnapshot> {
 		await this.operationQueue;
-		return {
+		if (!this.snapshotDirty && this.cachedSnapshot) {
+			return this.cachedSnapshot;
+		}
+		// Full serialize of the 1k buffer. Callers must not pass { scrollback: 0 }.
+		this.cachedSnapshot = {
 			snapshot: this.serializeAddon.serialize(),
 			cols: this.terminal.cols,
 			rows: this.terminal.rows,
 		};
+		this.snapshotDirty = false;
+		return this.cachedSnapshot;
 	}
 
 	dispose(): void {

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -503,6 +503,7 @@ export function createTerminalWebSocketBridge({
 					snapshot: snapshot?.snapshot ?? "",
 					cols: snapshot?.cols ?? null,
 					rows: snapshot?.rows ?? null,
+					restoreGeneration: snapshot?.restoreGeneration,
 				});
 			})
 			.catch(() => {

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -63,6 +63,12 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * Exposed so tests can use a small budget.
 	 */
 	viewerPendingBudgetBytes?: number;
+	/**
+	 * How many consecutive forced re-restores a viewer may receive before it is
+	 * terminated instead. Defaults to OUTPUT_VIEWER_FORCED_RESTORE_LIMIT.
+	 * Exposed so tests can use a small limit.
+	 */
+	forcedRestoreLimit?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -86,6 +92,10 @@ interface TerminalViewerState {
 	pendingOutputChunks: Buffer[];
 	pendingOutputBytes: number;
 	restoreComplete: boolean;
+	// Consecutive forced re-restores since the viewer last completed one. A viewer
+	// that keeps overflowing without ever finishing restore is terminated after a
+	// small number of attempts instead of being re-restored forever.
+	forcedRestoreCount: number;
 	ioState: IoOutputState | null;
 	ioSocket: WebSocket | null;
 	controlSocket: WebSocket | null;
@@ -133,6 +143,13 @@ const OUTPUT_VIEWER_PAUSE_BUDGET_MS = 2_000;
 // in runtime memory. Cap that buffer so a stuck viewer cannot leak memory without
 // bound; on overflow it gets a fresh restore instead.
 const OUTPUT_VIEWER_PENDING_BUDGET_BYTES = 512 * 1024;
+// A forced re-restore clears outputPaused and the ack-stall timer, so a viewer
+// that never completes restore would otherwise re-trigger the pending budget and
+// be re-restored forever: the ack-stall watchdog needs outputPaused to fire, and
+// the heartbeat cannot see a backgrounded tab (it still pongs). Cap consecutive
+// forced re-restores; past the limit, terminate the viewer exactly like the
+// ack-stall watchdog does.
+const OUTPUT_VIEWER_FORCED_RESTORE_LIMIT = 3;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -228,6 +245,7 @@ export function createTerminalWebSocketBridge({
 	viewerPauseBudgetBytes,
 	viewerPauseBudgetMs,
 	viewerPendingBudgetBytes,
+	forcedRestoreLimit,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -246,6 +264,7 @@ export function createTerminalWebSocketBridge({
 	const resolvedViewerPauseBudgetBytes = viewerPauseBudgetBytes ?? OUTPUT_VIEWER_PAUSE_BUDGET_BYTES;
 	const resolvedViewerPauseBudgetMs = viewerPauseBudgetMs ?? OUTPUT_VIEWER_PAUSE_BUDGET_MS;
 	const resolvedViewerPendingBudgetBytes = viewerPendingBudgetBytes ?? OUTPUT_VIEWER_PENDING_BUDGET_BYTES;
+	const resolvedForcedRestoreLimit = forcedRestoreLimit ?? OUTPUT_VIEWER_FORCED_RESTORE_LIMIT;
 	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
 	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
@@ -283,6 +302,7 @@ export function createTerminalWebSocketBridge({
 			pendingOutputChunks: [],
 			pendingOutputBytes: 0,
 			restoreComplete: false,
+			forcedRestoreCount: 0,
 			ioState: null,
 			ioSocket: null,
 			controlSocket: null,
@@ -598,6 +618,16 @@ export function createTerminalWebSocketBridge({
 		if (wasBackpressured && streamState.backpressuredViewerIds.size === 0) {
 			terminalManager.resumeOutput(taskId);
 		}
+		if (viewerState.forcedRestoreCount >= resolvedForcedRestoreLimit) {
+			// Every re-restore attempt so far ended with this viewer still unable to
+			// complete restore, so it cannot recover and must not keep generating
+			// snapshot work forever. Fall back to the ack-stall watchdog's behavior:
+			// terminate the io socket and let the normal close path clean up. A
+			// returning tab reconnects and gets a fresh restore.
+			viewerState.ioSocket?.terminate();
+			return;
+		}
+		viewerState.forcedRestoreCount += 1;
 		sendRestoreToViewer(viewerState, taskId, terminalManager, true);
 	};
 
@@ -731,6 +761,7 @@ export function createTerminalWebSocketBridge({
 		viewerState.restoreComplete = false;
 		viewerState.pendingOutputChunks = [];
 		viewerState.pendingOutputBytes = 0;
+		viewerState.forcedRestoreCount = 0;
 		viewerState.controlSocket = ws;
 		ensureOutputListener(streamState, taskId, terminalManager);
 		viewerState.detachControlListener?.();
@@ -781,6 +812,9 @@ export function createTerminalWebSocketBridge({
 
 			if (message.type === "restore_complete") {
 				viewerState.restoreComplete = true;
+				// A completed restore is genuine progress: the viewer recovered, so a
+				// much later unrelated overflow must not count against earlier ones.
+				viewerState.forcedRestoreCount = 0;
 				viewerState.flushPendingOutput();
 			}
 		});

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -39,6 +39,12 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * TERMINAL_WS_HEARTBEAT_INTERVAL_MS. Exposed so tests can use a short interval.
 	 */
 	heartbeatIntervalMs?: number;
+	/**
+	 * How long a backpressured viewer may go without acknowledging any output
+	 * before it is treated as unable to drain and disconnected. Defaults to
+	 * TERMINAL_WS_ACK_STALL_TIMEOUT_MS. Exposed so tests can use a short timeout.
+	 */
+	ackStallTimeoutMs?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -87,6 +93,13 @@ const OUTPUT_ACK_HIGH_WATER_MARK_BYTES = 100_000;
 const OUTPUT_ACK_LOW_WATER_MARK_BYTES = 5_000;
 const OUTPUT_RESUME_CHECK_INTERVAL_MS = 16;
 const TERMINAL_WS_HEARTBEAT_INTERVAL_MS = 30_000;
+// A backgrounded or suspended browser tab keeps answering protocol-level pings
+// (browsers pong from the network stack, without running JavaScript), so the
+// heartbeat above cannot detect it. But its renderer is frozen, so it never
+// sends output_ack, and a viewer that is already backpressured then holds
+// pauseOutput() on the shared PTY forever. Treat "no ack progress while paused"
+// as its own liveness signal and disconnect the viewer when it stalls.
+const TERMINAL_WS_ACK_STALL_TIMEOUT_MS = 20_000;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -178,6 +191,7 @@ export function createTerminalWebSocketBridge({
 	isTerminalControlWebSocketPath,
 	validateUpgradeSession,
 	heartbeatIntervalMs,
+	ackStallTimeoutMs,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -192,6 +206,7 @@ export function createTerminalWebSocketBridge({
 	const ioServer = new WebSocketServer({ noServer: true });
 	const controlServer = new WebSocketServer({ noServer: true });
 	const resolvedHeartbeatIntervalMs = heartbeatIntervalMs ?? TERMINAL_WS_HEARTBEAT_INTERVAL_MS;
+	const resolvedAckStallTimeoutMs = ackStallTimeoutMs ?? TERMINAL_WS_ACK_STALL_TIMEOUT_MS;
 	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
 	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
@@ -272,6 +287,10 @@ export function createTerminalWebSocketBridge({
 		let lastOutputSentAt = 0;
 		let outputPaused = false;
 		let resumeCheckTimer: ReturnType<typeof setTimeout> | null = null;
+		// Armed whenever this viewer is holding the PTY paused. Any acknowledged
+		// byte counts as progress and rearms it; expiry means the viewer is not
+		// draining at all and must not keep the shared PTY blocked.
+		let ackStallTimer: ReturnType<typeof setTimeout> | null = null;
 		// Same idea as VS Code terminal flow control: count output that has been sent
 		// but not yet acknowledged as committed by the terminal renderer. We also look
 		// at the websocket's own bufferedAmount so we catch both xterm lag and socket lag.
@@ -284,6 +303,29 @@ export function createTerminalWebSocketBridge({
 		const canResumeOutput = () =>
 			ws.bufferedAmount < OUTPUT_BUFFER_LOW_WATER_MARK_BYTES &&
 			unacknowledgedOutputBytes < OUTPUT_ACK_LOW_WATER_MARK_BYTES;
+
+		const clearAckStallTimer = () => {
+			if (ackStallTimer !== null) {
+				clearTimeout(ackStallTimer);
+				ackStallTimer = null;
+			}
+		};
+
+		const armAckStallTimer = () => {
+			clearAckStallTimer();
+			ackStallTimer = setTimeout(() => {
+				ackStallTimer = null;
+				if (!outputPaused || ws.readyState !== ws.OPEN) {
+					return;
+				}
+				// This viewer may still be answering pings, but it has acknowledged
+				// nothing for a full timeout while holding the PTY paused. Terminate
+				// it; the normal close handler releases its backpressure claim and
+				// resumes the PTY. A returning tab reconnects and gets a fresh restore.
+				ws.terminate();
+			}, resolvedAckStallTimeoutMs);
+			ackStallTimer.unref?.();
+		};
 
 		const clearResumeCheck = () => {
 			if (resumeCheckTimer !== null) {
@@ -305,6 +347,7 @@ export function createTerminalWebSocketBridge({
 			if (canResumeOutput()) {
 				outputPaused = false;
 				clearResumeCheck();
+				clearAckStallTimer();
 				streamState.backpressuredViewerIds.delete(clientId);
 				if (streamState.backpressuredViewerIds.size === 0) {
 					terminalManager.resumeOutput(taskId);
@@ -339,6 +382,7 @@ export function createTerminalWebSocketBridge({
 				if (!previouslyPaused) {
 					terminalManager.pauseOutput(taskId);
 				}
+				armAckStallTimer();
 				scheduleResumeCheck();
 			}
 		};
@@ -380,7 +424,13 @@ export function createTerminalWebSocketBridge({
 				}
 			},
 			acknowledgeOutput: (bytes: number) => {
-				unacknowledgedOutputBytes = Math.max(0, unacknowledgedOutputBytes - Math.max(0, Math.floor(bytes)));
+				const acknowledgedBytes = Math.max(0, Math.floor(bytes));
+				unacknowledgedOutputBytes = Math.max(0, unacknowledgedOutputBytes - acknowledgedBytes);
+				// A viewer that drains slowly is fine; a viewer that drains nothing is not.
+				// Rearm on progress so only a fully stalled renderer trips the watchdog.
+				if (acknowledgedBytes > 0 && outputPaused) {
+					armAckStallTimer();
+				}
 				checkResumeAfterBackpressure();
 			},
 			dispose: () => {
@@ -389,6 +439,7 @@ export function createTerminalWebSocketBridge({
 					outputFlushTimer = null;
 				}
 				clearResumeCheck();
+				clearAckStallTimer();
 				if (outputPaused) {
 					outputPaused = false;
 					streamState.backpressuredViewerIds.delete(clientId);

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -45,6 +45,24 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * TERMINAL_WS_ACK_STALL_TIMEOUT_MS. Exposed so tests can use a short timeout.
 	 */
 	ackStallTimeoutMs?: number;
+	/**
+	 * How many unacknowledged bytes a viewer may hold while the PTY is paused
+	 * before it is re-restored from a snapshot instead. Defaults to
+	 * OUTPUT_VIEWER_PAUSE_BUDGET_BYTES. Exposed so tests can use a small budget.
+	 */
+	viewerPauseBudgetBytes?: number;
+	/**
+	 * How long in milliseconds a viewer may hold the PTY paused before it is
+	 * re-restored from a snapshot instead. Defaults to
+	 * OUTPUT_VIEWER_PAUSE_BUDGET_MS. Exposed so tests can use a short budget.
+	 */
+	viewerPauseBudgetMs?: number;
+	/**
+	 * How many bytes may be buffered for a viewer that has not completed restore
+	 * before it is re-restored. Defaults to OUTPUT_VIEWER_PENDING_BUDGET_BYTES.
+	 * Exposed so tests can use a small budget.
+	 */
+	viewerPendingBudgetBytes?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -54,6 +72,9 @@ export interface TerminalWebSocketBridge {
 interface IoOutputState {
 	enqueueOutput: (chunk: Buffer) => void;
 	acknowledgeOutput: (bytes: number) => void;
+	// Called when a viewer exceeds its budget: drops everything buffered for this
+	// viewer and clears its flow-control state so the caller can re-restore it.
+	discardOutputForReRestore: () => void;
 	dispose: () => void;
 }
 
@@ -63,6 +84,7 @@ interface IoOutputState {
 interface TerminalViewerState {
 	clientId: string;
 	pendingOutputChunks: Buffer[];
+	pendingOutputBytes: number;
 	restoreComplete: boolean;
 	ioState: IoOutputState | null;
 	ioSocket: WebSocket | null;
@@ -100,6 +122,17 @@ const TERMINAL_WS_HEARTBEAT_INTERVAL_MS = 30_000;
 // pauseOutput() on the shared PTY forever. Treat "no ack progress while paused"
 // as its own liveness signal and disconnect the viewer when it stalls.
 const TERMINAL_WS_ACK_STALL_TIMEOUT_MS = 20_000;
+// Flow control pauses the shared PTY, which blocks the agent process on stdout,
+// so no single viewer may hold a pause open-ended. Give each viewer a byte and a
+// wall-clock budget; past either, that viewer alone loses its buffered output and
+// is re-restored from a snapshot while the PTY keeps running. Slow-but-progressing
+// viewers stay well inside both budgets; only genuinely stalled ones are re-restored.
+const OUTPUT_VIEWER_PAUSE_BUDGET_BYTES = 512 * 1024;
+const OUTPUT_VIEWER_PAUSE_BUDGET_MS = 2_000;
+// A viewer that connects but never sends restore_complete buffers every PTY chunk
+// in runtime memory. Cap that buffer so a stuck viewer cannot leak memory without
+// bound; on overflow it gets a fresh restore instead.
+const OUTPUT_VIEWER_PENDING_BUDGET_BYTES = 512 * 1024;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -192,6 +225,9 @@ export function createTerminalWebSocketBridge({
 	validateUpgradeSession,
 	heartbeatIntervalMs,
 	ackStallTimeoutMs,
+	viewerPauseBudgetBytes,
+	viewerPauseBudgetMs,
+	viewerPendingBudgetBytes,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -207,6 +243,9 @@ export function createTerminalWebSocketBridge({
 	const controlServer = new WebSocketServer({ noServer: true });
 	const resolvedHeartbeatIntervalMs = heartbeatIntervalMs ?? TERMINAL_WS_HEARTBEAT_INTERVAL_MS;
 	const resolvedAckStallTimeoutMs = ackStallTimeoutMs ?? TERMINAL_WS_ACK_STALL_TIMEOUT_MS;
+	const resolvedViewerPauseBudgetBytes = viewerPauseBudgetBytes ?? OUTPUT_VIEWER_PAUSE_BUDGET_BYTES;
+	const resolvedViewerPauseBudgetMs = viewerPauseBudgetMs ?? OUTPUT_VIEWER_PAUSE_BUDGET_MS;
+	const resolvedViewerPendingBudgetBytes = viewerPendingBudgetBytes ?? OUTPUT_VIEWER_PENDING_BUDGET_BYTES;
 	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
 	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
@@ -242,6 +281,7 @@ export function createTerminalWebSocketBridge({
 		const created: TerminalViewerState = {
 			clientId,
 			pendingOutputChunks: [],
+			pendingOutputBytes: 0,
 			restoreComplete: false,
 			ioState: null,
 			ioSocket: null,
@@ -255,6 +295,7 @@ export function createTerminalWebSocketBridge({
 					created.ioState.enqueueOutput(chunk);
 				}
 				created.pendingOutputChunks = [];
+				created.pendingOutputBytes = 0;
 			},
 		};
 		streamState.viewers.set(clientId, created);
@@ -281,6 +322,7 @@ export function createTerminalWebSocketBridge({
 		clientId: string,
 		taskId: string,
 		terminalManager: TerminalSessionService,
+		onPauseBudgetExceeded: () => void,
 	): IoOutputState => {
 		let pendingOutputChunks: Buffer[] = [];
 		let outputFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -291,6 +333,10 @@ export function createTerminalWebSocketBridge({
 		// byte counts as progress and rearms it; expiry means the viewer is not
 		// draining at all and must not keep the shared PTY blocked.
 		let ackStallTimer: ReturnType<typeof setTimeout> | null = null;
+		// Bounds how long this viewer may hold the PTY paused. Unlike the ack-stall
+		// timer above, acks do not rearm it: partial progress still keeps the agent
+		// blocked, so total pause time is capped and the timer restarts with each pause.
+		let pauseBudgetTimer: ReturnType<typeof setTimeout> | null = null;
 		// Same idea as VS Code terminal flow control: count output that has been sent
 		// but not yet acknowledged as committed by the terminal renderer. We also look
 		// at the websocket's own bufferedAmount so we catch both xterm lag and socket lag.
@@ -327,6 +373,28 @@ export function createTerminalWebSocketBridge({
 			ackStallTimer.unref?.();
 		};
 
+		const clearPauseBudgetTimer = () => {
+			if (pauseBudgetTimer !== null) {
+				clearTimeout(pauseBudgetTimer);
+				pauseBudgetTimer = null;
+			}
+		};
+
+		const armPauseBudgetTimer = () => {
+			clearPauseBudgetTimer();
+			pauseBudgetTimer = setTimeout(() => {
+				pauseBudgetTimer = null;
+				if (!outputPaused || ws.readyState !== ws.OPEN) {
+					return;
+				}
+				// This viewer has held the PTY paused for its entire budget, so the
+				// agent has been blocked on stdout the whole time. Release the pause
+				// and re-restore this viewer from a snapshot instead of waiting longer.
+				onPauseBudgetExceeded();
+			}, resolvedViewerPauseBudgetMs);
+			pauseBudgetTimer.unref?.();
+		};
+
 		const clearResumeCheck = () => {
 			if (resumeCheckTimer !== null) {
 				clearTimeout(resumeCheckTimer);
@@ -348,6 +416,7 @@ export function createTerminalWebSocketBridge({
 				outputPaused = false;
 				clearResumeCheck();
 				clearAckStallTimer();
+				clearPauseBudgetTimer();
 				streamState.backpressuredViewerIds.delete(clientId);
 				if (streamState.backpressuredViewerIds.size === 0) {
 					terminalManager.resumeOutput(taskId);
@@ -382,7 +451,15 @@ export function createTerminalWebSocketBridge({
 				if (!previouslyPaused) {
 					terminalManager.pauseOutput(taskId);
 				}
+				// A single chunk can overshoot the watermarks by more than the entire
+				// budget; re-restore immediately instead of pausing on a deficit that
+				// cannot drain in time.
+				if (unacknowledgedOutputBytes >= resolvedViewerPauseBudgetBytes) {
+					onPauseBudgetExceeded();
+					return;
+				}
 				armAckStallTimer();
+				armPauseBudgetTimer();
 				scheduleResumeCheck();
 			}
 		};
@@ -433,6 +510,21 @@ export function createTerminalWebSocketBridge({
 				}
 				checkResumeAfterBackpressure();
 			},
+			// Drop everything buffered for this viewer and reset its flow control so
+			// the caller can re-restore it. Backpressure bookkeeping on streamState
+			// is the caller's job, because the PTY only resumes when no viewer is left.
+			discardOutputForReRestore: () => {
+				if (outputFlushTimer !== null) {
+					clearTimeout(outputFlushTimer);
+					outputFlushTimer = null;
+				}
+				pendingOutputChunks = [];
+				clearResumeCheck();
+				clearAckStallTimer();
+				clearPauseBudgetTimer();
+				outputPaused = false;
+				unacknowledgedOutputBytes = 0;
+			},
 			dispose: () => {
 				if (outputFlushTimer !== null) {
 					clearTimeout(outputFlushTimer);
@@ -440,6 +532,7 @@ export function createTerminalWebSocketBridge({
 				}
 				clearResumeCheck();
 				clearAckStallTimer();
+				clearPauseBudgetTimer();
 				if (outputPaused) {
 					outputPaused = false;
 					streamState.backpressuredViewerIds.delete(clientId);
@@ -450,6 +543,62 @@ export function createTerminalWebSocketBridge({
 				pendingOutputChunks = [];
 			},
 		};
+	};
+
+	const sendRestoreToViewer = (
+		viewerState: TerminalViewerState,
+		taskId: string,
+		terminalManager: TerminalSessionService,
+		forceReapply: boolean,
+	): void => {
+		const controlSocket = viewerState.controlSocket;
+		if (!controlSocket) {
+			return;
+		}
+		void terminalManager
+			.getRestoreSnapshot(taskId)
+			.then((snapshot) => {
+				sendControlMessage(controlSocket, {
+					type: "restore",
+					snapshot: snapshot?.snapshot ?? "",
+					cols: snapshot?.cols ?? null,
+					rows: snapshot?.rows ?? null,
+					// A forced re-restore replaces output the viewer never committed, so
+					// it must be applied unconditionally. Omitting restoreGeneration is
+					// what guarantees that: clients skip restores whose generation they
+					// already applied, and this one must not be skipped.
+					restoreGeneration: forceReapply ? undefined : snapshot?.restoreGeneration,
+				});
+			})
+			.catch(() => {
+				sendControlMessage(controlSocket, {
+					type: "restore",
+					snapshot: "",
+					cols: null,
+					rows: null,
+				});
+			});
+	};
+
+	// Recovery for a viewer that exceeded its pause or pending budget: drop
+	// everything buffered for it, release its claim on the shared PTY, and resync
+	// it from a snapshot. The socket stays open and no other viewer is affected;
+	// the stalled viewer loses scrollback it never rendered, the agent keeps running.
+	const reRestoreViewer = (
+		streamState: TerminalStreamState,
+		viewerState: TerminalViewerState,
+		taskId: string,
+		terminalManager: TerminalSessionService,
+	): void => {
+		viewerState.ioState?.discardOutputForReRestore();
+		viewerState.pendingOutputChunks = [];
+		viewerState.pendingOutputBytes = 0;
+		viewerState.restoreComplete = false;
+		const wasBackpressured = streamState.backpressuredViewerIds.delete(viewerState.clientId);
+		if (wasBackpressured && streamState.backpressuredViewerIds.size === 0) {
+			terminalManager.resumeOutput(taskId);
+		}
+		sendRestoreToViewer(viewerState, taskId, terminalManager, true);
 	};
 
 	const ensureOutputListener = (
@@ -471,6 +620,10 @@ export function createTerminalWebSocketBridge({
 						continue;
 					}
 					viewerState.pendingOutputChunks.push(chunk);
+					viewerState.pendingOutputBytes += chunk.byteLength;
+					if (viewerState.pendingOutputBytes > resolvedViewerPendingBudgetBytes) {
+						reRestoreViewer(streamState, viewerState, taskId, terminalManager);
+					}
 				}
 			},
 		});
@@ -532,7 +685,9 @@ export function createTerminalWebSocketBridge({
 		const viewerState = getOrCreateViewerState(streamState, clientId);
 		const previousIoSocket = viewerState.ioSocket;
 		viewerState.ioState?.dispose();
-		viewerState.ioState = createIoOutputState(ws, streamState, clientId, taskId, terminalManager);
+		viewerState.ioState = createIoOutputState(ws, streamState, clientId, taskId, terminalManager, () =>
+			reRestoreViewer(streamState, viewerState, taskId, terminalManager),
+		);
 		viewerState.ioSocket = ws;
 		viewerState.flushPendingOutput();
 		ensureOutputListener(streamState, taskId, terminalManager);
@@ -575,6 +730,7 @@ export function createTerminalWebSocketBridge({
 		const previousControlSocket = viewerState.controlSocket;
 		viewerState.restoreComplete = false;
 		viewerState.pendingOutputChunks = [];
+		viewerState.pendingOutputBytes = 0;
 		viewerState.controlSocket = ws;
 		ensureOutputListener(streamState, taskId, terminalManager);
 		viewerState.detachControlListener?.();
@@ -596,25 +752,7 @@ export function createTerminalWebSocketBridge({
 			previousControlSocket.close(1000, "Replaced by newer terminal control connection.");
 		}
 
-		void terminalManager
-			.getRestoreSnapshot(taskId)
-			.then((snapshot) => {
-				sendControlMessage(ws, {
-					type: "restore",
-					snapshot: snapshot?.snapshot ?? "",
-					cols: snapshot?.cols ?? null,
-					rows: snapshot?.rows ?? null,
-					restoreGeneration: snapshot?.restoreGeneration,
-				});
-			})
-			.catch(() => {
-				sendControlMessage(ws, {
-					type: "restore",
-					snapshot: "",
-					cols: null,
-					rows: null,
-				});
-			});
+		sendRestoreToViewer(viewerState, taskId, terminalManager, false);
 
 		ws.on("message", (rawMessage: RawData) => {
 			const message = parseWebSocketPayload(rawMessage);

--- a/src/terminal/ws-server.ts
+++ b/src/terminal/ws-server.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage, Server } from "node:http";
 import type { Socket } from "node:net";
 
-import type { RawData, WebSocket } from "ws";
-import { WebSocketServer } from "ws";
+import type { RawData } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 
 import type { RuntimeTerminalWsServerMessage } from "../core/api-contract";
 import { parseTerminalWsClientMessage } from "../core/api-validation";
@@ -34,6 +34,11 @@ export interface CreateTerminalWebSocketBridgeRequest {
 	 * @returns true if the request is authenticated, false otherwise.
 	 */
 	validateUpgradeSession?: (cookieHeader: string | undefined) => boolean;
+	/**
+	 * Interval between viewer liveness pings. Defaults to
+	 * TERMINAL_WS_HEARTBEAT_INTERVAL_MS. Exposed so tests can use a short interval.
+	 */
+	heartbeatIntervalMs?: number;
 }
 
 export interface TerminalWebSocketBridge {
@@ -81,6 +86,7 @@ const OUTPUT_BUFFER_LOW_WATER_MARK_BYTES = Math.floor(OUTPUT_BUFFER_HIGH_WATER_M
 const OUTPUT_ACK_HIGH_WATER_MARK_BYTES = 100_000;
 const OUTPUT_ACK_LOW_WATER_MARK_BYTES = 5_000;
 const OUTPUT_RESUME_CHECK_INTERVAL_MS = 16;
+const TERMINAL_WS_HEARTBEAT_INTERVAL_MS = 30_000;
 
 function getWebSocketTransportSocket(ws: WebSocket): Socket | null {
 	const transportSocket = (ws as WebSocket & { _socket?: Socket })._socket;
@@ -125,12 +131,53 @@ function getTerminalClientId(url: URL): string {
 	return url.searchParams.get("clientId")?.trim() || "legacy";
 }
 
+// Browser viewer sockets can die without a clean close (laptop lid, dropped SSH
+// tunnel, killed browser). The ws library then keeps them OPEN indefinitely, and
+// while such a zombie viewer is backpressured it holds pauseOutput() on the shared
+// PTY forever, which blocks the agent process on its stdout writes.
+//
+// Ping every viewer periodically and terminate any socket that misses a pong. The
+// normal close handlers then run and release the viewer's backpressure claim.
+function startWebSocketHeartbeat(wss: WebSocketServer, intervalMs: number): () => void {
+	const aliveSockets = new WeakSet<WebSocket>();
+	const onConnection = (client: WebSocket) => {
+		aliveSockets.add(client);
+		client.on("pong", () => {
+			aliveSockets.add(client);
+		});
+	};
+	wss.on("connection", onConnection);
+	const timer = setInterval(() => {
+		for (const client of wss.clients) {
+			if (client.readyState !== WebSocket.OPEN) {
+				continue;
+			}
+			if (!aliveSockets.has(client)) {
+				client.terminate();
+				continue;
+			}
+			aliveSockets.delete(client);
+			try {
+				client.ping();
+			} catch {
+				client.terminate();
+			}
+		}
+	}, intervalMs);
+	timer.unref();
+	return () => {
+		clearInterval(timer);
+		wss.off("connection", onConnection);
+	};
+}
+
 export function createTerminalWebSocketBridge({
 	server,
 	resolveTerminalManager,
 	isTerminalIoWebSocketPath,
 	isTerminalControlWebSocketPath,
 	validateUpgradeSession,
+	heartbeatIntervalMs,
 }: CreateTerminalWebSocketBridgeRequest): TerminalWebSocketBridge {
 	const activeSockets = new Set<Socket>();
 	const terminalStreamStates = new Map<string, TerminalStreamState>();
@@ -144,6 +191,9 @@ export function createTerminalWebSocketBridge({
 
 	const ioServer = new WebSocketServer({ noServer: true });
 	const controlServer = new WebSocketServer({ noServer: true });
+	const resolvedHeartbeatIntervalMs = heartbeatIntervalMs ?? TERMINAL_WS_HEARTBEAT_INTERVAL_MS;
+	const stopIoHeartbeat = startWebSocketHeartbeat(ioServer, resolvedHeartbeatIntervalMs);
+	const stopControlHeartbeat = startWebSocketHeartbeat(controlServer, resolvedHeartbeatIntervalMs);
 
 	const getOrCreateTerminalStreamState = (connectionKey: string): TerminalStreamState => {
 		const existing = terminalStreamStates.get(connectionKey);
@@ -558,6 +608,8 @@ export function createTerminalWebSocketBridge({
 
 	return {
 		close: async () => {
+			stopIoHeartbeat();
+			stopControlHeartbeat();
 			for (const client of ioServer.clients) {
 				try {
 					client.terminate();

--- a/test/runtime/terminal/session-manager-auto-restart.test.ts
+++ b/test/runtime/terminal/session-manager-auto-restart.test.ts
@@ -195,4 +195,34 @@ describe("TerminalSessionManager auto-restart", () => {
 		expect(session.write).toHaveBeenCalledWith(deferredStartupInput);
 		expect(session.write).toHaveBeenCalledTimes(1);
 	});
+
+	it("keeps restoreGeneration for one live PTY and increments on a new start", async () => {
+		const spawnedSessions: Array<ReturnType<typeof createMockPtySession>> = [];
+		ptySessionSpawnMock.mockImplementation((request: MockSpawnRequest) => {
+			const session = createMockPtySession(111, request);
+			spawnedSessions.push(session);
+			return session;
+		});
+
+		const manager = new TerminalSessionManager();
+		const startRequest = {
+			taskId: "task-1",
+			agentId: "codex" as const,
+			binary: "codex",
+			args: [],
+			cwd: "/tmp/task-1",
+			prompt: "Fix the bug",
+		};
+
+		await manager.startTaskSession(startRequest);
+		const first = await manager.getRestoreSnapshot("task-1");
+		const second = await manager.getRestoreSnapshot("task-1");
+		expect(first?.restoreGeneration).toBe(1);
+		expect(second?.restoreGeneration).toBe(1);
+
+		spawnedSessions[0]?.triggerExit(0);
+		await manager.startTaskSession(startRequest);
+		const third = await manager.getRestoreSnapshot("task-1");
+		expect(third?.restoreGeneration).toBe(2);
+	});
 });

--- a/test/runtime/terminal/session-manager.test.ts
+++ b/test/runtime/terminal/session-manager.test.ts
@@ -216,6 +216,7 @@ describe("TerminalSessionManager", () => {
 			terminalStateMirror: {
 				getSnapshot: getSnapshotSpy,
 			},
+			restoreGeneration: 7,
 			listenerIdCounter: 1,
 			listeners: new Map(),
 		};
@@ -231,6 +232,7 @@ describe("TerminalSessionManager", () => {
 			snapshot: "serialized terminal",
 			cols: 120,
 			rows: 40,
+			restoreGeneration: 7,
 		});
 		expect(getSnapshotSpy).toHaveBeenCalledTimes(1);
 	});

--- a/test/runtime/terminal/terminal-state-mirror.test.ts
+++ b/test/runtime/terminal/terminal-state-mirror.test.ts
@@ -67,4 +67,53 @@ describe("TerminalStateMirror", () => {
 
 		expect(onInputResponse).toHaveBeenCalledWith("\u001b[1;1R");
 	});
+
+	it("keeps lines above the viewport in the restore snapshot", async () => {
+		const rows = 8;
+		const mirror = createMirror(40, rows);
+		const lines = Array.from({ length: rows + 12 }, (_, i) => `line-${i}`);
+		mirror.applyOutput(Buffer.from(`${lines.join("\r\n")}\r\n`, "utf8"));
+
+		const snapshot = await mirror.getSnapshot();
+
+		expect(snapshot.snapshot).toContain("line-0");
+		expect(snapshot.snapshot).toContain(`line-${rows + 11}`);
+	});
+
+	it("reuses the restore snapshot when nothing has been written or resized", async () => {
+		const mirror = createMirror();
+		mirror.applyOutput(Buffer.from("stable-output\r\n", "utf8"));
+
+		const first = await mirror.getSnapshot();
+		const second = await mirror.getSnapshot();
+
+		expect(second).toBe(first);
+		expect(second.snapshot).toContain("stable-output");
+	});
+
+	it("rebuilds the restore snapshot after new output", async () => {
+		const mirror = createMirror();
+		mirror.applyOutput(Buffer.from("before-output\r\n", "utf8"));
+		const first = await mirror.getSnapshot();
+
+		mirror.applyOutput(Buffer.from("after-output\r\n", "utf8"));
+		const second = await mirror.getSnapshot();
+
+		expect(second).not.toBe(first);
+		expect(second.snapshot).toContain("before-output");
+		expect(second.snapshot).toContain("after-output");
+	});
+
+	it("rebuilds the restore snapshot after a resize", async () => {
+		const mirror = createMirror(80, 24);
+		mirror.applyOutput(Buffer.from("before-resize\r\n", "utf8"));
+		const first = await mirror.getSnapshot();
+
+		mirror.resize(120, 40);
+		const second = await mirror.getSnapshot();
+
+		expect(second).not.toBe(first);
+		expect(second.cols).toBe(120);
+		expect(second.rows).toBe(40);
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -47,6 +47,7 @@ function rawDataToBuffer(data: RawData): Buffer {
 
 class FakeTerminalManager implements TerminalSessionService {
 	private readonly listenersByTaskId = new Map<string, Set<TerminalSessionListener>>();
+	restoreGeneration = 1;
 
 	attach(taskId: string, listener: TerminalSessionListener): (() => void) | null {
 		const listeners = this.listenersByTaskId.get(taskId) ?? new Set<TerminalSessionListener>();
@@ -66,8 +67,13 @@ class FakeTerminalManager implements TerminalSessionService {
 			snapshot: "",
 			cols: 80,
 			rows: 24,
+			restoreGeneration: this.restoreGeneration,
 		}),
 	);
+
+	beginNewSession(): void {
+		this.restoreGeneration += 1;
+	}
 	recoverStaleSession = vi.fn(() => createSummary());
 	writeInput = vi.fn(() => createSummary());
 	resize = vi.fn(() => true);
@@ -463,5 +469,45 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(controlSocketA.socket);
 		await closeSocket(ioSocketB.socket);
 		await closeSocket(controlSocketB.socket);
+	});
+
+	it("includes restoreGeneration on restore and keeps it for the same session", async () => {
+		const controlUrl = `${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-a`;
+
+		const first = await openQueuedWebSocket(controlUrl);
+		const restoreA = await waitForControlMessage(first, (message) => message.type === "restore");
+		expect(restoreA).toMatchObject({
+			type: "restore",
+			restoreGeneration: 1,
+		});
+		await closeSocket(first.socket);
+
+		const second = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-b`,
+		);
+		const restoreB = await waitForControlMessage(second, (message) => message.type === "restore");
+		expect(restoreB).toMatchObject({
+			type: "restore",
+			restoreGeneration: 1,
+		});
+		await closeSocket(second.socket);
+	});
+
+	it("sends a higher restoreGeneration after a new session starts", async () => {
+		const first = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-a`,
+		);
+		const restoreA = await waitForControlMessage(first, (message) => message.type === "restore");
+		expect(restoreA).toMatchObject({ type: "restore", restoreGeneration: 1 });
+		await closeSocket(first.socket);
+
+		terminalManager.beginNewSession();
+
+		const second = await openQueuedWebSocket(
+			`${runtimeUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=client-b`,
+		);
+		const restoreB = await waitForControlMessage(second, (message) => message.type === "restore");
+		expect(restoreB).toMatchObject({ type: "restore", restoreGeneration: 2 });
+		await closeSocket(second.socket);
 	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -543,4 +543,155 @@ describe("createTerminalWebSocketBridge", () => {
 			});
 		}
 	});
+
+	it("releases PTY backpressure from a viewer that pongs but never acknowledges output", async () => {
+		// A backgrounded mobile tab is not a zombie socket: browsers answer ping
+		// frames from the network stack, so the heartbeat sees it as alive. But its
+		// renderer is frozen, so xterm never fires the write callback that sends
+		// output_ack. Without the ack-stall watchdog this viewer holds pauseOutput()
+		// on the shared PTY forever and the agent blocks on its next stdout write.
+		const stallManager = new FakeTerminalManager();
+		const stallServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const stallBridge = createTerminalWebSocketBridge({
+			server: stallServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? stallManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			// Long enough that the heartbeat cannot be what releases the PTY.
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 150,
+		});
+		stallServer.listen(0, "127.0.0.1");
+		await once(stallServer, "listening");
+		const stallAddress = stallServer.address() as AddressInfo | null;
+		if (!stallAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(stallAddress.port);
+		const stallUrl = `ws://127.0.0.1:${stallAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${stallUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=backgrounded`;
+			const controlUrl = `${stallUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=backgrounded`;
+
+			// Note: default autoPong. This viewer answers every ping, exactly like a
+			// real suspended tab, so the liveness heartbeat will never terminate it.
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			stallManager.emitOutput(TASK_ID, "x".repeat(120_000));
+			await waitForAssertion(() => {
+				expect(stallManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+			expect(stallManager.resumeOutput).not.toHaveBeenCalled();
+
+			// No output_ack is ever sent. The stall watchdog disconnects the viewer
+			// and the close path releases its claim on the shared PTY.
+			await waitForAssertion(() => {
+				expect(stallManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await waitForAssertion(() => {
+				expect(ioSocket?.socket.readyState).toBe(WebSocket.CLOSED);
+			}, 2_000);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await stallBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				stallServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("keeps a slow but progressing viewer connected while it drains", async () => {
+		// The watchdog must not punish a genuinely slow renderer. Partial acks are
+		// progress and rearm the timer, so only a fully stalled viewer is dropped.
+		const slowManager = new FakeTerminalManager();
+		const slowServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const slowBridge = createTerminalWebSocketBridge({
+			server: slowServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? slowManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 200,
+		});
+		slowServer.listen(0, "127.0.0.1");
+		await once(slowServer, "listening");
+		const slowAddress = slowServer.address() as AddressInfo | null;
+		if (!slowAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(slowAddress.port);
+		const slowUrl = `ws://127.0.0.1:${slowAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${slowUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+			const controlUrl = `${slowUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const totalBytes = 120_000;
+			slowManager.emitOutput(TASK_ID, "x".repeat(totalBytes));
+			await waitForAssertion(() => {
+				expect(slowManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+
+			// Dribble acks in over more than one watchdog period.
+			let acknowledged = 0;
+			while (acknowledged < totalBytes) {
+				const chunk = Math.min(20_000, totalBytes - acknowledged);
+				controlSocket.socket.send(JSON.stringify({ type: "output_ack", bytes: chunk }));
+				acknowledged += chunk;
+				await new Promise((resolve) => setTimeout(resolve, 60));
+			}
+
+			await waitForAssertion(() => {
+				expect(slowManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await slowBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				slowServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -1057,4 +1057,170 @@ describe("createTerminalWebSocketBridge", () => {
 			});
 		}
 	});
+
+	it("terminates a permanently frozen viewer after the forced re-restore limit", async () => {
+		// A forced re-restore clears outputPaused and the ack-stall timer, so a
+		// viewer that never completes restore again would otherwise trip the pending
+		// budget and be re-restored forever: neither existing safety net can stop
+		// that loop (heartbeat is far away, and the watchdog needs outputPaused).
+		// The cap must terminate it instead.
+		const forcedRestoreLimit = 2;
+		const frozenManager = new FakeTerminalManager();
+		const frozenServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const frozenBridge = createTerminalWebSocketBridge({
+			server: frozenServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? frozenManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPauseBudgetMs: 100,
+			viewerPendingBudgetBytes: 8 * 1024,
+			forcedRestoreLimit,
+		});
+		frozenServer.listen(0, "127.0.0.1");
+		await once(frozenServer, "listening");
+		const frozenAddress = frozenServer.address() as AddressInfo | null;
+		if (!frozenAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(frozenAddress.port);
+		const frozenUrl = `ws://127.0.0.1:${frozenAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${frozenUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=frozen`;
+			const controlUrl = `${frozenUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=frozen`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			// Complete the initial restore once so this viewer can be backpressured
+			// and actually pause the PTY; after this it never acks and never
+			// completes another restore, like a permanently frozen tab.
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+			// Let restore_complete land before emitting: with the tiny pending budget,
+			// output that reached the pending buffer first would itself trip a
+			// re-restore before this viewer could ever pause the PTY.
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			frozenManager.emitOutput(TASK_ID, "x".repeat(120_000));
+			await waitForAssertion(() => {
+				expect(frozenManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+
+			// Feed output until the viewer is terminated or the loop gives up.
+			for (let iteration = 0; iteration < 10 && ioSocket.socket.readyState !== WebSocket.CLOSED; iteration++) {
+				frozenManager.emitOutput(TASK_ID, "x".repeat(32 * 1024));
+				await new Promise((resolve) => setTimeout(resolve, 20));
+			}
+
+			await waitForAssertion(() => {
+				expect(ioSocket?.socket.readyState).toBe(WebSocket.CLOSED);
+			}, 3_000);
+
+			// The initial connect restore plus at most one forced attempt per unit of
+			// limit; after that the viewer is terminated, not re-restored again.
+			const forcedRestores = controlSocket.queue.filter((rawData) => {
+				const message = JSON.parse(rawDataToBuffer(rawData).toString("utf8")) as RuntimeTerminalWsServerMessage;
+				return message.type === "restore";
+			});
+			expect(forcedRestores.length).toBeLessThanOrEqual(forcedRestoreLimit);
+			// The viewer's backpressure claim was released, so the PTY is not left paused.
+			expect(frozenManager.resumeOutput).toHaveBeenCalled();
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await frozenBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				frozenServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("resets the forced re-restore counter when a viewer recovers", async () => {
+		// Regression guard: two overflows separated by a successful restore must not
+		// be summed toward the limit. With forcedRestoreLimit of 1, a viewer whose
+		// counter was not reset would be terminated on the second overflow.
+		const recoveringManager = new FakeTerminalManager();
+		const recoveringServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const recoveringBridge = createTerminalWebSocketBridge({
+			server: recoveringServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? recoveringManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPauseBudgetMs: 100,
+			forcedRestoreLimit: 1,
+		});
+		recoveringServer.listen(0, "127.0.0.1");
+		await once(recoveringServer, "listening");
+		const recoveringAddress = recoveringServer.address() as AddressInfo | null;
+		if (!recoveringAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(recoveringAddress.port);
+		const recoveringUrl = `ws://127.0.0.1:${recoveringAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${recoveringUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=recovering`;
+			const controlUrl = `${recoveringUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=recovering`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			// First overflow: stall past the pause budget without acking.
+			recoveringManager.emitOutput(TASK_ID, "x".repeat(120_000));
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+
+			// The viewer recovers.
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			// Second, unrelated overflow later on.
+			recoveringManager.emitOutput(TASK_ID, "y".repeat(120_000));
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore", 3_000);
+
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+			expect(recoveringManager.resumeOutput).toHaveBeenCalledTimes(2);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await recoveringBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				recoveringServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -464,4 +464,83 @@ describe("createTerminalWebSocketBridge", () => {
 		await closeSocket(ioSocketB.socket);
 		await closeSocket(controlSocketB.socket);
 	});
+
+	it("terminates an unresponsive viewer and releases its PTY backpressure", async () => {
+		const heartbeatManager = new FakeTerminalManager();
+		const heartbeatServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const heartbeatBridge = createTerminalWebSocketBridge({
+			server: heartbeatServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? heartbeatManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 50,
+		});
+		heartbeatServer.listen(0, "127.0.0.1");
+		await once(heartbeatServer, "listening");
+		const heartbeatAddress = heartbeatServer.address() as AddressInfo | null;
+		if (!heartbeatAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(heartbeatAddress.port);
+		const heartbeatUrl = `ws://127.0.0.1:${heartbeatAddress.port}`;
+
+		let ioSocket: WebSocket | null = null;
+		let controlSocket: WebSocket | null = null;
+		try {
+			const ioUrl = `${heartbeatUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=zombie`;
+			const controlUrl = `${heartbeatUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=zombie`;
+
+			// Zombie viewer: connected, but never acks output and never replies to pings.
+			ioSocket = new WebSocket(ioUrl, { autoPong: false });
+			await once(ioSocket, "open");
+			controlSocket = new WebSocket(controlUrl, { autoPong: false });
+			// Register before "open" resolves: the server sends restore immediately.
+			const restoreReceived = new Promise<void>((resolve) => {
+				controlSocket?.on("message", (message) => {
+					const parsed = JSON.parse(rawDataToBuffer(message).toString("utf8")) as RuntimeTerminalWsServerMessage;
+					if (parsed.type === "restore") {
+						resolve();
+					}
+				});
+			});
+			await once(controlSocket, "open");
+			await restoreReceived;
+			controlSocket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const output = "x".repeat(120_000);
+			heartbeatManager.emitOutput(TASK_ID, output);
+			await waitForAssertion(() => {
+				expect(heartbeatManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+			expect(heartbeatManager.resumeOutput).not.toHaveBeenCalled();
+
+			// The heartbeat terminates the unresponsive sockets, and the close path
+			// releases the viewer's backpressure claim on the shared PTY.
+			await waitForAssertion(() => {
+				expect(heartbeatManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await waitForAssertion(() => {
+				expect(ioSocket?.readyState).toBe(WebSocket.CLOSED);
+			}, 2_000);
+		} finally {
+			for (const socket of [ioSocket, controlSocket]) {
+				if (socket && socket.readyState !== WebSocket.CLOSED) {
+					socket.terminate();
+				}
+			}
+			await heartbeatBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				heartbeatServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });

--- a/test/runtime/terminal/ws-server.test.ts
+++ b/test/runtime/terminal/ws-server.test.ts
@@ -740,4 +740,321 @@ describe("createTerminalWebSocketBridge", () => {
 			});
 		}
 	});
+
+	it("re-restores a viewer that never acks and resumes the PTY instead of blocking", async () => {
+		// The pause budget must rescue the PTY on its own: both the heartbeat and the
+		// ack-stall watchdog are set far above the budget so neither of them can be
+		// what releases the pause.
+		const budgetManager = new FakeTerminalManager();
+		const budgetServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const budgetBridge = createTerminalWebSocketBridge({
+			server: budgetServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? budgetManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPauseBudgetMs: 150,
+		});
+		budgetServer.listen(0, "127.0.0.1");
+		await once(budgetServer, "listening");
+		const budgetAddress = budgetServer.address() as AddressInfo | null;
+		if (!budgetAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(budgetAddress.port);
+		const budgetUrl = `ws://127.0.0.1:${budgetAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${budgetUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=stalled`;
+			const controlUrl = `${budgetUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=stalled`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			budgetManager.emitOutput(TASK_ID, "x".repeat(120_000));
+			await waitForAssertion(() => {
+				expect(budgetManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+			expect(budgetManager.resumeOutput).not.toHaveBeenCalled();
+
+			// The viewer never acks. Instead of holding the pause until the ack-stall
+			// watchdog (60s away), the wall-clock pause budget expires and re-restores
+			// this viewer, which releases the shared PTY.
+			await waitForAssertion(() => {
+				expect(budgetManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			const reRestore = await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			// Forced re-restores omit restoreGeneration so clients cannot skip them.
+			expect(reRestore).not.toHaveProperty("restoreGeneration");
+			// This is a recovery, not an eviction: the viewer keeps its sockets.
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await budgetBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				budgetServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("keeps a second viewer streaming while the first viewer overflows its budget", async () => {
+		const isolatedManager = new FakeTerminalManager();
+		const isolatedServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const isolatedBridge = createTerminalWebSocketBridge({
+			server: isolatedServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? isolatedManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPauseBudgetMs: 150,
+		});
+		isolatedServer.listen(0, "127.0.0.1");
+		await once(isolatedServer, "listening");
+		const isolatedAddress = isolatedServer.address() as AddressInfo | null;
+		if (!isolatedAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(isolatedAddress.port);
+		const isolatedUrl = `ws://127.0.0.1:${isolatedAddress.port}`;
+
+		let ioSocketA: QueuedWebSocket | null = null;
+		let controlSocketA: QueuedWebSocket | null = null;
+		let ioSocketB: QueuedWebSocket | null = null;
+		let controlSocketB: QueuedWebSocket | null = null;
+		try {
+			const ioUrlA = `${isolatedUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=stalled`;
+			const controlUrlA = `${isolatedUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=stalled`;
+			const ioUrlB = `${isolatedUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=healthy`;
+			const controlUrlB = `${isolatedUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=healthy`;
+
+			ioSocketA = await openQueuedWebSocket(ioUrlA);
+			controlSocketA = await openQueuedWebSocket(controlUrlA);
+			ioSocketB = await openQueuedWebSocket(ioUrlB);
+			controlSocketB = await openQueuedWebSocket(controlUrlB);
+
+			await waitForControlMessage(controlSocketA, (message) => message.type === "restore");
+			await waitForControlMessage(controlSocketB, (message) => message.type === "restore");
+			controlSocketA.socket.send(JSON.stringify({ type: "restore_complete" }));
+			controlSocketB.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const output = "x".repeat(120_000);
+			isolatedManager.emitOutput(TASK_ID, output);
+			const outputA = await waitForIoMessage(ioSocketA);
+			const outputB = await waitForIoMessage(ioSocketB);
+			expect(outputA.byteLength).toBe(Buffer.byteLength(output));
+			expect(outputB.byteLength).toBe(Buffer.byteLength(output));
+			await waitForAssertion(() => {
+				expect(isolatedManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+
+			// The healthy viewer drains; the stalled viewer never acks.
+			controlSocketB.socket.send(JSON.stringify({ type: "output_ack", bytes: outputB.byteLength }));
+
+			// The stalled viewer overflows its budget and is re-restored, which releases
+			// the shared PTY. The healthy viewer is untouched by any of this.
+			await waitForAssertion(() => {
+				expect(isolatedManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await waitForControlMessage(controlSocketA, (message) => message.type === "restore");
+
+			isolatedManager.emitOutput(TASK_ID, "tail-output");
+			await expect(waitForIoMessage(ioSocketB)).resolves.toEqual(Buffer.from("tail-output", "utf8"));
+			expect(ioSocketA.socket.readyState).toBe(WebSocket.OPEN);
+
+			// The healthy viewer never receives a second restore.
+			const extraRestoresForB = controlSocketB.queue.filter((rawData) => {
+				const message = JSON.parse(rawDataToBuffer(rawData).toString("utf8")) as RuntimeTerminalWsServerMessage;
+				return message.type === "restore";
+			});
+			expect(extraRestoresForB).toHaveLength(0);
+		} finally {
+			for (const queued of [ioSocketA, controlSocketA, ioSocketB, controlSocketB]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await isolatedBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				isolatedServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("bounds pre-restore buffering for a viewer that never completes restore", async () => {
+		// Without the pending budget, a viewer that connects and never sends
+		// restore_complete accumulates every PTY chunk in runtime memory forever.
+		const pendingManager = new FakeTerminalManager();
+		const pendingServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const pendingBridge = createTerminalWebSocketBridge({
+			server: pendingServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? pendingManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPendingBudgetBytes: 8 * 1024,
+		});
+		pendingServer.listen(0, "127.0.0.1");
+		await once(pendingServer, "listening");
+		const pendingAddress = pendingServer.address() as AddressInfo | null;
+		if (!pendingAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(pendingAddress.port);
+		const pendingUrl = `ws://127.0.0.1:${pendingAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${pendingUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=never-restored`;
+			const controlUrl = `${pendingUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=never-restored`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			// Deliberately never send restore_complete.
+
+			pendingManager.emitOutput(TASK_ID, "x".repeat(32 * 1024));
+
+			// The pending buffer overflows and the viewer is re-restored instead of
+			// growing without bound. No live output was ever committed, so the PTY
+			// was never paused either.
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			expect(pendingManager.pauseOutput).not.toHaveBeenCalled();
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await pendingBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				pendingServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
+
+	it("does not re-restore a slow but progressing viewer within its budget", async () => {
+		// Regression guard against an over-eager budget: partial acks are progress.
+		// A viewer that keeps draining within its byte and wall-clock budgets must
+		// ride out the pause and never lose its stream.
+		const slowBudgetManager = new FakeTerminalManager();
+		const slowBudgetServer = createServer((_request, response) => {
+			response.writeHead(404);
+			response.end();
+		});
+		const slowBudgetBridge = createTerminalWebSocketBridge({
+			server: slowBudgetServer,
+			resolveTerminalManager: (workspaceId) => (workspaceId === WORKSPACE_ID ? slowBudgetManager : null),
+			isTerminalIoWebSocketPath: (pathname) => pathname === "/api/terminal/io",
+			isTerminalControlWebSocketPath: (pathname) => pathname === "/api/terminal/control",
+			heartbeatIntervalMs: 60_000,
+			ackStallTimeoutMs: 60_000,
+			viewerPauseBudgetMs: 2_000,
+			viewerPauseBudgetBytes: 512 * 1024,
+		});
+		slowBudgetServer.listen(0, "127.0.0.1");
+		await once(slowBudgetServer, "listening");
+		const slowBudgetAddress = slowBudgetServer.address() as AddressInfo | null;
+		if (!slowBudgetAddress) {
+			throw new Error("Expected websocket server address.");
+		}
+		setKanbanRuntimePort(slowBudgetAddress.port);
+		const slowBudgetUrl = `ws://127.0.0.1:${slowBudgetAddress.port}`;
+
+		let ioSocket: QueuedWebSocket | null = null;
+		let controlSocket: QueuedWebSocket | null = null;
+		try {
+			const ioUrl = `${slowBudgetUrl}/api/terminal/io?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+			const controlUrl = `${slowBudgetUrl}/api/terminal/control?taskId=${TASK_ID}&workspaceId=${WORKSPACE_ID}&clientId=slow`;
+
+			ioSocket = await openQueuedWebSocket(ioUrl);
+			controlSocket = await openQueuedWebSocket(controlUrl);
+
+			await waitForControlMessage(controlSocket, (message) => message.type === "restore");
+			controlSocket.socket.send(JSON.stringify({ type: "restore_complete" }));
+
+			const totalBytes = 120_000;
+			slowBudgetManager.emitOutput(TASK_ID, "x".repeat(totalBytes));
+			await waitForAssertion(() => {
+				expect(slowBudgetManager.pauseOutput).toHaveBeenCalledTimes(1);
+			});
+
+			// Dribble acks in; the full drain stays inside the pause budget.
+			let acknowledged = 0;
+			while (acknowledged < totalBytes) {
+				const chunk = Math.min(20_000, totalBytes - acknowledged);
+				controlSocket.socket.send(JSON.stringify({ type: "output_ack", bytes: chunk }));
+				acknowledged += chunk;
+				await new Promise((resolve) => setTimeout(resolve, 60));
+			}
+
+			await waitForAssertion(() => {
+				expect(slowBudgetManager.resumeOutput).toHaveBeenCalledTimes(1);
+			}, 2_000);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			const extraRestores = controlSocket.queue.filter((rawData) => {
+				const message = JSON.parse(rawDataToBuffer(rawData).toString("utf8")) as RuntimeTerminalWsServerMessage;
+				return message.type === "restore";
+			});
+			expect(extraRestores).toHaveLength(0);
+			expect(ioSocket.socket.readyState).toBe(WebSocket.OPEN);
+		} finally {
+			for (const queued of [ioSocket, controlSocket]) {
+				if (queued && queued.socket.readyState !== WebSocket.CLOSED) {
+					queued.socket.terminate();
+				}
+			}
+			await slowBudgetBridge.close();
+			await new Promise<void>((resolve, reject) => {
+				slowBudgetServer.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				});
+			});
+		}
+	});
 });

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -12,6 +12,7 @@ import type {
 	RuntimeTerminalWsClientMessage,
 	RuntimeTerminalWsServerMessage,
 } from "@/runtime/types";
+import { type AppliedRestore, shouldSkipWarmRestore } from "@/terminal/restore-generation";
 import { splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
 import { clearTerminalGeometry, reportTerminalGeometry } from "@/terminal/terminal-geometry-registry";
 import { createKanbanTerminalOptions } from "@/terminal/terminal-options";
@@ -162,6 +163,7 @@ class PersistentTerminal {
 	private restoreCompleted = false;
 	private outputTextDecoder = new TextDecoder();
 	private terminalWriteQueue: Promise<void> = Promise.resolve();
+	private lastRestore: AppliedRestore | null = null;
 	private disposed = false;
 
 	constructor(
@@ -314,18 +316,23 @@ class PersistentTerminal {
 		snapshot: string,
 		cols: number | null | undefined,
 		rows: number | null | undefined,
+		restoreGeneration?: number,
 	): Promise<void> {
+		if (shouldSkipWarmRestore(this.lastRestore, { restoreGeneration, cols, rows })) {
+			return;
+		}
 		await this.terminalWriteQueue.catch(() => undefined);
 		this.terminal.reset();
 		if (cols && rows && (this.terminal.cols !== cols || this.terminal.rows !== rows)) {
 			this.terminal.resize(cols, rows);
 		}
-		if (!snapshot) {
-			return;
+		if (snapshot) {
+			for (const chunk of splitRestoreSnapshot(snapshot)) {
+				await this.enqueueTerminalWrite(chunk);
+			}
 		}
-		for (const chunk of splitRestoreSnapshot(snapshot)) {
-			await this.enqueueTerminalWrite(chunk);
-		}
+		this.lastRestore =
+			restoreGeneration !== undefined && cols && rows ? { generation: restoreGeneration, cols, rows } : null;
 	}
 
 	private requestResize(): void {
@@ -424,7 +431,7 @@ class PersistentTerminal {
 
 			if (payload.type === "restore") {
 				this.restoreCompleted = false;
-				void this.applyRestore(payload.snapshot, payload.cols, payload.rows)
+				void this.applyRestore(payload.snapshot, payload.cols, payload.rows, payload.restoreGeneration)
 					.then(() => {
 						if (this.disposed || this.controlSocket !== controlSocket) {
 							return;
@@ -694,6 +701,7 @@ class PersistentTerminal {
 		this.ioSocket = null;
 		this.controlSocket = null;
 		this.subscribers.clear();
+		this.lastRestore = null;
 		this.terminal.dispose();
 		this.hostElement.remove();
 	}

--- a/web-ui/src/terminal/persistent-terminal-manager.ts
+++ b/web-ui/src/terminal/persistent-terminal-manager.ts
@@ -12,6 +12,7 @@ import type {
 	RuntimeTerminalWsClientMessage,
 	RuntimeTerminalWsServerMessage,
 } from "@/runtime/types";
+import { splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
 import { clearTerminalGeometry, reportTerminalGeometry } from "@/terminal/terminal-geometry-registry";
 import { createKanbanTerminalOptions } from "@/terminal/terminal-options";
 import {
@@ -322,7 +323,9 @@ class PersistentTerminal {
 		if (!snapshot) {
 			return;
 		}
-		await this.enqueueTerminalWrite(snapshot);
+		for (const chunk of splitRestoreSnapshot(snapshot)) {
+			await this.enqueueTerminalWrite(chunk);
+		}
 	}
 
 	private requestResize(): void {

--- a/web-ui/src/terminal/restore-generation.test.ts
+++ b/web-ui/src/terminal/restore-generation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipWarmRestore } from "@/terminal/restore-generation";
+
+const lastRestore = { generation: 3, cols: 80, rows: 24 };
+
+describe("shouldSkipWarmRestore", () => {
+	it("skips when generation and size already match the last apply", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 3,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(true);
+	});
+
+	it("applies when the restore generation is newer", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 4,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when cols or rows changed for the same generation", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				restoreGeneration: 3,
+				cols: 120,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when the server omitted restoreGeneration", () => {
+		expect(
+			shouldSkipWarmRestore(lastRestore, {
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+
+	it("applies when this viewer has not restored yet", () => {
+		expect(
+			shouldSkipWarmRestore(null, {
+				restoreGeneration: 3,
+				cols: 80,
+				rows: 24,
+			}),
+		).toBe(false);
+	});
+});

--- a/web-ui/src/terminal/restore-generation.ts
+++ b/web-ui/src/terminal/restore-generation.ts
@@ -1,0 +1,23 @@
+export interface AppliedRestore {
+	generation: number;
+	cols: number;
+	rows: number;
+}
+
+export interface IncomingRestore {
+	restoreGeneration?: number;
+	cols: number | null | undefined;
+	rows: number | null | undefined;
+}
+
+export function shouldSkipWarmRestore(lastRestore: AppliedRestore | null, incoming: IncomingRestore): boolean {
+	if (incoming.restoreGeneration === undefined || lastRestore === null) {
+		return false;
+	}
+
+	return (
+		lastRestore.generation === incoming.restoreGeneration &&
+		lastRestore.cols === incoming.cols &&
+		lastRestore.rows === incoming.rows
+	);
+}

--- a/web-ui/src/terminal/restore-snapshot-chunks.test.ts
+++ b/web-ui/src/terminal/restore-snapshot-chunks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { RESTORE_WRITE_CHUNK_BYTES, splitRestoreSnapshot } from "@/terminal/restore-snapshot-chunks";
+
+describe("splitRestoreSnapshot", () => {
+	it("returns no writes for an empty snapshot", () => {
+		expect(splitRestoreSnapshot("")).toEqual([]);
+	});
+
+	it("keeps a snapshot that fits in one parse budget as one write", () => {
+		const snapshot = "a".repeat(RESTORE_WRITE_CHUNK_BYTES);
+
+		expect(splitRestoreSnapshot(snapshot)).toEqual([snapshot]);
+	});
+
+	it("splits one byte over the parse budget into two writes", () => {
+		const snapshot = "a".repeat(RESTORE_WRITE_CHUNK_BYTES + 1);
+
+		const chunks = splitRestoreSnapshot(snapshot);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0]).toHaveLength(RESTORE_WRITE_CHUNK_BYTES);
+		expect(chunks[1]).toBe("a");
+		expect(chunks.join("")).toBe(snapshot);
+	});
+
+	it("joins back to the original snapshot with no drop or reorder", () => {
+		const snapshot = `${"ab".repeat(10_000)}🙂${"cd".repeat(8_000)}`;
+
+		expect(splitRestoreSnapshot(snapshot).join("")).toBe(snapshot);
+	});
+});

--- a/web-ui/src/terminal/restore-snapshot-chunks.ts
+++ b/web-ui/src/terminal/restore-snapshot-chunks.ts
@@ -1,0 +1,36 @@
+/** xterm parse budget for restore writes, not a second scrollback cap. */
+export const RESTORE_WRITE_CHUNK_BYTES = 16 * 1024;
+
+export function splitRestoreSnapshot(snapshot: string, chunkBytes: number = RESTORE_WRITE_CHUNK_BYTES): string[] {
+	if (snapshot.length === 0) {
+		return [];
+	}
+
+	const encoder = new TextEncoder();
+	const parts: string[] = [];
+	let start = 0;
+	let usedBytes = 0;
+	let index = 0;
+
+	while (index < snapshot.length) {
+		const codePoint = snapshot.codePointAt(index);
+		if (codePoint === undefined) {
+			break;
+		}
+		const char = String.fromCodePoint(codePoint);
+		const charBytes = encoder.encode(char).byteLength;
+		if (usedBytes > 0 && usedBytes + charBytes > chunkBytes) {
+			parts.push(snapshot.slice(start, index));
+			start = index;
+			usedBytes = 0;
+		}
+		usedBytes += charBytes;
+		index += char.length;
+	}
+
+	if (start < snapshot.length) {
+		parts.push(snapshot.slice(start));
+	}
+
+	return parts;
+}

--- a/web-ui/src/terminal/terminal-options.test.ts
+++ b/web-ui/src/terminal/terminal-options.test.ts
@@ -16,7 +16,7 @@ describe("createKanbanTerminalOptions", () => {
 		expect(options.cursorBlink).toBe(false);
 		expect(options.cursorInactiveStyle).toBe("outline");
 		expect(options.cursorStyle).toBe("block");
-		expect(options.scrollback).toBe(10_000);
+		expect(options.scrollback).toBe(1_000);
 		expect(options.macOptionIsMeta).toBe(true);
 		expect(options.windowOptions).toEqual({
 			getCellSizePixels: true,

--- a/web-ui/src/terminal/terminal-options.ts
+++ b/web-ui/src/terminal/terminal-options.ts
@@ -13,6 +13,18 @@ const TERMINAL_WORD_SEPARATOR = " ()[]{}',\"`";
 const TERMINAL_FONT_FAMILY =
 	"'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";
 
+/**
+ * Browser xterm scrollback.
+ *
+ * Must stay in sync with the server-side `TERMINAL_SCROLLBACK` in
+ * `src/terminal/terminal-state-mirror.ts`. On every task switch the browser
+ * receives a full `restore` snapshot and does `terminal.reset()` +
+ * `terminal.write(snapshot)`. A 10,000-line scrollback made this write block
+ * the main thread for ~60s during long agent runs (#581). 1,000 lines keeps
+ * recent output visible while capping the restore cost at ~10x smaller.
+ */
+const TERMINAL_SCROLLBACK = 1_000;
+
 export function createKanbanTerminalOptions({
 	cursorColor,
 	isMacPlatform,
@@ -38,7 +50,7 @@ export function createKanbanTerminalOptions({
 		rightClickSelectsWord: false,
 		scrollOnEraseInDisplay: true,
 		scrollOnUserInput: true,
-		scrollback: 10_000,
+		scrollback: TERMINAL_SCROLLBACK,
 		smoothScrollDuration: 0,
 		theme: {
 			background: terminalBackgroundColor,

--- a/web-ui/src/terminal/terminal-options.ts
+++ b/web-ui/src/terminal/terminal-options.ts
@@ -14,14 +14,12 @@ const TERMINAL_FONT_FAMILY =
 	"'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Monaco, 'Courier New', monospace";
 
 /**
- * Browser xterm scrollback.
+ * Browser display cap for the last 1,000 lines.
  *
- * Must stay in sync with the server-side `TERMINAL_SCROLLBACK` in
- * `src/terminal/terminal-state-mirror.ts`. On every task switch the browser
- * receives a full `restore` snapshot and does `terminal.reset()` +
- * `terminal.write(snapshot)`. A 10,000-line scrollback made this write block
- * the main thread for ~60s during long agent runs (#581). 1,000 lines keeps
- * recent output visible while capping the restore cost at ~10x smaller.
+ * This is the room the client needs to hold a full 1k restore snapshot.
+ * It is not a second restore-size cap, and it does not have to match the
+ * server buffer in order to shrink the payload. Restore is a cached full
+ * serialize applied in 16 KiB writes; warm reconnects can skip reset.
  */
 const TERMINAL_SCROLLBACK = 1_000;
 


### PR DESCRIPTION
> **Dependency note — please merge these first:** this branch is based on `fix/terminal-restore-perf-581` (#596) because mid-stream re-restore is only safe with restore generation tracking, and it also merges `fix/terminal-heartbeat-zombie-viewers` (#607) because this fix builds on (and explicitly retains) the heartbeat and ack-stall watchdog from that PR. Neither has landed on `main` yet. The actual change for this PR is the last commit; review best with #596 and #607 already in mind.

Fixes #610

## Failure mode

Backpressure in `ws-server.ts` pauses the shared PTY when a browser viewer falls behind, and because `pty.pause()` stops draining the PTY master fd, the kernel pipe fills and **the agent process blocks on its next stdout write**. The pause is only released when *every* backpressured viewer drains, with no ceiling on how long or how much a single viewer may hold it — so a browser tab's rendering speed sits directly on the agent process's critical path. The existing heartbeat and ack-stall watchdog only recover *after* a timeout, during which the agent stays blocked. Separately, `pendingOutputChunks` grows without bound for any viewer that connects and never sends `restore_complete`.

## Design

Each viewer gets a byte and wall-clock budget for holding the PTY paused (`OUTPUT_VIEWER_PAUSE_BUDGET_BYTES = 512 KiB`, `OUTPUT_VIEWER_PAUSE_BUDGET_MS = 2 s`), and when it exceeds either, that viewer alone is dropped from the backpressure set, its buffered output is discarded, and it is re-restored from a snapshot over its still-open socket while the PTY resumes. The pre-restore buffer is capped at `OUTPUT_VIEWER_PENDING_BUDGET_BYTES = 512 KiB`; on overflow the viewer is re-restored instead of leaking runtime memory. All three budgets are injectable via `CreateTerminalWebSocketBridgeRequest`, same as `heartbeatIntervalMs`/`ackStallTimeoutMs`.

Notes:

- **`pauseOutput`/`resumeOutput` and the ack-stall watchdog are retained, not removed.** Short-lived flow control is still the right first response to a genuine burst, and the watchdog/heartbeat remain backstops for viewers that die in ways the budget doesn't cover. This change makes the pause bounded, not obsolete.
- Forced re-restores **omit `restoreGeneration`** on purpose: clients skip restores whose generation they already applied (`shouldSkipWarmRestore`), and a re-restore replaces output the viewer never committed, so it must apply unconditionally. Omitting the optional field guarantees that through the existing client logic — no client-side change was needed (`persistent-terminal-manager.ts` verified: it applies the restore, resets `lastRestore`, and re-sends `restore_complete`). This stands in for a "new generation" because generation is owned by the session manager, which is out of scope here.
- High/low watermark values are unchanged; no files outside `src/terminal/ws-server.ts` and its tests were touched.

## Tests prove the fix

New tests in `test/runtime/terminal/ws-server.test.ts` (budgets injected small):

1. `re-restores a viewer that never acks and resumes the PTY instead of blocking` — heartbeat and ack-stall both set to 60 s so only the budget can rescue; asserts resume, a second `restore` (with no `restoreGeneration`), and the io socket still `OPEN`
2. `keeps a second viewer streaming while the first viewer overflows its budget` — healthy viewer keeps receiving output and gets no `restore`
3. `bounds pre-restore buffering for a viewer that never completes restore` — never sends `restore_complete`, gets re-restored, PTY never paused
4. `does not re-restore a slow but progressing viewer within its budget` — dribbled acks ride out the pause (regression guard; passes before the fix too, as it must)

The existing `keeps the PTY paused until every backpressured viewer drains` still passes unchanged — both viewers drain in ~40 ms, well inside the default 2 s/512 KiB budgets, so its semantics are preserved as written.

**Without the source fix** (source stashed, tests kept):

```
 ❯ test/runtime/terminal/ws-server.test.ts (16 tests | 3 failed) 7298ms
     × re-restores a viewer that never acks and resumes the PTY instead of blocking 2024ms
     × keeps a second viewer streaming while the first viewer overflows its budget 2020ms
     × bounds pre-restore buffering for a viewer that never completes restore 2007ms
 Test Files  1 failed (1)
      Tests  3 failed | 13 passed (16)
```

**With the fix:**

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

## Full gate

- `npm run check` — biome, `tsc --noEmit`, full suite: 59 files / 595 tests, all passing
- `npm run build` — full production build succeeds


---

**Follow-up commit `4c4d451` fixes a loop found in review:** a viewer that never completes restore could be re-restored indefinitely, because a forced re-restore clears `outputPaused` and the ack-stall timer — the exact state the ack-stall watchdog's guard depends on — while the heartbeat cannot see a backgrounded tab that still pongs. Consecutive forced re-restores are now capped (`OUTPUT_VIEWER_FORCED_RESTORE_LIMIT = 3`, injectable); past the limit the viewer's backpressure claim is released and its io socket is terminated, exactly as before this PR. The counter resets on `restore_complete` and on a fresh control connection, so a viewer that recovers is not penalised. New tests: the frozen-viewer test fails without the fix (viewer never terminates); the recovery-reset test passes either way and is a regression guard.
