### PR TITLE
fix(runtime-state-hub): heartbeat to drop dead WebSocket clients (#285)

### DIFF
--- a/src/server/runtime-state-hub.ts
+++ b/src/server/runtime-state-hub.ts
@@ -36,6 +36,9 @@ export interface CreateRuntimeStateHubDependencies {
 		WorkspaceRegistry,
 		"resolveWorkspaceForStream" | "buildProjectsPayload" | "buildWorkspaceStateSnapshot"
 	>;
+	// #285: optional heartbeat interval override (milliseconds). Defaults to 30s.
+	// Exposed so tests can drive the ping/pong sweep on a short real interval.
+	heartbeatIntervalMs?: number;
 }
 
 export interface RuntimeStateHub {
@@ -72,6 +75,34 @@ export function createRuntimeStateHub(deps: CreateRuntimeStateHubDependencies): 
 	const runtimeStateWorkspaceIdByClient = new Map<WebSocket, string>();
 	let clineSessionContextVersion = 0;
 	const runtimeStateWebSocketServer = new WebSocketServer({ noServer: true });
+	// #285: detect dead clients (laptop sleep, network blip, tab killed before clean
+	// unload) with a WebSocket ping/pong heartbeat, so stale sockets do not accumulate
+	// in runtimeStateClients forever. Unresponsive sockets are terminated and cleaned up.
+	const RUNTIME_STATE_HEARTBEAT_INTERVAL_MS = deps.heartbeatIntervalMs ?? 30_000;
+	const runtimeStateClientLiveness = new WeakMap<WebSocket, boolean>();
+	const runtimeStateHeartbeatTimer = setInterval(() => {
+		for (const client of runtimeStateClients) {
+			if (runtimeStateClientLiveness.get(client) === false) {
+				cleanupRuntimeStateClient(client);
+				try {
+					client.terminate();
+				} catch {
+					// Ignore termination errors for an already-dead socket.
+				}
+				continue;
+			}
+			runtimeStateClientLiveness.set(client, false);
+			try {
+				client.ping();
+			} catch {
+				// Ignore ping errors; the next sweep terminates the socket.
+			}
+		}
+	}, RUNTIME_STATE_HEARTBEAT_INTERVAL_MS);
+	// Do not keep the process alive solely for the heartbeat sweep.
+	if (typeof runtimeStateHeartbeatTimer.unref === "function") {
+		runtimeStateHeartbeatTimer.unref();
+	}
 	const workspaceMetadataMonitor = createWorkspaceMetadataMonitor({
 		onMetadataUpdated: (workspaceId, workspaceMetadata) => {
 			const clients = runtimeStateClientsByWorkspaceId.get(workspaceId);
@@ -339,6 +370,10 @@ export function createRuntimeStateHub(deps: CreateRuntimeStateHubDependencies): 
 	};
 
 	runtimeStateWebSocketServer.on("connection", async (client: WebSocket, context: unknown) => {
+		runtimeStateClientLiveness.set(client, true);
+		client.on("pong", () => {
+			runtimeStateClientLiveness.set(client, true);
+		});
 		client.on("close", () => {
 			cleanupRuntimeStateClient(client);
 		});
@@ -583,6 +618,7 @@ export function createRuntimeStateHub(deps: CreateRuntimeStateHubDependencies): 
 				}
 			}
 			clineMessageUnsubscribeByWorkspaceId.clear();
+			clearInterval(runtimeStateHeartbeatTimer);
 			workspaceMetadataMonitor.close();
 			for (const client of runtimeStateClients) {
 				try {

--- a/test/server/runtime-state-hub-heartbeat.test.ts
+++ b/test/server/runtime-state-hub-heartbeat.test.ts
@@ -30,7 +30,7 @@ describe("runtime-state hub heartbeat (#285)", () => {
 		});
 		server = createServer();
 		server.on("upgrade", (req, socket, head) => {
-			hub.handleUpgrade(req, socket, head, undefined);
+			hub.handleUpgrade(req, socket, head, { requestedWorkspaceId: null });
 		});
 		await new Promise<void>((resolve) => server.listen(0, resolve));
 		port = (server.address() as AddressInfo).port;

--- a/test/server/runtime-state-hub-heartbeat.test.ts
+++ b/test/server/runtime-state-hub-heartbeat.test.ts
@@ -1,0 +1,83 @@
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+
+import { createRuntimeStateHub } from "../../src/server/runtime-state-hub";
+
+// #285 regression: the hub pings clients and terminates ones that never pong,
+// so dead sockets do not accumulate. We spy on the server-side socket's
+// terminate() to assert the sweep acts on a silent peer deterministically.
+
+function stubWorkspaceRegistry() {
+	return {
+		resolveWorkspaceForStream: () => ({ workspaceId: null, workspacePath: null }),
+		buildProjectsPayload: async () => ({ currentProjectId: null, projects: [] }),
+		buildWorkspaceStateSnapshot: async () => null,
+	} as any;
+}
+
+describe("runtime-state hub heartbeat (#285)", () => {
+	let server: Server;
+	let hub: ReturnType<typeof createRuntimeStateHub>;
+	let port: number;
+
+	beforeEach(async () => {
+		hub = createRuntimeStateHub({
+			workspaceRegistry: stubWorkspaceRegistry(),
+			heartbeatIntervalMs: 50,
+		});
+		server = createServer();
+		server.on("upgrade", (req, socket, head) => {
+			hub.handleUpgrade(req, socket, head, undefined);
+		});
+		await new Promise<void>((resolve) => server.listen(0, resolve));
+		port = (server.address() as AddressInfo).port;
+	});
+
+	afterEach(async () => {
+		await hub.close();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	});
+
+	it("terminates a client that never answers a ping", async () => {
+		const socket = new WebSocket("ws://127.0.0.1:" + port);
+		// Suppress the automatic pong at the protocol level: replace the receiver's
+		// ping handling so this peer never answers, emulating a silently dead client.
+		socket.on("open", () => {
+			const anySocket = socket as any;
+			if (anySocket._receiver) {
+				anySocket._receiver.on = anySocket._receiver.on || (() => {});
+			}
+			// Overwrite the frame that would auto-pong: monkeypatch pong() to a noop.
+			anySocket.pong = () => {};
+		});
+		await new Promise<void>((resolve, reject) => {
+			socket.on("open", () => resolve());
+			socket.on("error", reject);
+		});
+		const closed = new Promise<boolean>((resolve) => {
+			socket.on("close", () => resolve(true));
+			setTimeout(() => resolve(false), 3_000);
+		});
+		const wasClosed = await closed;
+		expect(wasClosed).toBe(true);
+	});
+
+	it("keeps a client that answers pings alive", async () => {
+		const socket = new WebSocket("ws://127.0.0.1:" + port);
+		await new Promise<void>((resolve, reject) => {
+			socket.on("open", () => resolve());
+			socket.on("error", reject);
+		});
+		let closedEarly = false;
+		socket.on("close", () => {
+			closedEarly = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 400));
+		expect(closedEarly).toBe(false);
+		expect(socket.readyState).toBe(WebSocket.OPEN);
+		socket.close();
+	});
+});


### PR DESCRIPTION
## Problem

Fixes #285. The runtime-state WebSocket hub (`src/server/runtime-state-hub.ts`) never pings its clients. When a client's TCP connection dies silently (laptop sleep, network blip, a browser tab killed before a clean unload), the server never notices: the stale socket stays in `runtimeStateClients` forever and keeps receiving writes.

This is distinct from the terminal-PTY backpressure work in #607/#610/#611 (`src/terminal/ws-server.ts`); this PR only touches the runtime-state hub.

## Fix

Add a ping/pong heartbeat sweep in `createRuntimeStateHub`:

- On each connection, mark the socket alive and refresh liveness on every `pong`.
- Every interval (default **30s**), terminate and clean up sockets that did not answer the previous ping, then ping the rest.
- The interval is configurable via an optional `heartbeatIntervalMs` dep (used by the test), and the timer is `unref()`-ed so it never keeps the process alive on its own.
- `clearInterval` on hub `close()`.

## Tests

Adds `test/server/runtime-state-hub-heartbeat.test.ts` with two cases against a real ephemeral server:

- a client that never answers the ping is terminated;
- a client that answers pings stays connected.

Verified red→green: without the fix the dead-client case fails; with it both pass. No regressions in `test:fast`. `tsc --noEmit` clean.

## Scope

Bug fix / stability only. No protocol or message-shape changes; standard WebSocket control frames.
