### PR TITLE
fix(git-actions): route commit and PR prompts by the card's agent

### DIFF
--- a/web-ui/src/hooks/use-git-actions.test.tsx
+++ b/web-ui/src/hooks/use-git-actions.test.tsx
@@ -3,7 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type UseGitActionsResult, useGitActions } from "@/hooks/use-git-actions";
-import type { RuntimeConfigResponse, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
+import type { RuntimeAgentId, RuntimeConfigResponse, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
 import { clearTaskWorkspaceInfo, clearTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 import type { BoardData } from "@/types";
 
@@ -19,6 +19,7 @@ vi.mock("@/components/git-history/use-git-history-data", () => ({
 }));
 
 interface HookSnapshot {
+	handleCommitTask: UseGitActionsResult["handleCommitTask"];
 	handleAgentCommitTask: UseGitActionsResult["handleAgentCommitTask"];
 }
 
@@ -51,7 +52,7 @@ function createGitHistoryResult(): UseGitActionsResult["gitHistory"] {
 	};
 }
 
-function createBoard(): BoardData {
+function createBoard(agentId?: RuntimeAgentId): BoardData {
 	return {
 		columns: [
 			{
@@ -68,6 +69,7 @@ function createBoard(): BoardData {
 						baseRef: "main",
 						createdAt: 1,
 						updatedAt: 1,
+						...(agentId ? { agentId } : {}),
 					},
 				],
 			},
@@ -130,18 +132,22 @@ function createWorkspaceInfo(): RuntimeTaskWorkspaceInfoResponse {
 
 function HookHarness({
 	onSnapshot,
+	board = createBoard(),
+	runtimeProjectConfig = createRuntimeConfig("cline"),
 	sendTaskSessionInput,
 	sendTaskChatMessage,
 }: {
 	onSnapshot: (snapshot: HookSnapshot) => void;
+	board?: BoardData;
+	runtimeProjectConfig?: RuntimeConfigResponse;
 	sendTaskSessionInput: Parameters<typeof useGitActions>[0]["sendTaskSessionInput"];
 	sendTaskChatMessage: Parameters<typeof useGitActions>[0]["sendTaskChatMessage"];
 }): null {
 	const gitActions = useGitActions({
 		currentProjectId: "project-1",
-		board: createBoard(),
+		board,
 		selectedCard: null,
-		runtimeProjectConfig: createRuntimeConfig("cline"),
+		runtimeProjectConfig,
 		sendTaskSessionInput,
 		sendTaskChatMessage,
 		fetchTaskWorkspaceInfo: async () => createWorkspaceInfo(),
@@ -151,9 +157,10 @@ function HookHarness({
 
 	useEffect(() => {
 		onSnapshot({
+			handleCommitTask: gitActions.handleCommitTask,
 			handleAgentCommitTask: gitActions.handleAgentCommitTask,
 		});
-	}, [gitActions.handleAgentCommitTask, onSnapshot]);
+	}, [gitActions.handleAgentCommitTask, gitActions.handleCommitTask, onSnapshot]);
 
 	return null;
 }
@@ -162,6 +169,46 @@ describe("useGitActions", () => {
 	let container: HTMLDivElement;
 	let root: Root;
 	let previousActEnvironment: boolean | undefined;
+
+	async function commitFromReviewCard(args: {
+		projectAgentId: RuntimeConfigResponse["selectedAgentId"];
+		cardAgentId?: RuntimeAgentId;
+	}): Promise<{
+		sendTaskSessionInput: ReturnType<typeof vi.fn>;
+		sendTaskChatMessage: ReturnType<typeof vi.fn>;
+	}> {
+		const sendTaskSessionInput = vi.fn(async () => ({ ok: true }));
+		const sendTaskChatMessage = vi.fn(async () => ({ ok: true }));
+		let latestSnapshot: HookSnapshot | null = null;
+
+		await act(async () => {
+			root.render(
+				<HookHarness
+					board={createBoard(args.cardAgentId)}
+					runtimeProjectConfig={createRuntimeConfig(args.projectAgentId)}
+					sendTaskSessionInput={sendTaskSessionInput}
+					sendTaskChatMessage={sendTaskChatMessage}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await Promise.resolve();
+		});
+
+		if (latestSnapshot === null) {
+			throw new Error("Expected a hook snapshot.");
+		}
+
+		await act(async () => {
+			latestSnapshot?.handleCommitTask("task-1");
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		return { sendTaskSessionInput, sendTaskChatMessage };
+	}
 
 	beforeEach(() => {
 		showAppToastMock.mockReset();
@@ -223,6 +270,70 @@ describe("useGitActions", () => {
 
 		expect(sendTaskChatMessage).toHaveBeenCalledWith("task-1", expect.any(String), { mode: "act" });
 		expect(sendTaskSessionInput).not.toHaveBeenCalled();
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("routes a cline card override to chat when the project default is a terminal agent", async () => {
+		const { sendTaskSessionInput, sendTaskChatMessage } = await commitFromReviewCard({
+			projectAgentId: "codex",
+			cardAgentId: "cline",
+		});
+
+		expect(sendTaskChatMessage).toHaveBeenCalledWith("task-1", expect.any(String), { mode: "act" });
+		expect(sendTaskSessionInput).not.toHaveBeenCalled();
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("routes a terminal card override to the session when the project default is cline", async () => {
+		const { sendTaskSessionInput, sendTaskChatMessage } = await commitFromReviewCard({
+			projectAgentId: "cline",
+			cardAgentId: "codex",
+		});
+
+		expect(sendTaskChatMessage).not.toHaveBeenCalled();
+		expect(sendTaskSessionInput).toHaveBeenCalledWith("task-1", expect.any(String), {
+			appendNewline: false,
+			mode: "paste",
+		});
+
+		await act(async () => {
+			await new Promise<void>((resolve) => {
+				window.setTimeout(resolve, 200);
+			});
+		});
+
+		expect(sendTaskSessionInput).toHaveBeenCalledWith("task-1", "\r", { appendNewline: false });
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("routes a card with no agent override through cline chat when the project default is cline", async () => {
+		const { sendTaskSessionInput, sendTaskChatMessage } = await commitFromReviewCard({
+			projectAgentId: "cline",
+		});
+
+		expect(sendTaskChatMessage).toHaveBeenCalledWith("task-1", expect.any(String), { mode: "act" });
+		expect(sendTaskSessionInput).not.toHaveBeenCalled();
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("routes a card with no agent override through the session when the project default is a terminal agent", async () => {
+		const { sendTaskSessionInput, sendTaskChatMessage } = await commitFromReviewCard({
+			projectAgentId: "codex",
+		});
+
+		expect(sendTaskChatMessage).not.toHaveBeenCalled();
+		expect(sendTaskSessionInput).toHaveBeenCalledWith("task-1", expect.any(String), {
+			appendNewline: false,
+			mode: "paste",
+		});
+
+		await act(async () => {
+			await new Promise<void>((resolve) => {
+				window.setTimeout(resolve, 200);
+			});
+		});
+
+		expect(sendTaskSessionInput).toHaveBeenCalledWith("task-1", "\r", { appendNewline: false });
 		expect(showAppToastMock).not.toHaveBeenCalled();
 	});
 });

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -214,10 +214,6 @@ export function useGitActions({
 		return next;
 	}, [taskGitActionLoadingByTaskId]);
 
-	const shouldUseClineChatForTaskGitActions = isNativeClineAgentSelected(
-		runtimeProjectConfig?.selectedAgentId ?? null,
-	);
-
 	const runTaskGitAction = useCallback(
 		async (taskId: string, action: TaskGitAction, source: TaskGitActionSource) => {
 			const taskLoadingState = taskGitActionLoadingByTaskId[taskId];
@@ -286,7 +282,9 @@ export function useGitActions({
 							}
 						: null,
 				});
-				if (shouldUseClineChatForTaskGitActions) {
+				const effectiveAgentId = selection.card.agentId ?? runtimeProjectConfig?.selectedAgentId ?? null;
+				const useClineChat = isNativeClineAgentSelected(effectiveAgentId);
+				if (useClineChat) {
 					const sent = await sendTaskChatMessage(taskId, prompt, { mode: "act" });
 					if (!sent.ok) {
 						showAppToast({
@@ -334,7 +332,6 @@ export function useGitActions({
 			sendTaskChatMessage,
 			sendTaskSessionInput,
 			setTaskGitActionLoading,
-			shouldUseClineChatForTaskGitActions,
 			taskGitActionLoadingByTaskId,
 		],
 	);


### PR DESCRIPTION
Fixes #617

Commit and Open PR choose Cline chat or the task terminal from the project default agent. They ignore the agent on the card.

A Cline card in a Codex project gets a terminal paste. A Codex card in a Cline project gets a chat message to a session that is not Cline. The action looks started. Then nothing happens.

Cards already store `agentId`. Session start and the card-detail panel already use it. This call site did not.

After the card is found, the hook uses the card agent. If the card has no agent, it uses the project default:

```ts
const effectiveAgentId = selection.card.agentId ?? runtimeProjectConfig?.selectedAgentId ?? null;
const useClineChat = isNativeClineAgentSelected(effectiveAgentId);
```

Cards with no override keep current behaviour. Prompt text and delivery stay the same.

The tests call `handleCommitTask`, not Open PR. Both handlers share `runTaskGitAction`. Coverage is via commit.

Per-task agent selection is already in the product. See #431 and #592. This is the missed git-action consumer.

## Tests

`npm --prefix web-ui run test -- src/hooks/use-git-actions.test.tsx`

Without the source change (the two override cases fail; the no-override cases still pass):

```
 ✓ sends commit prompts through the native cline chat API
 × routes a cline card override to chat when the project default is a terminal agent
 × routes a terminal card override to the session when the project default is cline
 ✓ routes a card with no agent override through cline chat when the project default is cline
 ✓ routes a card with no agent override through the session when the project default is a terminal agent

Tests  2 failed | 3 passed (5)
```

With the source change:

```
 ✓ src/hooks/use-git-actions.test.tsx (5 tests)

 Test Files  1 passed (1)
      Tests  5 passed (5)
```
