### PR TITLE
fix(worktree): provision ignored paths from an allowlist instead of a denylist

### DIFF
--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -21,6 +21,7 @@ interface RuntimeGlobalConfigFileShape {
 
 interface RuntimeProjectConfigFileShape {
 	shortcuts?: RuntimeProjectShortcut[];
+	worktreeSharedDirectories?: string[];
 }
 
 export interface RuntimeConfigState {
@@ -391,7 +392,21 @@ async function writeRuntimeProjectConfigFile(
 		}
 		return;
 	}
-	if (normalizedShortcuts.length === 0) {
+
+	const existing = await readRuntimeConfigFile<RuntimeProjectConfigFileShape>(configPath);
+	const preservedSharedDirectories = Array.isArray(existing?.worktreeSharedDirectories)
+		? existing.worktreeSharedDirectories
+		: undefined;
+
+	const payload: RuntimeProjectConfigFileShape = {};
+	if (normalizedShortcuts.length > 0) {
+		payload.shortcuts = normalizedShortcuts;
+	}
+	if (preservedSharedDirectories !== undefined) {
+		payload.worktreeSharedDirectories = preservedSharedDirectories;
+	}
+
+	if (Object.keys(payload).length === 0) {
 		await rm(configPath, { force: true });
 		try {
 			await rm(dirname(configPath));
@@ -400,15 +415,10 @@ async function writeRuntimeProjectConfigFile(
 		}
 		return;
 	}
-	await lockedFileSystem.writeJsonFileAtomic(
-		configPath,
-		{
-			shortcuts: normalizedShortcuts,
-		} satisfies RuntimeProjectConfigFileShape,
-		{
-			lock: null,
-		},
-	);
+
+	await lockedFileSystem.writeJsonFileAtomic(configPath, payload, {
+		lock: null,
+	});
 }
 
 interface RuntimeConfigFiles {

--- a/src/workspace/task-worktree-provisioning.ts
+++ b/src/workspace/task-worktree-provisioning.ts
@@ -1,0 +1,200 @@
+export const WORKTREE_ALLOWLIST_FILENAME = ".kanban-worktree-allowlist";
+export const DEFAULT_WORKTREE_SHARED_DIRECTORIES = ["node_modules"] as const;
+export const WORKTREE_ALLOWLIST_MAX_BYTES = 64 * 1024;
+export const WORKTREE_ALLOWLIST_MAX_ENTRIES = 256;
+
+const CREDENTIAL_BASENAMES = new Set([
+	".env",
+	".envrc",
+	".npmrc",
+	".pypirc",
+	".netrc",
+	".git-credentials",
+	"id_rsa",
+	"id_dsa",
+	"id_ecdsa",
+	"id_ed25519",
+	"credentials.json",
+	"credentials.yml",
+	"credentials.yaml",
+	"auth.json",
+	"secrets.json",
+	"service-account.json",
+]);
+
+export interface WorktreeAllowlistParseResult {
+	paths: string[];
+	rejected: string[];
+}
+
+export interface WorktreeProvisionSelection {
+	allowlistedPaths: readonly string[];
+	sharedDirectories: readonly string[];
+}
+
+export function toWorktreeRelativePath(path: string): string {
+	return path
+		.trim()
+		.replaceAll("\\", "/")
+		.replace(/\/+$/g, "")
+		.split("/")
+		.filter((segment) => segment.length > 0)
+		.join("/");
+}
+
+function isGlobPattern(path: string): boolean {
+	return /[*?[]/.test(path);
+}
+
+function isUnsafeRelativePath(path: string): boolean {
+	if (!path) {
+		return true;
+	}
+	if (path.startsWith("/") || path.startsWith("~") || /^[A-Za-z]:/.test(path)) {
+		return true;
+	}
+	return path.split("/").some((segment) => segment === "." || segment === "..");
+}
+
+function getPathBasename(relativePath: string): string {
+	const segments = relativePath.split("/").filter((segment) => segment.length > 0);
+	return segments.at(-1) ?? "";
+}
+
+export function isCredentialRelativePath(relativePath: string): boolean {
+	const normalized = toWorktreeRelativePath(relativePath);
+	if (!normalized) {
+		return false;
+	}
+
+	return normalized.split("/").some((segment) => {
+		if (CREDENTIAL_BASENAMES.has(segment)) {
+			return true;
+		}
+		return segment.startsWith(".env.");
+	});
+}
+
+export function parseWorktreeAllowlistFile(
+	content: string,
+	byteLength = Buffer.byteLength(content),
+): WorktreeAllowlistParseResult {
+	if (byteLength > WORKTREE_ALLOWLIST_MAX_BYTES) {
+		return {
+			paths: [],
+			rejected: [`${WORKTREE_ALLOWLIST_FILENAME} exceeds the ${String(WORKTREE_ALLOWLIST_MAX_BYTES)} byte size cap`],
+		};
+	}
+
+	const paths: string[] = [];
+	const rejected: string[] = [];
+	const seen = new Set<string>();
+
+	for (const rawLine of content.split(/\r?\n/u)) {
+		const trimmed = rawLine.trim();
+		if (!trimmed || trimmed.startsWith("#")) {
+			continue;
+		}
+
+		const normalized = toWorktreeRelativePath(trimmed);
+		if (!normalized || isUnsafeRelativePath(normalized) || isGlobPattern(trimmed) || isGlobPattern(normalized)) {
+			rejected.push(trimmed);
+			continue;
+		}
+
+		if (seen.has(normalized)) {
+			continue;
+		}
+		if (paths.length >= WORKTREE_ALLOWLIST_MAX_ENTRIES) {
+			rejected.push(trimmed);
+			continue;
+		}
+
+		seen.add(normalized);
+		paths.push(normalized);
+	}
+
+	return { paths, rejected };
+}
+
+export function normalizeWorktreeSharedDirectories(value: unknown): string[] | null {
+	if (!Array.isArray(value)) {
+		return null;
+	}
+
+	const directories: string[] = [];
+	const seen = new Set<string>();
+	for (const entry of value) {
+		if (typeof entry !== "string") {
+			continue;
+		}
+		const normalized = toWorktreeRelativePath(entry);
+		if (!normalized || isUnsafeRelativePath(normalized) || isGlobPattern(entry) || isGlobPattern(normalized)) {
+			continue;
+		}
+		if (isCredentialRelativePath(normalized)) {
+			continue;
+		}
+		if (seen.has(normalized)) {
+			continue;
+		}
+		seen.add(normalized);
+		directories.push(normalized);
+	}
+	return directories;
+}
+
+function matchesSharedDirectory(relativePath: string, sharedDirectory: string): boolean {
+	if (relativePath === sharedDirectory) {
+		return true;
+	}
+	if (sharedDirectory.includes("/")) {
+		return relativePath.startsWith(`${sharedDirectory}/`);
+	}
+	return getPathBasename(relativePath) === sharedDirectory;
+}
+
+export function shouldProvisionIgnoredPath(relativePath: string, selection: WorktreeProvisionSelection): boolean {
+	const normalized = toWorktreeRelativePath(relativePath);
+	if (!normalized) {
+		return false;
+	}
+
+	const allowlisted = new Set(selection.allowlistedPaths.map((path) => toWorktreeRelativePath(path)).filter(Boolean));
+	if (allowlisted.has(normalized)) {
+		return true;
+	}
+
+	if (isCredentialRelativePath(normalized)) {
+		return false;
+	}
+
+	return selection.sharedDirectories.some((directory) => {
+		const normalizedDirectory = toWorktreeRelativePath(directory);
+		if (!normalizedDirectory || isCredentialRelativePath(normalizedDirectory) || isGlobPattern(normalizedDirectory)) {
+			return false;
+		}
+		return matchesSharedDirectory(normalized, normalizedDirectory);
+	});
+}
+
+export function selectIgnoredPathsToProvision(
+	ignoredPaths: readonly string[],
+	selection: WorktreeProvisionSelection,
+): string[] {
+	return ignoredPaths.filter((relativePath) => shouldProvisionIgnoredPath(relativePath, selection));
+}
+
+export function formatUnprovisionedIgnoredPathWarning(relativePaths: readonly string[]): string | null {
+	const uniquePaths = [...new Set(relativePaths.map((path) => toWorktreeRelativePath(path)).filter(Boolean))];
+	if (uniquePaths.length === 0) {
+		return null;
+	}
+
+	const namedPaths = uniquePaths.slice(0, 5);
+	const extraCount = uniquePaths.length - namedPaths.length;
+	const pathList = namedPaths.map((path) => `"${path}"`).join(", ");
+	const extra = extraCount > 0 ? ` (and ${String(extraCount)} more)` : "";
+
+	return `Ignored path ${pathList}${extra} exists in the primary checkout but was not provisioned into the task worktree. Add the literal relative path to ${WORKTREE_ALLOWLIST_FILENAME} at the repository root to provision it. Credential filenames cannot be provisioned through worktreeSharedDirectories.`;
+}

--- a/src/workspace/task-worktree-provisioning.ts
+++ b/src/workspace/task-worktree-provisioning.ts
@@ -75,6 +75,20 @@ export function isCredentialRelativePath(relativePath: string): boolean {
 	});
 }
 
+export function listContainsCredentialBasename(names: readonly string[]): string[] {
+	const found: string[] = [];
+	const seen = new Set<string>();
+	for (const name of names) {
+		const basename = toWorktreeRelativePath(name).split("/")[0] ?? "";
+		if (!basename || seen.has(basename) || !isCredentialRelativePath(basename)) {
+			continue;
+		}
+		seen.add(basename);
+		found.push(basename);
+	}
+	return found;
+}
+
 export function parseWorktreeAllowlistFile(
 	content: string,
 	byteLength = Buffer.byteLength(content),
@@ -196,5 +210,18 @@ export function formatUnprovisionedIgnoredPathWarning(relativePaths: readonly st
 	const pathList = namedPaths.map((path) => `"${path}"`).join(", ");
 	const extra = extraCount > 0 ? ` (and ${String(extraCount)} more)` : "";
 
-	return `Ignored path ${pathList}${extra} exists in the primary checkout but was not provisioned into the task worktree. Add the literal relative path to ${WORKTREE_ALLOWLIST_FILENAME} at the repository root to provision it. Credential filenames cannot be provisioned through worktreeSharedDirectories.`;
+	return `Ignored path ${pathList}${extra} exists in the primary checkout but was not provisioned into the task worktree. Add the literal relative path to ${WORKTREE_ALLOWLIST_FILENAME} at the repository root to provision it.`;
+}
+
+export function formatSharedDirectoryCredentialWarning(
+	relativePath: string,
+	credentialNames: readonly string[],
+): string | null {
+	const directory = toWorktreeRelativePath(relativePath);
+	const names = listContainsCredentialBasename(credentialNames);
+	if (!directory || names.length === 0) {
+		return null;
+	}
+	const named = names.map((name) => `"${name}"`).join(", ");
+	return `Shared directory "${directory}" was not provisioned because it contains ${named}. Do not share a directory that holds secrets.`;
 }

--- a/src/workspace/task-worktree.ts
+++ b/src/workspace/task-worktree.ts
@@ -1,6 +1,7 @@
 import { access, lstat, mkdir, readdir, readFile, rm, symlink } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 
+import { getRuntimeProjectConfigPath } from "../config/runtime-config";
 import type {
 	RuntimeTaskWorkspaceInfoResponse,
 	RuntimeWorktreeDeleteResponse,
@@ -10,6 +11,14 @@ import { type LockRequest, lockedFileSystem } from "../fs/locked-file-system";
 import { getRuntimeHomePath, getTaskWorktreesHomePath, loadWorkspaceContext } from "../state/workspace-state";
 import { getGitCommandErrorMessage, getGitStdout, readGitHeadInfo, runGit } from "./git-utils";
 import { getWorkspaceFolderLabelForWorktreePath, normalizeTaskIdForWorktreePath } from "./task-worktree-path";
+import {
+	DEFAULT_WORKTREE_SHARED_DIRECTORIES,
+	formatUnprovisionedIgnoredPathWarning,
+	normalizeWorktreeSharedDirectories,
+	parseWorktreeAllowlistFile,
+	selectIgnoredPathsToProvision,
+	WORKTREE_ALLOWLIST_FILENAME,
+} from "./task-worktree-provisioning";
 import { listTurbopackNodeModulesSymlinkSkipPaths } from "./task-worktree-turbopack";
 
 const KANBAN_MANAGED_EXCLUDE_BLOCK_START = "# kanban-managed-symlinked-ignored-paths:start";
@@ -282,6 +291,36 @@ async function listIgnoredPaths(repoPath: string): Promise<string[]> {
 		.filter((line) => line.length > 0);
 }
 
+async function loadWorktreeAllowlistedPaths(repoPath: string): Promise<string[]> {
+	const allowlistPath = join(repoPath, WORKTREE_ALLOWLIST_FILENAME);
+	try {
+		const content = await readFile(allowlistPath, "utf8");
+		return parseWorktreeAllowlistFile(content, Buffer.byteLength(content)).paths;
+	} catch {
+		return [];
+	}
+}
+
+async function loadWorktreeSharedDirectories(repoPath: string): Promise<string[]> {
+	try {
+		const raw = await readFile(getRuntimeProjectConfigPath(repoPath), "utf8");
+		const parsed: unknown = JSON.parse(raw);
+		const sharedDirectories =
+			parsed && typeof parsed === "object" && !Array.isArray(parsed)
+				? (parsed as { worktreeSharedDirectories?: unknown }).worktreeSharedDirectories
+				: undefined;
+		const normalized = normalizeWorktreeSharedDirectories(sharedDirectories);
+		return normalized ?? [...DEFAULT_WORKTREE_SHARED_DIRECTORIES];
+	} catch {
+		return [...DEFAULT_WORKTREE_SHARED_DIRECTORIES];
+	}
+}
+
+function joinWorktreeWarnings(...warnings: Array<string | null | undefined>): string | undefined {
+	const parts = warnings.map((warning) => warning?.trim()).filter((warning): warning is string => Boolean(warning));
+	return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
 async function worktreeHasConfiguredSubmodules(worktreePath: string): Promise<boolean> {
 	const gitmodulesPath = join(worktreePath, ".gitmodules");
 	if (!(await pathExists(gitmodulesPath))) {
@@ -355,12 +394,26 @@ async function syncManagedIgnoredPathExcludes(repoPath: string, relativePaths: s
 	await lockedFileSystem.writeTextFileAtomic(excludePath, normalizedNextContent);
 }
 
-async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: string): Promise<void> {
+async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: string): Promise<string | undefined> {
 	const ignoredPaths = getUniquePaths(await listIgnoredPaths(repoPath)).filter(
 		(relativePath) => !shouldSkipSymlink(relativePath),
 	);
 	const turbopackNodeModulesSkipPaths = new Set(await listTurbopackNodeModulesSymlinkSkipPaths(repoPath));
-	const mirroredIgnoredPaths = ignoredPaths.filter((relativePath) => !turbopackNodeModulesSkipPaths.has(relativePath));
+	const candidatePaths = ignoredPaths.filter((relativePath) => !turbopackNodeModulesSkipPaths.has(relativePath));
+	const mirroredIgnoredPaths = selectIgnoredPathsToProvision(candidatePaths, {
+		allowlistedPaths: await loadWorktreeAllowlistedPaths(repoPath),
+		sharedDirectories: await loadWorktreeSharedDirectories(repoPath),
+	});
+
+	const unprovisionedExistingPaths: string[] = [];
+	for (const relativePath of candidatePaths) {
+		if (mirroredIgnoredPaths.includes(relativePath)) {
+			continue;
+		}
+		if (await pathExists(join(repoPath, relativePath))) {
+			unprovisionedExistingPaths.push(relativePath);
+		}
+	}
 
 	await syncManagedIgnoredPathExcludes(repoPath, mirroredIgnoredPaths);
 	for (const relativePath of mirroredIgnoredPaths) {
@@ -386,6 +439,8 @@ async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: stri
 			isDirectory: sourceStat.isDirectory(),
 		});
 	}
+
+	return formatUnprovisionedIgnoredPathWarning(unprovisionedExistingPaths) ?? undefined;
 }
 
 async function initializeSubmodulesIfNeeded(worktreePath: string): Promise<void> {
@@ -396,10 +451,10 @@ async function initializeSubmodulesIfNeeded(worktreePath: string): Promise<void>
 	await getGitStdout(["submodule", "update", "--init", "--recursive"], worktreePath);
 }
 
-async function prepareNewTaskWorktree(repoPath: string, worktreePath: string): Promise<void> {
+async function prepareNewTaskWorktree(repoPath: string, worktreePath: string): Promise<string | undefined> {
 	try {
 		await initializeSubmodulesIfNeeded(worktreePath);
-		await syncIgnoredPathsIntoWorktree(repoPath, worktreePath);
+		return await syncIgnoredPathsIntoWorktree(repoPath, worktreePath);
 	} catch (error) {
 		await removeTaskWorktreeInternal(repoPath, worktreePath).catch(() => {});
 		throw error;
@@ -449,24 +504,26 @@ export async function ensureTaskWorktreeIfDoesntExist(options: {
 		// worktrees are now treated as authoritative and only missing worktrees are created.
 		const existingResult = await runGit(worktreePath, ["rev-parse", "HEAD"]);
 		if (existingResult.ok && existingResult.stdout) {
-			await syncIgnoredPathsIntoWorktree(context.repoPath, worktreePath);
+			const warning = await syncIgnoredPathsIntoWorktree(context.repoPath, worktreePath);
 			return {
 				ok: true,
 				path: worktreePath,
 				baseRef: options.baseRef.trim(),
 				baseCommit: existingResult.stdout,
+				warning,
 			};
 		}
 
 		return await withTaskWorktreeSetupLock(context.repoPath, async () => {
 			const lockedExistingCommit = await tryRunGit(worktreePath, ["rev-parse", "HEAD"]);
 			if (lockedExistingCommit) {
-				await syncIgnoredPathsIntoWorktree(context.repoPath, worktreePath);
+				const warning = await syncIgnoredPathsIntoWorktree(context.repoPath, worktreePath);
 				return {
 					ok: true,
 					path: worktreePath,
 					baseRef: options.baseRef.trim(),
 					baseCommit: lockedExistingCommit,
+					warning,
 				};
 			}
 
@@ -531,7 +588,7 @@ export async function ensureTaskWorktreeIfDoesntExist(options: {
 					"Could not restore the saved task patch onto its original commit. Started from the task base ref instead.";
 				await getGitStdout(["worktree", "add", "--detach", worktreePath, baseCommit], context.repoPath);
 			}
-			await prepareNewTaskWorktree(context.repoPath, worktreePath);
+			const provisioningWarning = await prepareNewTaskWorktree(context.repoPath, worktreePath);
 
 			if (storedPatch && baseCommit === storedPatch.commit) {
 				try {
@@ -547,7 +604,7 @@ export async function ensureTaskWorktreeIfDoesntExist(options: {
 				path: worktreePath,
 				baseRef: requestedBaseRef,
 				baseCommit,
-				warning,
+				warning: joinWorktreeWarnings(provisioningWarning, warning),
 			};
 		});
 	} catch (error) {

--- a/src/workspace/task-worktree.ts
+++ b/src/workspace/task-worktree.ts
@@ -13,7 +13,9 @@ import { getGitCommandErrorMessage, getGitStdout, readGitHeadInfo, runGit } from
 import { getWorkspaceFolderLabelForWorktreePath, normalizeTaskIdForWorktreePath } from "./task-worktree-path";
 import {
 	DEFAULT_WORKTREE_SHARED_DIRECTORIES,
+	formatSharedDirectoryCredentialWarning,
 	formatUnprovisionedIgnoredPathWarning,
+	listContainsCredentialBasename,
 	normalizeWorktreeSharedDirectories,
 	parseWorktreeAllowlistFile,
 	selectIgnoredPathsToProvision,
@@ -400,14 +402,47 @@ async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: stri
 	);
 	const turbopackNodeModulesSkipPaths = new Set(await listTurbopackNodeModulesSymlinkSkipPaths(repoPath));
 	const candidatePaths = ignoredPaths.filter((relativePath) => !turbopackNodeModulesSkipPaths.has(relativePath));
-	const mirroredIgnoredPaths = selectIgnoredPathsToProvision(candidatePaths, {
-		allowlistedPaths: await loadWorktreeAllowlistedPaths(repoPath),
+	const allowlistedPaths = await loadWorktreeAllowlistedPaths(repoPath);
+	const allowlisted = new Set(allowlistedPaths);
+	const selectedPaths = selectIgnoredPathsToProvision(candidatePaths, {
+		allowlistedPaths,
 		sharedDirectories: await loadWorktreeSharedDirectories(repoPath),
 	});
 
+	const mirroredIgnoredPaths: string[] = [];
+	const nestedCredentialWarnings: string[] = [];
+	const skippedForNestedCredentials = new Set<string>();
+
+	for (const relativePath of selectedPaths) {
+		if (allowlisted.has(relativePath)) {
+			mirroredIgnoredPaths.push(relativePath);
+			continue;
+		}
+
+		const sourcePath = join(repoPath, relativePath);
+		const sourceStat = await lstat(sourcePath).catch(() => null);
+		if (!sourceStat?.isDirectory()) {
+			mirroredIgnoredPaths.push(relativePath);
+			continue;
+		}
+
+		const topLevelNames = await readdir(sourcePath);
+		const credentialNames = listContainsCredentialBasename(topLevelNames);
+		if (credentialNames.length > 0) {
+			skippedForNestedCredentials.add(relativePath);
+			const warning = formatSharedDirectoryCredentialWarning(relativePath, credentialNames);
+			if (warning) {
+				nestedCredentialWarnings.push(warning);
+			}
+			continue;
+		}
+
+		mirroredIgnoredPaths.push(relativePath);
+	}
+
 	const unprovisionedExistingPaths: string[] = [];
 	for (const relativePath of candidatePaths) {
-		if (mirroredIgnoredPaths.includes(relativePath)) {
+		if (mirroredIgnoredPaths.includes(relativePath) || skippedForNestedCredentials.has(relativePath)) {
 			continue;
 		}
 		if (await pathExists(join(repoPath, relativePath))) {
@@ -440,7 +475,10 @@ async function syncIgnoredPathsIntoWorktree(repoPath: string, worktreePath: stri
 		});
 	}
 
-	return formatUnprovisionedIgnoredPathWarning(unprovisionedExistingPaths) ?? undefined;
+	return joinWorktreeWarnings(
+		...nestedCredentialWarnings,
+		formatUnprovisionedIgnoredPathWarning(unprovisionedExistingPaths),
+	);
 }
 
 async function initializeSubmodulesIfNeeded(worktreePath: string): Promise<void> {

--- a/test/integration/task-worktree.integration.test.ts
+++ b/test/integration/task-worktree.integration.test.ts
@@ -103,8 +103,9 @@ describe.sequential("task-worktree integration", () => {
 				writeFileSync(join(repoPath, ".husky", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
 				writeFileSync(join(repoPath, ".husky", "_", ".gitignore"), "*\n", "utf8");
 				writeFileSync(join(repoPath, ".husky", "_", "pre-commit"), "#!/bin/sh\nexit 0\n", "utf8");
+				writeFileSync(join(repoPath, ".kanban-worktree-allowlist"), ".husky/_\n", "utf8");
 
-				runGit(repoPath, ["add", "README.md", ".husky/pre-commit"]);
+				runGit(repoPath, ["add", "README.md", ".husky/pre-commit", ".kanban-worktree-allowlist"]);
 				runGit(repoPath, ["commit", "-m", "init"]);
 
 				const ignoredPaths = runGit(repoPath, [
@@ -180,13 +181,10 @@ describe.sequential("task-worktree integration", () => {
 
 				const nextPath = join(ensured.path, ".next");
 				const nodeModulesPath = join(ensured.path, "node_modules");
-				expectMirroredPathBehavior(nextPath);
+				expect(existsSync(nextPath)).toBe(false);
 				expectMirroredPathBehavior(nodeModulesPath);
 				expect(runGit(ensured.path, ["status", "--porcelain", "--", ".next"])).toBe("");
 				expect(runGit(ensured.path, ["status", "--porcelain", "--", "node_modules"])).toBe("");
-				if (existsSync(nextPath)) {
-					expect(runGit(ensured.path, ["check-ignore", "-v", ".next"])).toContain("info/exclude");
-				}
 				if (existsSync(nodeModulesPath)) {
 					expect(runGit(ensured.path, ["check-ignore", "-v", "node_modules"])).toContain("info/exclude");
 				}
@@ -234,7 +232,7 @@ describe.sequential("task-worktree integration", () => {
 
 				const nextPath = join(ensured.path, ".next");
 				const nodeModulesPath = join(ensured.path, "node_modules");
-				expectMirroredPathBehavior(nextPath);
+				expect(existsSync(nextPath)).toBe(false);
 				expect(existsSync(nodeModulesPath)).toBe(false);
 				expect(runGit(ensured.path, ["status", "--porcelain", "--", ".next"])).toBe("");
 				expect(runGit(ensured.path, ["status", "--porcelain", "--", "node_modules"])).toBe("");
@@ -438,6 +436,204 @@ describe.sequential("task-worktree integration", () => {
 
 				expect(restored.warning).toContain("Saved task changes could not be reapplied automatically.");
 				expect(runGit(restored.path, ["rev-parse", "HEAD"])).toBe(createdCommit);
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	it("does not provision a gitignored .env into task worktrees by default", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-env-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(repoPath, { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), ".env\n", "utf8");
+				writeFileSync(join(repoPath, ".env"), "SECRET=not-for-agents\n", "utf8");
+
+				runGit(repoPath, ["add", "README.md", ".gitignore"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-env",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				expect(existsSync(join(ensured.path, ".env"))).toBe(false);
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	it("does not provision a credential filename via worktreeSharedDirectories", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-shared-env-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(join(repoPath, ".cline", "kanban"), { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), ".env\n", "utf8");
+				writeFileSync(join(repoPath, ".env"), "SECRET=not-for-agents\n", "utf8");
+				writeFileSync(
+					join(repoPath, ".cline", "kanban", "config.json"),
+					JSON.stringify({ worktreeSharedDirectories: [".env"] }),
+					"utf8",
+				);
+
+				runGit(repoPath, ["add", "README.md", ".gitignore"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-shared-env",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				expect(existsSync(join(ensured.path, ".env"))).toBe(false);
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	it("provisions an allowlisted ignored path and keeps it ignored inside the worktree", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-allowlist-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(join(repoPath, "cache"), { recursive: true });
+				mkdirSync(join(repoPath, "scratch"), { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), "/cache/\n/scratch/\n", "utf8");
+				writeFileSync(join(repoPath, "cache", "data.txt"), "cached\n", "utf8");
+				writeFileSync(join(repoPath, "scratch", "notes.txt"), "local\n", "utf8");
+				writeFileSync(join(repoPath, ".kanban-worktree-allowlist"), "cache\n", "utf8");
+
+				runGit(repoPath, ["add", "README.md", ".gitignore", ".kanban-worktree-allowlist"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-allowlist",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				const cachePath = join(ensured.path, "cache");
+				expectMirroredPathBehavior(cachePath);
+				expect(existsSync(join(ensured.path, "scratch"))).toBe(false);
+				expect(runGit(ensured.path, ["status", "--porcelain", "--", "cache"])).toBe("");
+				if (existsSync(cachePath)) {
+					expect(runGit(ensured.path, ["check-ignore", "-v", "cache"])).toContain("info/exclude");
+				}
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	it("provisions node_modules with default configuration and does not provision unrelated ignored files", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-node-modules-default-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(join(repoPath, "node_modules"), { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), "/node_modules/\nscratch.log\n", "utf8");
+				writeFileSync(join(repoPath, "node_modules", "package.json"), '{\n  "name": "fixture"\n}\n', "utf8");
+				writeFileSync(join(repoPath, "scratch.log"), "local\n", "utf8");
+
+				runGit(repoPath, ["add", "README.md", ".gitignore"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-node-modules-default",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				const nodeModulesPath = join(ensured.path, "node_modules");
+				expectMirroredPathBehavior(nodeModulesPath);
+				expect(existsSync(join(ensured.path, "scratch.log"))).toBe(false);
+				expect(runGit(ensured.path, ["status", "--porcelain", "--", "node_modules"])).toBe("");
+				if (existsSync(nodeModulesPath)) {
+					expect(runGit(ensured.path, ["check-ignore", "-v", "node_modules"])).toContain("info/exclude");
+				}
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	it("warns with the path name when an ignored primary-checkout path is not provisioned", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-missing-path-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(join(repoPath, ".next"), { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), "/.next/\n", "utf8");
+				writeFileSync(join(repoPath, ".next", "BUILD_ID"), "build\n", "utf8");
+
+				runGit(repoPath, ["add", "README.md", ".gitignore"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-missing-path",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				expect(existsSync(join(ensured.path, ".next"))).toBe(false);
+				expect(ensured.warning).toContain(".next");
+				expect(ensured.warning).toContain(".kanban-worktree-allowlist");
 			} finally {
 				cleanup();
 			}

--- a/test/integration/task-worktree.integration.test.ts
+++ b/test/integration/task-worktree.integration.test.ts
@@ -517,6 +517,50 @@ describe.sequential("task-worktree integration", () => {
 		});
 	});
 
+	it("does not provision a shared directory that contains a credential at the top level", async () => {
+		await withTemporaryHome(async () => {
+			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-shared-nested-env-");
+			try {
+				const repoPath = join(sandboxRoot, "repo");
+				mkdirSync(join(repoPath, "config"), { recursive: true });
+				mkdirSync(join(repoPath, ".cline", "kanban"), { recursive: true });
+
+				runGit(repoPath, ["init"]);
+				runGit(repoPath, ["config", "user.name", "Kanban Test"]);
+				runGit(repoPath, ["config", "user.email", "kanban-test@example.com"]);
+
+				writeFileSync(join(repoPath, "README.md"), "hello\n", "utf8");
+				writeFileSync(join(repoPath, ".gitignore"), "/config/\n", "utf8");
+				writeFileSync(join(repoPath, "config", ".env"), "SECRET=not-for-agents\n", "utf8");
+				writeFileSync(join(repoPath, "config", "app.json"), "{}\n", "utf8");
+				writeFileSync(
+					join(repoPath, ".cline", "kanban", "config.json"),
+					JSON.stringify({ worktreeSharedDirectories: ["config"] }),
+					"utf8",
+				);
+
+				runGit(repoPath, ["add", "README.md", ".gitignore"]);
+				runGit(repoPath, ["commit", "-m", "init"]);
+
+				const ensured = await ensureTaskWorktreeIfDoesntExist({
+					cwd: repoPath,
+					taskId: "task-shared-nested-env",
+					baseRef: "HEAD",
+				});
+				expect(ensured.ok).toBe(true);
+				if (!ensured.ok || !ensured.path) {
+					throw new Error("Task worktree was not created");
+				}
+
+				expect(existsSync(join(ensured.path, "config"))).toBe(false);
+				expect(ensured.warning).toContain("config");
+				expect(ensured.warning).toContain(".env");
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
 	it("provisions an allowlisted ignored path and keeps it ignored inside the worktree", async () => {
 		await withTemporaryHome(async () => {
 			const { path: sandboxRoot, cleanup } = createTempDir("kanban-task-worktree-allowlist-");

--- a/test/runtime/config/runtime-config.test.ts
+++ b/test/runtime/config/runtime-config.test.ts
@@ -318,6 +318,45 @@ describe.sequential("runtime-config auto agent selection", () => {
 		}
 	});
 
+	it("preserves worktreeSharedDirectories when shortcuts are saved", async () => {
+		const { path: tempHome, cleanup: cleanupHome } = createTempDir("kanban-home-runtime-config-preserve-shared-");
+		const { path: tempProject, cleanup: cleanupProject } = createTempDir(
+			"kanban-project-runtime-config-preserve-shared-",
+		);
+
+		try {
+			const runtimeProjectConfigDir = join(tempProject, ".cline", "kanban");
+			mkdirSync(runtimeProjectConfigDir, { recursive: true });
+			writeFileSync(
+				join(runtimeProjectConfigDir, "config.json"),
+				JSON.stringify({ worktreeSharedDirectories: ["node_modules", ".next"] }),
+				"utf8",
+			);
+
+			await withTemporaryEnv({ home: tempHome }, async () => {
+				await saveRuntimeConfig(tempProject, {
+					selectedAgentId: "cline",
+					selectedShortcutLabel: null,
+					agentAutonomousModeEnabled: true,
+					readyForReviewNotificationsEnabled: true,
+					shortcuts: [{ label: "Ship", command: "npm run ship" }],
+					commitPromptTemplate: "commit",
+					openPrPromptTemplate: "pr",
+				});
+
+				const payload = JSON.parse(readFileSync(join(runtimeProjectConfigDir, "config.json"), "utf8")) as {
+					shortcuts?: unknown;
+					worktreeSharedDirectories?: string[];
+				};
+				expect(payload.worktreeSharedDirectories).toEqual(["node_modules", ".next"]);
+				expect(payload.shortcuts).toEqual([{ label: "Ship", command: "npm run ship" }]);
+			});
+		} finally {
+			cleanupProject();
+			cleanupHome();
+		}
+	});
+
 	it("removes an existing empty project config file when no shortcuts are saved", async () => {
 		const { path: tempHome, cleanup: cleanupHome } = createTempDir("kanban-home-runtime-config-cleanup-empty-");
 		const { path: tempProject, cleanup: cleanupProject } = createTempDir(

--- a/test/runtime/task-worktree-provisioning.test.ts
+++ b/test/runtime/task-worktree-provisioning.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
 	DEFAULT_WORKTREE_SHARED_DIRECTORIES,
+	formatSharedDirectoryCredentialWarning,
 	formatUnprovisionedIgnoredPathWarning,
 	isCredentialRelativePath,
+	listContainsCredentialBasename,
 	parseWorktreeAllowlistFile,
 	selectIgnoredPathsToProvision,
 	shouldProvisionIgnoredPath,
@@ -56,6 +58,18 @@ describe("task-worktree provisioning allowlist", () => {
 				sharedDirectories: [".env", "node_modules"],
 			}),
 		).toBe(false);
+	});
+
+	it("detects credential basenames in a directory listing", () => {
+		expect(listContainsCredentialBasename(["README.md", ".env", "app.js"])).toEqual([".env"]);
+		expect(listContainsCredentialBasename(["package.json", ".bin"])).toEqual([]);
+	});
+
+	it("warns when a shared directory contains a credential basename", () => {
+		const warning = formatSharedDirectoryCredentialWarning("config", [".env"]);
+		expect(warning).toContain("config");
+		expect(warning).toContain(".env");
+		expect(warning).toContain("Do not share a directory that holds secrets");
 	});
 
 	it("provisions an allowlisted credential path only as an exact literal", () => {

--- a/test/runtime/task-worktree-provisioning.test.ts
+++ b/test/runtime/task-worktree-provisioning.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_WORKTREE_SHARED_DIRECTORIES,
+	formatUnprovisionedIgnoredPathWarning,
+	isCredentialRelativePath,
+	parseWorktreeAllowlistFile,
+	selectIgnoredPathsToProvision,
+	shouldProvisionIgnoredPath,
+	WORKTREE_ALLOWLIST_FILENAME,
+	WORKTREE_ALLOWLIST_MAX_BYTES,
+} from "../../src/workspace/task-worktree-provisioning";
+
+describe("task-worktree provisioning allowlist", () => {
+	it("uses node_modules as the default shared directory", () => {
+		expect(DEFAULT_WORKTREE_SHARED_DIRECTORIES).toEqual(["node_modules"]);
+	});
+
+	it("treats .env and common credential filenames as credentials", () => {
+		expect(isCredentialRelativePath(".env")).toBe(true);
+		expect(isCredentialRelativePath(".env.local")).toBe(true);
+		expect(isCredentialRelativePath(".envrc")).toBe(true);
+		expect(isCredentialRelativePath(".npmrc")).toBe(true);
+		expect(isCredentialRelativePath("id_rsa")).toBe(true);
+		expect(isCredentialRelativePath("node_modules")).toBe(false);
+		expect(isCredentialRelativePath(".next")).toBe(false);
+	});
+
+	it("parses literal allowlist paths and rejects glob patterns", () => {
+		const parsed = parseWorktreeAllowlistFile(
+			["cache", ".env", "dist/*", "build?", "[secret]", "", "# comment"].join("\n"),
+		);
+		expect(parsed.paths).toEqual(["cache", ".env"]);
+		expect(parsed.rejected).toEqual(["dist/*", "build?", "[secret]"]);
+	});
+
+	it("rejects an oversize allowlist file", () => {
+		const parsed = parseWorktreeAllowlistFile("cache\n", WORKTREE_ALLOWLIST_MAX_BYTES + 1);
+		expect(parsed.paths).toEqual([]);
+		expect(parsed.rejected.length).toBeGreaterThan(0);
+	});
+
+	it("does not provision .env by default", () => {
+		expect(
+			shouldProvisionIgnoredPath(".env", {
+				allowlistedPaths: [],
+				sharedDirectories: [...DEFAULT_WORKTREE_SHARED_DIRECTORIES],
+			}),
+		).toBe(false);
+	});
+
+	it("does not provision a credential filename through shared directories", () => {
+		expect(
+			shouldProvisionIgnoredPath(".env", {
+				allowlistedPaths: [],
+				sharedDirectories: [".env", "node_modules"],
+			}),
+		).toBe(false);
+	});
+
+	it("provisions an allowlisted credential path only as an exact literal", () => {
+		expect(
+			shouldProvisionIgnoredPath(".env", {
+				allowlistedPaths: [".env"],
+				sharedDirectories: [...DEFAULT_WORKTREE_SHARED_DIRECTORIES],
+			}),
+		).toBe(true);
+		expect(
+			shouldProvisionIgnoredPath(".env.local", {
+				allowlistedPaths: [".env*"],
+				sharedDirectories: [],
+			}),
+		).toBe(false);
+	});
+
+	it("provisions node_modules and nested node_modules from the default shared directory", () => {
+		expect(
+			shouldProvisionIgnoredPath("node_modules", {
+				allowlistedPaths: [],
+				sharedDirectories: [...DEFAULT_WORKTREE_SHARED_DIRECTORIES],
+			}),
+		).toBe(true);
+		expect(
+			shouldProvisionIgnoredPath("apps/web/node_modules", {
+				allowlistedPaths: [],
+				sharedDirectories: [...DEFAULT_WORKTREE_SHARED_DIRECTORIES],
+			}),
+		).toBe(true);
+	});
+
+	it("selects only allowlisted and shared-directory paths", () => {
+		expect(
+			selectIgnoredPathsToProvision([".env", "node_modules", "cache", "scratch"], {
+				allowlistedPaths: ["cache"],
+				sharedDirectories: [...DEFAULT_WORKTREE_SHARED_DIRECTORIES],
+			}),
+		).toEqual(["node_modules", "cache"]);
+	});
+
+	it("names the missing path and the allowlist file in the warning", () => {
+		const warning = formatUnprovisionedIgnoredPathWarning([".next"]);
+		expect(warning).toContain(".next");
+		expect(warning).toContain(WORKTREE_ALLOWLIST_FILENAME);
+	});
+});


### PR DESCRIPTION
Fixes #619

Every gitignored path is currently symlinked into every task worktree. The skip list is OS junk (`.DS_Store`, `Thumbs.db`, `.git`). A gitignored `.env` is copied into the sandbox with everything else. That is too broad.

**Behaviour change.** `.husky/_`, `.next`, `dist`, `.turbo`, `venv` and similar stop being provisioned by default. If an ignored path exists in the primary checkout and is not provisioned, worktree ensure returns a warning that names the path and points at `.kanban-worktree-allowlist`. `node_modules` still works with no config.

**Design.**

- Repo-root `.kanban-worktree-allowlist`: literal relative paths only. No globs. 64 KiB and 256-entry caps.
- `worktreeSharedDirectories` in `.cline/kanban/config.json`, default `["node_modules"]` (including nested `…/node_modules`). Saving shortcuts preserves the field.
- Credential *paths* are never provisioned through shared directories. A shared directory with a credential filename in its top level is not symlinked. A credential nested deeper is still reachable, because `git ls-files --directory` reports the folder as one entry. Do not share a directory that holds secrets.
- Symlinked paths still go through the managed `.git/info/exclude` block.

[#447](https://github.com/cline/kanban/issues/447) is fixed as a side effect. That issue wants a way to stop `node_modules` being symlinked, for Vite. Set `worktreeSharedDirectories` to `[]`.

## Tests

`npx vitest run test/integration/task-worktree.integration.test.ts`

Without the source change:

```
 × does not provision a gitignored .env into task worktrees by default
 × does not provision a credential filename via worktreeSharedDirectories
 × does not provision a shared directory that contains a credential at the top level
 × provisions an allowlisted ignored path and keeps it ignored inside the worktree
 × provisions node_modules with default configuration and does not provision unrelated ignored files
 × warns with the path name when an ignored primary-checkout path is not provisioned
```

With the source change, those tests pass. `npm run check` and `npm run build` are green.
