### PR TITLE
fix(auto-review): persist pending git action so review cards can't strand

### DIFF
--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -129,6 +129,14 @@ function normalizeRuntimeTaskClineSettings(input: {
 	};
 }
 
+export const runtimeTaskPendingGitActionSchema = z.object({
+	action: runtimeTaskAutoReviewModeSchema,
+	requestedAt: z.number(),
+	headCommitAtRequest: z.string().nullable(),
+	attempt: z.number().int().nonnegative().default(0),
+});
+export type RuntimeTaskPendingGitAction = z.infer<typeof runtimeTaskPendingGitActionSchema>;
+
 export const runtimeBoardCardSchema = z
 	.object({
 		id: z.string(),
@@ -146,6 +154,7 @@ export const runtimeBoardCardSchema = z
 		baseRef: z.string(),
 		createdAt: z.number(),
 		updatedAt: z.number(),
+		pendingGitAction: runtimeTaskPendingGitActionSchema.nullable().optional(),
 	})
 	.transform(
 		({

--- a/src/core/task-board-mutations.ts
+++ b/src/core/task-board-mutations.ts
@@ -7,9 +7,22 @@ import type {
 	RuntimeTaskAutoReviewMode,
 	RuntimeTaskClineSettings,
 	RuntimeTaskImage,
+	RuntimeTaskPendingGitAction,
 } from "./api-contract";
 import { createUniqueTaskId } from "./task-id";
 import { resolveTaskTitle } from "./task-title";
+
+/**
+ * How long a persisted pending git action stays armed before it is treated as
+ * stale. The agent commit/PR choreography takes minutes, so give it generous
+ * headroom. Shared by every actor that reads the arming state: the runtime
+ * auto-review reconciler and the browser.
+ */
+export const PENDING_GIT_ACTION_STALE_AFTER_MS = 15 * 60_000;
+
+export function isPendingGitActionStale(pending: RuntimeTaskPendingGitAction, now: number = Date.now()): boolean {
+	return now - pending.requestedAt > PENDING_GIT_ACTION_STALE_AFTER_MS;
+}
 
 export interface RuntimeCreateTaskInput {
 	taskId?: string;

--- a/test/runtime/api-validation.test.ts
+++ b/test/runtime/api-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-
+import { runtimeBoardCardSchema } from "../../src/core/api-contract";
 import {
 	parseHookIngestRequest,
 	parseTaskSessionStartRequest,
@@ -87,5 +87,58 @@ describe("parseTaskSessionStartRequest", () => {
 			baseRef: "main",
 			resumeFromTrash: true,
 		});
+	});
+});
+
+describe("runtimeBoardCardSchema pendingGitAction", () => {
+	const legacyCard = {
+		id: "task-1",
+		prompt: "Do the thing",
+		startInPlanMode: false,
+		baseRef: "main",
+		createdAt: 1,
+		updatedAt: 2,
+	};
+
+	it("parses legacy cards without pendingGitAction unchanged", () => {
+		const parsed = runtimeBoardCardSchema.parse(legacyCard);
+		expect(parsed.pendingGitAction).toBeUndefined();
+		expect(parsed.id).toBe("task-1");
+		expect(parsed.prompt).toBe("Do the thing");
+	});
+
+	it("parses null pendingGitAction", () => {
+		const parsed = runtimeBoardCardSchema.parse({ ...legacyCard, pendingGitAction: null });
+		expect(parsed.pendingGitAction).toBeNull();
+	});
+
+	it("parses a persisted pendingGitAction and defaults attempt to 0", () => {
+		const parsed = runtimeBoardCardSchema.parse({
+			...legacyCard,
+			pendingGitAction: {
+				action: "commit",
+				requestedAt: 123,
+				headCommitAtRequest: "abc123",
+			},
+		});
+		expect(parsed.pendingGitAction).toEqual({
+			action: "commit",
+			requestedAt: 123,
+			headCommitAtRequest: "abc123",
+			attempt: 0,
+		});
+	});
+
+	it("rejects an unknown pendingGitAction action", () => {
+		expect(() =>
+			runtimeBoardCardSchema.parse({
+				...legacyCard,
+				pendingGitAction: {
+					action: "push",
+					requestedAt: 123,
+					headCommitAtRequest: null,
+				},
+			}),
+		).toThrow();
 	});
 });

--- a/web-ui/src/hooks/use-board-interactions.ts
+++ b/web-ui/src/hooks/use-board-interactions.ts
@@ -9,6 +9,7 @@ import { useProgrammaticCardMoves } from "@/hooks/use-programmatic-card-moves";
 import { useReviewAutoActions } from "@/hooks/use-review-auto-actions";
 import type { UseTaskSessionsResult } from "@/hooks/use-task-sessions";
 import type { RuntimeTaskSessionSummary, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
+import { patchCardPendingGitAction } from "@/runtime/workspace-state-query";
 import {
 	applyDragResult,
 	clearColumnTasks,
@@ -531,12 +532,19 @@ export function useBoardInteractions({
 		setRequestMoveTaskToTrashHandler(requestMoveTaskToTrash);
 	}, [requestMoveTaskToTrash, setRequestMoveTaskToTrashHandler]);
 
+	const persistPendingGitAction = useCallback(
+		async (taskId: string, value: Parameters<typeof patchCardPendingGitAction>[2]) =>
+			await patchCardPendingGitAction(currentProjectId, taskId, value),
+		[currentProjectId],
+	);
+
 	useReviewAutoActions({
 		board,
 		taskGitActionLoadingByTaskId,
 		runAutoReviewGitAction,
 		requestMoveTaskToTrash: requestMoveTaskToTrashWithAnimation,
 		resetKey: currentProjectId,
+		persistPendingGitAction,
 	});
 
 	const resumeTaskFromTrash = useCallback(

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -18,6 +18,7 @@ import {
 } from "@/stores/workspace-metadata-store";
 import type { SendTerminalInputOptions } from "@/terminal/terminal-input";
 import type { BoardCard, BoardData, CardSelection } from "@/types";
+import { isPendingGitActionStale } from "@/types";
 
 type TaskGitActionSource = "card" | "agent";
 
@@ -219,10 +220,21 @@ export function useGitActions({
 	);
 
 	const runTaskGitAction = useCallback(
-		async (taskId: string, action: TaskGitAction, source: TaskGitActionSource) => {
+		async (
+			taskId: string,
+			action: TaskGitAction,
+			source: TaskGitActionSource,
+			options: { skipPendingGitActionLock?: boolean } = {},
+		) => {
 			const taskLoadingState = taskGitActionLoadingByTaskId[taskId];
 			const actionInFlightSource = action === "commit" ? taskLoadingState?.commitSource : taskLoadingState?.prSource;
 			if (actionInFlightSource !== null && actionInFlightSource !== undefined) {
+				return false;
+			}
+			// Cross-tab lock: refuse a second git action while another one is armed on the
+			// card. The arming state is server-side, so every tab sees it.
+			const pendingGitAction = findCardSelection(board, taskId)?.card.pendingGitAction ?? null;
+			if (!options.skipPendingGitActionLock && pendingGitAction && !isPendingGitActionStale(pendingGitAction)) {
 				return false;
 			}
 			setTaskGitActionLoading(taskId, action, source);
@@ -500,7 +512,9 @@ export function useGitActions({
 
 	const runAutoReviewGitAction = useCallback(
 		async (taskId: string, action: TaskGitAction) => {
-			return await runTaskGitAction(taskId, action, "card");
+			// The auto-review loop persists the arming state itself before calling this,
+			// so it must bypass the pending-git-action lock it just set.
+			return await runTaskGitAction(taskId, action, "card", { skipPendingGitActionLock: true });
 		},
 		[runTaskGitAction],
 	);

--- a/web-ui/src/hooks/use-review-auto-actions.test.tsx
+++ b/web-ui/src/hooks/use-review-auto-actions.test.tsx
@@ -2,11 +2,18 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
+import type { PersistPendingGitAction } from "@/hooks/use-review-auto-actions";
 import { useReviewAutoActions } from "@/hooks/use-review-auto-actions";
+import { normalizeBoardData } from "@/state/board-state";
 import { resetWorkspaceMetadataStore, setTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
-import type { BoardColumnId, BoardData, ReviewTaskWorkspaceSnapshot } from "@/types";
+import type { BoardColumnId, BoardData, ReviewTaskWorkspaceSnapshot, TaskPendingGitAction } from "@/types";
+import { PENDING_GIT_ACTION_STALE_AFTER_MS } from "@/types";
 
-function createBoard(autoReviewEnabled: boolean): BoardData {
+function createBoard(options?: {
+	autoReviewEnabled?: boolean;
+	pendingGitAction?: TaskPendingGitAction | null;
+}): BoardData {
+	const autoReviewEnabled = options?.autoReviewEnabled ?? true;
 	return {
 		columns: [
 			{ id: "backlog", title: "Backlog", cards: [] },
@@ -25,6 +32,7 @@ function createBoard(autoReviewEnabled: boolean): BoardData {
 						baseRef: "main",
 						createdAt: 1,
 						updatedAt: 1,
+						...(options?.pendingGitAction !== undefined ? { pendingGitAction: options.pendingGitAction } : {}),
 					},
 				],
 			},
@@ -34,8 +42,8 @@ function createBoard(autoReviewEnabled: boolean): BoardData {
 	};
 }
 
-const workspaceSnapshots: Record<string, ReviewTaskWorkspaceSnapshot> = {
-	"task-1": {
+function createSnapshot(overrides?: Partial<ReviewTaskWorkspaceSnapshot>): ReviewTaskWorkspaceSnapshot {
+	return {
 		taskId: "task-1",
 		path: "/tmp/task-1",
 		branch: "task-1",
@@ -44,17 +52,24 @@ const workspaceSnapshots: Record<string, ReviewTaskWorkspaceSnapshot> = {
 		changedFiles: 3,
 		additions: 10,
 		deletions: 2,
-	},
+		...overrides,
+	};
+}
+
+const workspaceSnapshots: Record<string, ReviewTaskWorkspaceSnapshot> = {
+	"task-1": createSnapshot(),
 };
 
 function HookHarness({
 	board,
 	runAutoReviewGitAction,
 	requestMoveTaskToTrash,
+	persistPendingGitAction,
 }: {
 	board: BoardData;
 	runAutoReviewGitAction: (taskId: string, action: TaskGitAction) => Promise<boolean>;
 	requestMoveTaskToTrash: (taskId: string, fromColumnId: BoardColumnId) => Promise<void>;
+	persistPendingGitAction?: PersistPendingGitAction;
 }): null {
 	setTaskWorkspaceSnapshot(workspaceSnapshots["task-1"] ?? null);
 	useReviewAutoActions({
@@ -62,6 +77,7 @@ function HookHarness({
 		taskGitActionLoadingByTaskId: {},
 		runAutoReviewGitAction,
 		requestMoveTaskToTrash,
+		persistPendingGitAction,
 	});
 	return null;
 }
@@ -79,6 +95,7 @@ describe("useReviewAutoActions", () => {
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = createRoot(container);
+		workspaceSnapshots["task-1"] = createSnapshot();
 	});
 
 	afterEach(() => {
@@ -103,7 +120,7 @@ describe("useReviewAutoActions", () => {
 		await act(async () => {
 			root.render(
 				<HookHarness
-					board={createBoard(true)}
+					board={createBoard({ autoReviewEnabled: true })}
 					runAutoReviewGitAction={runAutoReviewGitAction}
 					requestMoveTaskToTrash={requestMoveTaskToTrash}
 				/>,
@@ -113,7 +130,7 @@ describe("useReviewAutoActions", () => {
 		await act(async () => {
 			root.render(
 				<HookHarness
-					board={createBoard(false)}
+					board={createBoard({ autoReviewEnabled: false })}
 					runAutoReviewGitAction={runAutoReviewGitAction}
 					requestMoveTaskToTrash={requestMoveTaskToTrash}
 				/>,
@@ -126,5 +143,218 @@ describe("useReviewAutoActions", () => {
 
 		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
 		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+	});
+
+	it("persists the pending git action when arming and advances the card after remount once HEAD moves (issue #365)", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+		const persistPendingGitAction = vi.fn<PersistPendingGitAction>(async () => true);
+
+		// Arm: working changes present in review.
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard()}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+					persistPendingGitAction={persistPendingGitAction}
+				/>,
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(persistPendingGitAction).toHaveBeenCalledTimes(1);
+		const armedValue = persistPendingGitAction.mock.calls[0]?.[1];
+		expect(armedValue).toMatchObject({
+			action: "commit",
+			headCommitAtRequest: "abc123",
+			attempt: 0,
+		});
+		expect(runAutoReviewGitAction).toHaveBeenCalledWith("task-1", "commit");
+		if (!armedValue) {
+			throw new Error("expected the hook to persist an arming value");
+		}
+
+		// Simulate the server echo landing on the board, then drop all in-memory hook
+		// state by remounting (reload / project switch).
+		act(() => {
+			root.unmount();
+		});
+		root = createRoot(container);
+		workspaceSnapshots["task-1"] = createSnapshot({ changedFiles: 0, headCommit: "def456" });
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard({ pendingGitAction: armedValue })}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+					persistPendingGitAction={persistPendingGitAction}
+				/>,
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		// HEAD moved past the commit recorded at arming time: evidence the commit landed.
+		expect(requestMoveTaskToTrash).toHaveBeenCalledTimes(1);
+		expect(requestMoveTaskToTrash).toHaveBeenCalledWith(
+			"task-1",
+			"review",
+			expect.objectContaining({ skipWorkingChangeWarning: true }),
+		);
+		expect(persistPendingGitAction).toHaveBeenLastCalledWith("task-1", null);
+		expect(runAutoReviewGitAction).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not advance an armed card when the tree is clean but HEAD is unchanged", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+		const persistPendingGitAction = vi.fn<PersistPendingGitAction>(async () => true);
+		const pendingGitAction: TaskPendingGitAction = {
+			action: "commit",
+			requestedAt: Date.now(),
+			headCommitAtRequest: "abc123",
+			attempt: 0,
+		};
+		workspaceSnapshots["task-1"] = createSnapshot({ changedFiles: 0, headCommit: "abc123" });
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard({ pendingGitAction })}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+					persistPendingGitAction={persistPendingGitAction}
+				/>,
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
+		expect(persistPendingGitAction).not.toHaveBeenCalledWith("task-1", null);
+	});
+
+	it("refuses to start a second git action while a recent pending action is armed", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+		const persistPendingGitAction = vi.fn<PersistPendingGitAction>(async () => true);
+		const pendingGitAction: TaskPendingGitAction = {
+			action: "commit",
+			requestedAt: Date.now(),
+			headCommitAtRequest: "abc123",
+			attempt: 0,
+		};
+		// Working changes are present, which would normally trigger a git action.
+		workspaceSnapshots["task-1"] = createSnapshot({ changedFiles: 5 });
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard({ pendingGitAction })}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+					persistPendingGitAction={persistPendingGitAction}
+				/>,
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
+		expect(persistPendingGitAction).not.toHaveBeenCalled();
+		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+	});
+
+	it("clears a stale pending git action instead of leaving the card armed forever", async () => {
+		const runAutoReviewGitAction = vi.fn(async () => true);
+		const requestMoveTaskToTrash = vi.fn(async () => {});
+		const persistPendingGitAction = vi.fn<PersistPendingGitAction>(async () => true);
+		const pendingGitAction: TaskPendingGitAction = {
+			action: "commit",
+			requestedAt: Date.now() - PENDING_GIT_ACTION_STALE_AFTER_MS - 1000,
+			headCommitAtRequest: "abc123",
+			attempt: 2,
+		};
+		workspaceSnapshots["task-1"] = createSnapshot({ changedFiles: 5 });
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard({ pendingGitAction })}
+					runAutoReviewGitAction={runAutoReviewGitAction}
+					requestMoveTaskToTrash={requestMoveTaskToTrash}
+					persistPendingGitAction={persistPendingGitAction}
+				/>,
+			);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(persistPendingGitAction).toHaveBeenCalledWith("task-1", null);
+		expect(requestMoveTaskToTrash).not.toHaveBeenCalled();
+		expect(runAutoReviewGitAction).not.toHaveBeenCalled();
+	});
+
+	it("parses legacy boards without pendingGitAction and keeps valid pendingGitAction values", () => {
+		const legacyBoard = {
+			columns: [
+				{
+					id: "review",
+					title: "Review",
+					cards: [
+						{
+							id: "task-legacy",
+							title: "Legacy task",
+							prompt: "Legacy task",
+							startInPlanMode: false,
+							autoReviewEnabled: true,
+							autoReviewMode: "commit",
+							baseRef: "main",
+							createdAt: 1,
+							updatedAt: 1,
+						},
+						{
+							id: "task-armed",
+							title: "Armed task",
+							prompt: "Armed task",
+							startInPlanMode: false,
+							autoReviewEnabled: true,
+							autoReviewMode: "commit",
+							baseRef: "main",
+							createdAt: 1,
+							updatedAt: 1,
+							pendingGitAction: {
+								action: "commit",
+								requestedAt: 123,
+								headCommitAtRequest: null,
+								attempt: 1,
+							},
+						},
+					],
+				},
+			],
+			dependencies: [],
+		};
+
+		const normalized = normalizeBoardData(legacyBoard);
+		expect(normalized).not.toBeNull();
+		const reviewColumn = normalized?.columns.find((column) => column.id === "review");
+		expect(reviewColumn?.cards).toHaveLength(2);
+		expect(reviewColumn?.cards[0]?.pendingGitAction).toBeUndefined();
+		expect(reviewColumn?.cards[1]?.pendingGitAction).toEqual({
+			action: "commit",
+			requestedAt: 123,
+			headCommitAtRequest: null,
+			attempt: 1,
+		});
 	});
 });

--- a/web-ui/src/hooks/use-review-auto-actions.ts
+++ b/web-ui/src/hooks/use-review-auto-actions.ts
@@ -1,16 +1,26 @@
 import { useCallback, useEffect, useRef } from "react";
 
+import { showAppToast } from "@/components/app-toaster";
 import type { TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
 import { findCardSelection } from "@/state/board-state";
 import { getTaskWorkspaceSnapshot, subscribeToAnyTaskMetadata } from "@/stores/workspace-metadata-store";
-import type { BoardCard, BoardColumnId, BoardData, TaskAutoReviewMode } from "@/types";
-import { resolveTaskAutoReviewMode } from "@/types";
+import type { BoardCard, BoardColumnId, BoardData, TaskAutoReviewMode, TaskPendingGitAction } from "@/types";
+import { isPendingGitActionStale, resolveTaskAutoReviewMode } from "@/types";
 
 const AUTO_REVIEW_ACTION_DELAY_MS = 500;
 
 function isTaskAutoReviewEnabled(task: BoardCard): boolean {
 	return task.autoReviewEnabled === true;
 }
+
+/**
+ * Persists (or clears) the durable `pendingGitAction` arming state on a card.
+ * Returns `true` when the requested state was applied, and `false` when the write was
+ * refused (for example because another tab already armed the same card).
+ */
+export type PersistPendingGitAction = (taskId: string, value: TaskPendingGitAction | null) => Promise<boolean>;
+
+const noopPersistPendingGitAction: PersistPendingGitAction = async () => true;
 
 interface TaskGitActionLoadingStateLike {
 	commitSource: string | null;
@@ -31,6 +41,7 @@ interface UseReviewAutoActionsOptions {
 		options?: RequestMoveTaskToTrashOptions,
 	) => Promise<void>;
 	resetKey?: string | null;
+	persistPendingGitAction?: PersistPendingGitAction;
 }
 
 export function useReviewAutoActions({
@@ -39,11 +50,18 @@ export function useReviewAutoActions({
 	runAutoReviewGitAction,
 	requestMoveTaskToTrash,
 	resetKey,
+	persistPendingGitAction,
 }: UseReviewAutoActionsOptions): void {
 	const boardRef = useRef<BoardData>(board);
 	const runAutoReviewGitActionRef = useRef(runAutoReviewGitAction);
 	const requestMoveTaskToTrashRef = useRef(requestMoveTaskToTrash);
-	const awaitingCleanActionByTaskIdRef = useRef<Record<string, TaskGitAction>>({});
+	const persistPendingGitActionRef = useRef<PersistPendingGitAction>(
+		persistPendingGitAction ?? noopPersistPendingGitAction,
+	);
+	// In-memory mirror of the durable arming state. Bridges the window between arming a
+	// card and the persisted `pendingGitAction` arriving back on the board. The card
+	// field (server-side) is the source of truth; this ref alone must never be.
+	const localPendingGitActionByTaskIdRef = useRef<Record<string, TaskPendingGitAction>>({});
 	const timerByTaskIdRef = useRef<Record<string, number>>({});
 	type ScheduledAutoReviewAction = TaskAutoReviewMode | "move_to_done_after_git_action";
 	const scheduledActionByTaskIdRef = useRef<Record<string, ScheduledAutoReviewAction>>({});
@@ -61,6 +79,16 @@ export function useReviewAutoActions({
 		requestMoveTaskToTrashRef.current = requestMoveTaskToTrash;
 	}, [requestMoveTaskToTrash]);
 
+	useEffect(() => {
+		persistPendingGitActionRef.current = persistPendingGitAction ?? noopPersistPendingGitAction;
+	}, [persistPendingGitAction]);
+
+	const clearPendingGitAction = useCallback((taskId: string) => {
+		void persistPendingGitActionRef.current(taskId, null).catch(() => {
+			// Clearing is best-effort; the staleness timeout bounds a stranded entry.
+		});
+	}, []);
+
 	const clearAutoReviewTimer = useCallback((taskId: string) => {
 		const timer = timerByTaskIdRef.current[taskId];
 		if (typeof timer === "number") {
@@ -74,7 +102,9 @@ export function useReviewAutoActions({
 		for (const timer of Object.values(timerByTaskIdRef.current)) {
 			window.clearTimeout(timer);
 		}
-		awaitingCleanActionByTaskIdRef.current = {};
+		// Only the ephemeral mirror is cleared here: the durable arming state lives on
+		// the card (`pendingGitAction`) and must survive unmounts and project switches.
+		localPendingGitActionByTaskIdRef.current = {};
 		timerByTaskIdRef.current = {};
 		scheduledActionByTaskIdRef.current = {};
 		moveToTrashInFlightTaskIdsRef.current.clear();
@@ -119,14 +149,17 @@ export function useReviewAutoActions({
 					columnByTaskId.set(card.id, column.id);
 					if (column.id === "review") {
 						reviewCardsForAutomation.push(card);
+					} else if (card.pendingGitAction) {
+						// A card that left review while armed must not stay armed forever.
+						clearPendingGitAction(card.id);
 					}
 				}
 			}
 
-			for (const taskId of Object.keys(awaitingCleanActionByTaskIdRef.current)) {
+			for (const taskId of Object.keys(localPendingGitActionByTaskIdRef.current)) {
 				const columnId = columnByTaskId.get(taskId);
 				if (!columnId || columnId === "trash") {
-					delete awaitingCleanActionByTaskIdRef.current[taskId];
+					delete localPendingGitActionByTaskIdRef.current[taskId];
 					clearAutoReviewTimer(taskId);
 					moveToTrashInFlightTaskIdsRef.current.delete(taskId);
 				}
@@ -146,10 +179,22 @@ export function useReviewAutoActions({
 			}
 
 			for (const reviewTask of reviewCardsForAutomation) {
+				const cardPendingGitAction = reviewTask.pendingGitAction ?? null;
+				// Once the persisted arming state arrives back on the card, the local
+				// mirror is redundant.
+				if (cardPendingGitAction && localPendingGitActionByTaskIdRef.current[reviewTask.id]) {
+					delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
+				}
+				const pendingGitAction =
+					cardPendingGitAction ?? localPendingGitActionByTaskIdRef.current[reviewTask.id] ?? null;
+
 				const autoReviewEnabled = isTaskAutoReviewEnabled(reviewTask);
 				if (!autoReviewEnabled) {
-					delete awaitingCleanActionByTaskIdRef.current[reviewTask.id];
+					delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
 					clearAutoReviewTimer(reviewTask.id);
+					if (cardPendingGitAction) {
+						clearPendingGitAction(reviewTask.id);
+					}
 					continue;
 				}
 
@@ -164,13 +209,34 @@ export function useReviewAutoActions({
 
 				// Commit/PR automation mental model:
 				// - A task is only "armed" for auto-done after we actually see working changes in review and trigger commit/pr.
+				// - The arming state is persisted on the card (`pendingGitAction`) so it survives reloads,
+				//   unmounts, and project switches, and acts as a cross-tab lock.
 				// - Review entries with zero changes (common during start-in-plan-mode planning loops) are intentionally ignored.
-				// - Once armed, a later review state with zero changes is treated as commit/pr success, then we auto-move to done.
+				// - Once armed, completion is judged on evidence: the workspace HEAD moved past the commit
+				//   recorded at arming time. Zero changed files with an unchanged HEAD means the tree was
+				//   cleaned some other way and must NOT advance the card.
 				const changedFiles = getTaskWorkspaceSnapshot(reviewTask.id)?.changedFiles;
-				const awaitingAction = awaitingCleanActionByTaskIdRef.current[reviewTask.id] ?? null;
-				if (awaitingAction) {
+				if (pendingGitAction) {
+					if (isPendingGitActionStale(pendingGitAction)) {
+						delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
+						clearAutoReviewTimer(reviewTask.id);
+						clearPendingGitAction(reviewTask.id);
+						showAppToast(
+							{
+								intent: "warning",
+								icon: "warning-sign",
+								message: `Auto-review ${pendingGitAction.action} for "${reviewTask.title}" timed out before completing. The card stays in Review.`,
+								timeout: 7000,
+							},
+							`auto-review-pending-git-action-timeout-${reviewTask.id}`,
+						);
+						continue;
+					}
+
+					const headCommit = getTaskWorkspaceSnapshot(reviewTask.id)?.headCommit ?? null;
+					const headCommitMoved = headCommit !== null && headCommit !== pendingGitAction.headCommitAtRequest;
 					if (
-						changedFiles === 0 &&
+						headCommitMoved &&
 						!isGitActionInFlight &&
 						!moveToTrashInFlightTaskIdsRef.current.has(reviewTask.id)
 					) {
@@ -182,8 +248,15 @@ export function useReviewAutoActions({
 							if (!isTaskAutoReviewEnabled(latestSelection.card)) {
 								return;
 							}
+							const latestPendingGitAction =
+								latestSelection.card.pendingGitAction ??
+								localPendingGitActionByTaskIdRef.current[reviewTask.id] ??
+								null;
+							if (!latestPendingGitAction) {
+								return;
+							}
 							const latestMode = resolveTaskAutoReviewMode(latestSelection.card.autoReviewMode);
-							if (latestMode !== autoReviewMode) {
+							if (latestMode !== latestPendingGitAction.action) {
 								return;
 							}
 							moveToTrashInFlightTaskIdsRef.current.add(reviewTask.id);
@@ -192,8 +265,9 @@ export function useReviewAutoActions({
 									skipWorkingChangeWarning: true,
 								})
 								.finally(() => {
-									delete awaitingCleanActionByTaskIdRef.current[reviewTask.id];
+									delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
 									moveToTrashInFlightTaskIdsRef.current.delete(reviewTask.id);
+									clearPendingGitAction(reviewTask.id);
 								});
 						});
 					} else {
@@ -219,16 +293,46 @@ export function useReviewAutoActions({
 					if (latestMode !== autoReviewMode) {
 						return;
 					}
-					awaitingCleanActionByTaskIdRef.current[reviewTask.id] = latestMode;
-					void runAutoReviewGitActionRef.current(reviewTask.id, latestMode).then((triggered) => {
-						if (!triggered && awaitingCleanActionByTaskIdRef.current[reviewTask.id] === latestMode) {
-							delete awaitingCleanActionByTaskIdRef.current[reviewTask.id];
+					if (latestSelection.card.pendingGitAction ?? localPendingGitActionByTaskIdRef.current[reviewTask.id]) {
+						// Already armed here or in another tab.
+						return;
+					}
+					const pendingValue: TaskPendingGitAction = {
+						action: latestMode,
+						requestedAt: Date.now(),
+						headCommitAtRequest: getTaskWorkspaceSnapshot(reviewTask.id)?.headCommit ?? null,
+						attempt: 0,
+					};
+					void (async () => {
+						let armed = true;
+						try {
+							armed = await persistPendingGitActionRef.current(reviewTask.id, pendingValue);
+						} catch {
+							// Persistence unavailable: degrade to the legacy in-tab arming behavior.
+							armed = true;
 						}
-					});
+						if (!armed) {
+							// Another tab or earlier request already armed this card.
+							return;
+						}
+						localPendingGitActionByTaskIdRef.current[reviewTask.id] = pendingValue;
+						try {
+							const triggered = await runAutoReviewGitActionRef.current(reviewTask.id, latestMode);
+							if (!triggered && localPendingGitActionByTaskIdRef.current[reviewTask.id] === pendingValue) {
+								delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
+								clearPendingGitAction(reviewTask.id);
+							}
+						} catch {
+							if (localPendingGitActionByTaskIdRef.current[reviewTask.id] === pendingValue) {
+								delete localPendingGitActionByTaskIdRef.current[reviewTask.id];
+								clearPendingGitAction(reviewTask.id);
+							}
+						}
+					})();
 				});
 			}
 		},
-		[clearAutoReviewTimer, scheduleAutoReviewAction, taskGitActionLoadingByTaskId],
+		[clearAutoReviewTimer, clearPendingGitAction, scheduleAutoReviewAction, taskGitActionLoadingByTaskId],
 	);
 
 	useEffect(() => {

--- a/web-ui/src/runtime/workspace-state-query.ts
+++ b/web-ui/src/runtime/workspace-state-query.ts
@@ -1,6 +1,12 @@
 import { TRPCClientError } from "@trpc/client";
 import { createWorkspaceTrpcClient, readTrpcConflictRevision } from "@/runtime/trpc-client";
-import type { RuntimeWorkspaceStateResponse, RuntimeWorkspaceStateSaveRequest } from "@/runtime/types";
+import type {
+	RuntimeBoardCard,
+	RuntimeBoardData,
+	RuntimeWorkspaceStateResponse,
+	RuntimeWorkspaceStateSaveRequest,
+} from "@/runtime/types";
+import { isPendingGitActionStale, type TaskPendingGitAction } from "@/types";
 
 export class WorkspaceStateConflictError extends Error {
 	readonly currentRevision: number;
@@ -33,4 +39,92 @@ export async function saveWorkspaceState(
 		}
 		throw error;
 	}
+}
+
+/**
+ * Persists (or clears) `pendingGitAction` on a single board card via a server-side
+ * read-modify-write of the workspace state. The server revision check makes this safe
+ * across browser tabs: two tabs arming the same card cannot both succeed, so the
+ * persisted field doubles as a cross-tab lock.
+ *
+ * Returns `true` when the server state ends up matching `value`, and `false` when the
+ * write was refused (another recent pending action already holds the lock, the card is
+ * gone, or revision conflicts could not be resolved).
+ */
+export async function patchCardPendingGitAction(
+	workspaceId: string | null,
+	taskId: string,
+	value: TaskPendingGitAction | null,
+): Promise<boolean> {
+	if (!workspaceId) {
+		return false;
+	}
+	const maxAttempts = 3;
+	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+		const state = await fetchWorkspaceState(workspaceId);
+		const card = findCardInBoard(state.board, taskId);
+		if (!card) {
+			return false;
+		}
+		const existing = card.pendingGitAction ?? null;
+		let nextValue = value;
+		if (value === null) {
+			if (existing === null) {
+				return true;
+			}
+		} else {
+			if (existing !== null && !isPendingGitActionStale(existing)) {
+				// Another tab (or an earlier request in this tab) already armed this card.
+				return false;
+			}
+			if (existing !== null) {
+				nextValue = { ...value, attempt: existing.attempt + 1 };
+			}
+		}
+		const board = patchBoardCardPendingGitAction(state.board, taskId, nextValue ?? null);
+		try {
+			await saveWorkspaceState(workspaceId, {
+				board,
+				sessions: state.sessions,
+				expectedRevision: state.revision,
+			});
+			return true;
+		} catch (error) {
+			if (error instanceof WorkspaceStateConflictError) {
+				continue;
+			}
+			throw error;
+		}
+	}
+	return false;
+}
+
+function findCardInBoard(board: RuntimeBoardData, taskId: string): RuntimeBoardCard | null {
+	for (const column of board.columns) {
+		for (const card of column.cards) {
+			if (card.id === taskId) {
+				return card;
+			}
+		}
+	}
+	return null;
+}
+
+function patchBoardCardPendingGitAction(
+	board: RuntimeBoardData,
+	taskId: string,
+	value: TaskPendingGitAction | null,
+): RuntimeBoardData {
+	return {
+		...board,
+		columns: board.columns.map((column) => {
+			if (!column.cards.some((card) => card.id === taskId)) {
+				return column;
+			}
+			return {
+				...column,
+				cards: column.cards.map((card) => (card.id === taskId ? { ...card, pendingGitAction: value } : card)),
+			};
+		}),
+	};
 }

--- a/web-ui/src/state/board-state.ts
+++ b/web-ui/src/state/board-state.ts
@@ -16,6 +16,7 @@ import {
 	resolveTaskAutoReviewMode,
 	type TaskAutoReviewMode,
 	type TaskImage,
+	type TaskPendingGitAction,
 } from "@/types";
 
 export interface TaskDraft {
@@ -143,6 +144,37 @@ function normalizeTaskClineSettings(input: {
 	};
 }
 
+function normalizeTaskPendingGitAction(rawPending: unknown): TaskPendingGitAction | undefined {
+	if (!rawPending || typeof rawPending !== "object") {
+		return undefined;
+	}
+	const pending = rawPending as {
+		action?: unknown;
+		requestedAt?: unknown;
+		headCommitAtRequest?: unknown;
+		attempt?: unknown;
+	};
+	if (pending.action !== "commit" && pending.action !== "pr") {
+		return undefined;
+	}
+	if (typeof pending.requestedAt !== "number") {
+		return undefined;
+	}
+	const headCommitAtRequest =
+		pending.headCommitAtRequest === null || typeof pending.headCommitAtRequest === "string"
+			? pending.headCommitAtRequest
+			: undefined;
+	if (headCommitAtRequest === undefined) {
+		return undefined;
+	}
+	return {
+		action: pending.action,
+		requestedAt: pending.requestedAt,
+		headCommitAtRequest,
+		attempt: typeof pending.attempt === "number" && pending.attempt >= 0 ? Math.floor(pending.attempt) : 0,
+	};
+}
+
 function normalizeCard(rawCard: unknown): BoardCard | null {
 	if (!rawCard || typeof rawCard !== "object") {
 		return null;
@@ -164,6 +196,7 @@ function normalizeCard(rawCard: unknown): BoardCard | null {
 		clineReasoningEffort?: unknown;
 		createdAt?: unknown;
 		updatedAt?: unknown;
+		pendingGitAction?: unknown;
 	};
 	const prompt = typeof card.prompt === "string" ? card.prompt.trim() : "";
 	if (!prompt) {
@@ -185,6 +218,7 @@ function normalizeCard(rawCard: unknown): BoardCard | null {
 	});
 
 	const now = Date.now();
+	const pendingGitAction = normalizeTaskPendingGitAction(card.pendingGitAction);
 
 	return {
 		id: typeof card.id === "string" && card.id ? card.id : createShortTaskId(createBrowserUuid),
@@ -201,6 +235,7 @@ function normalizeCard(rawCard: unknown): BoardCard | null {
 		...(clineSettings !== undefined ? { clineSettings } : {}),
 		createdAt: typeof card.createdAt === "number" ? card.createdAt : now,
 		updatedAt: typeof card.updatedAt === "number" ? card.updatedAt : now,
+		...(pendingGitAction !== undefined ? { pendingGitAction } : {}),
 	};
 }
 

--- a/web-ui/src/types/board.ts
+++ b/web-ui/src/types/board.ts
@@ -1,11 +1,14 @@
+import { isPendingGitActionStale, PENDING_GIT_ACTION_STALE_AFTER_MS } from "@runtime-task-state";
 import type {
 	RuntimeAgentId,
 	RuntimeBoardColumnId,
 	RuntimeTaskAutoReviewMode,
 	RuntimeTaskClineSettings,
 	RuntimeTaskImage,
+	RuntimeTaskPendingGitAction,
 } from "@/runtime/types";
 
+export { isPendingGitActionStale, PENDING_GIT_ACTION_STALE_AFTER_MS };
 export type BoardColumnId = RuntimeBoardColumnId;
 
 export type TaskAutoReviewMode = RuntimeTaskAutoReviewMode;
@@ -36,6 +39,8 @@ export function getTaskAutoReviewCancelButtonLabel(mode: TaskAutoReviewMode | nu
 	return "Cancel Auto-commit";
 }
 
+export type TaskPendingGitAction = RuntimeTaskPendingGitAction;
+
 export interface BoardCard {
 	id: string;
 	title: string;
@@ -49,6 +54,7 @@ export interface BoardCard {
 	baseRef: string;
 	createdAt: number;
 	updatedAt: number;
+	pendingGitAction?: TaskPendingGitAction | null;
 }
 
 export interface BoardColumn {


### PR DESCRIPTION
A card's armed auto-review state lives in browser memory. Reload the tab, close it, or switch project between sending the commit prompt and the commit landing, and the only record that a git action was requested is gone. The commit can succeed and the card still sits in review until someone trashes it by hand.

Fixes #365.

## The fix

One optional additive field on the board card, `pendingGitAction`. Existing `board.json` files parse unchanged; there is no migration.

```ts
export const runtimeTaskPendingGitActionSchema = z.object({
  action: runtimeTaskAutoReviewModeSchema,
  requestedAt: z.number(),
  headCommitAtRequest: z.string().nullable(),
  attempt: z.number().int().nonnegative().default(0),
});
```

- **Written** when auto-review triggers a git action, capturing the workspace `headCommit` at that moment.
- **Completed on evidence, not absence:** the action succeeds when HEAD differs from `headCommitAtRequest`. `changedFiles === 0` with an unchanged HEAD does not advance the card.
- **Guarded:** a second git action is refused while `pendingGitAction` is non-null and recent. The state is on the card, so this is a cross-tab lock.
- **Bounded:** after 15 minutes the pending action is cleared and the user is warned, rather than the card staying armed forever.

The staleness constant and helper live in `src/core/task-board-mutations.ts`, not `api-contract.ts`. web-ui consumes the contract type-only; a value import would pull zod into the SPA bundle.

This is the base of a stack. #615 builds on it and moves the actor from the browser into the runtime. This PR is complete on its own: it fixes #365 whether or not #615 lands.

## Tests

New tests in `web-ui/src/hooks/use-review-auto-actions.test.tsx` (remount survival / #365 regression, no-advance on clean tree with unchanged HEAD, second action refused, legacy board hydration, staleness) and schema parse tests in `test/runtime/api-validation.test.ts`.

Revert-and-rerun proof that the new tests fail without the source change:

```
$ <revert implementation sources to origin/main>
$ npm --prefix web-ui run test -- src/hooks/use-review-auto-actions.test.tsx
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
   × persists the pending git action when arming and advances the card after remount once HEAD moves (issue #365)
   × refuses to start a second git action while a recent pending action is armed
   × clears a stale pending git action instead of leaving the card armed forever
   × parses legacy boards without pendingGitAction and keeps valid pendingGitAction values

$ <restore>
$ npm --prefix web-ui run test -- src/hooks/use-review-auto-actions.test.tsx
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

`npm run check`, `npm run build`, `npm run web:typecheck` and `npm run web:test` pass.
