### PR TITLE
fix(git-actions): confirm prompt delivery instead of a fixed 200ms delay

### DIFF
--- a/web-ui/src/hooks/use-git-actions.test.tsx
+++ b/web-ui/src/hooks/use-git-actions.test.tsx
@@ -3,12 +3,18 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type UseGitActionsResult, useGitActions } from "@/hooks/use-git-actions";
-import type { RuntimeConfigResponse, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
+import type {
+	RuntimeConfigResponse,
+	RuntimeTaskSessionSummary,
+	RuntimeTaskWorkspaceInfoResponse,
+	RuntimeWorkspaceStateResponse,
+} from "@/runtime/types";
 import { clearTaskWorkspaceInfo, clearTaskWorkspaceSnapshot } from "@/stores/workspace-metadata-store";
 import type { BoardData } from "@/types";
 
 const showAppToastMock = vi.hoisted(() => vi.fn());
 const useGitHistoryDataMock = vi.hoisted(() => vi.fn());
+const fetchWorkspaceStateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/app-toaster", () => ({
 	showAppToast: showAppToastMock,
@@ -18,8 +24,13 @@ vi.mock("@/components/git-history/use-git-history-data", () => ({
 	useGitHistoryData: useGitHistoryDataMock,
 }));
 
+vi.mock("@/runtime/workspace-state-query", () => ({
+	fetchWorkspaceState: fetchWorkspaceStateMock,
+}));
+
 interface HookSnapshot {
 	handleAgentCommitTask: UseGitActionsResult["handleAgentCommitTask"];
+	runAutoReviewGitAction: UseGitActionsResult["runAutoReviewGitAction"];
 }
 
 function createGitHistoryResult(): UseGitActionsResult["gitHistory"] {
@@ -128,20 +139,58 @@ function createWorkspaceInfo(): RuntimeTaskWorkspaceInfoResponse {
 	};
 }
 
+function createSessionSummary(overrides: Partial<RuntimeTaskSessionSummary> = {}): RuntimeTaskSessionSummary {
+	return {
+		taskId: "task-1",
+		state: "idle",
+		agentId: "codex",
+		workspacePath: "/tmp/task-1",
+		pid: 1,
+		startedAt: 1,
+		updatedAt: 1,
+		lastOutputAt: 1000,
+		reviewReason: null,
+		exitCode: null,
+		lastHookAt: null,
+		latestHookActivity: null,
+		warningMessage: null,
+		...overrides,
+	};
+}
+
+function createWorkspaceState(summary: RuntimeTaskSessionSummary): RuntimeWorkspaceStateResponse {
+	return {
+		repoPath: "/tmp/project-1",
+		statePath: "/tmp/project-1/.cline/kanban",
+		git: {
+			currentBranch: "main",
+			defaultBranch: "main",
+			branches: ["main"],
+		},
+		board: createBoard(),
+		sessions: {
+			[summary.taskId]: summary,
+		},
+		revision: 1,
+	};
+}
+
 function HookHarness({
 	onSnapshot,
 	sendTaskSessionInput,
 	sendTaskChatMessage,
+	selectedAgentId = "cline",
 }: {
 	onSnapshot: (snapshot: HookSnapshot) => void;
 	sendTaskSessionInput: Parameters<typeof useGitActions>[0]["sendTaskSessionInput"];
 	sendTaskChatMessage: Parameters<typeof useGitActions>[0]["sendTaskChatMessage"];
+	selectedAgentId?: RuntimeConfigResponse["selectedAgentId"];
 }): null {
 	const gitActions = useGitActions({
 		currentProjectId: "project-1",
 		board: createBoard(),
 		selectedCard: null,
-		runtimeProjectConfig: createRuntimeConfig("cline"),
+		runtimeProjectConfig: createRuntimeConfig(selectedAgentId),
 		sendTaskSessionInput,
 		sendTaskChatMessage,
 		fetchTaskWorkspaceInfo: async () => createWorkspaceInfo(),
@@ -152,8 +201,9 @@ function HookHarness({
 	useEffect(() => {
 		onSnapshot({
 			handleAgentCommitTask: gitActions.handleAgentCommitTask,
+			runAutoReviewGitAction: gitActions.runAutoReviewGitAction,
 		});
-	}, [gitActions.handleAgentCommitTask, onSnapshot]);
+	}, [gitActions.handleAgentCommitTask, gitActions.runAutoReviewGitAction, onSnapshot]);
 
 	return null;
 }
@@ -167,6 +217,8 @@ describe("useGitActions", () => {
 		showAppToastMock.mockReset();
 		useGitHistoryDataMock.mockReset();
 		useGitHistoryDataMock.mockReturnValue(createGitHistoryResult());
+		fetchWorkspaceStateMock.mockReset();
+		fetchWorkspaceStateMock.mockResolvedValue(createWorkspaceState(createSessionSummary()));
 		clearTaskWorkspaceInfo("task-1");
 		clearTaskWorkspaceSnapshot("task-1");
 		previousActEnvironment = (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -182,6 +234,7 @@ describe("useGitActions", () => {
 			root.unmount();
 		});
 		container.remove();
+		vi.useRealTimers();
 		clearTaskWorkspaceInfo("task-1");
 		clearTaskWorkspaceSnapshot("task-1");
 		if (previousActEnvironment === undefined) {
@@ -191,6 +244,45 @@ describe("useGitActions", () => {
 				previousActEnvironment;
 		}
 	});
+
+	function useDeliveryFakeTimers(): void {
+		vi.useFakeTimers({
+			toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+		});
+	}
+
+	async function renderHarness(args: {
+		selectedAgentId?: RuntimeConfigResponse["selectedAgentId"];
+		sendTaskSessionInput: Parameters<typeof useGitActions>[0]["sendTaskSessionInput"];
+		sendTaskChatMessage?: Parameters<typeof useGitActions>[0]["sendTaskChatMessage"];
+	}): Promise<HookSnapshot> {
+		let latestSnapshot: HookSnapshot | null = null;
+		await act(async () => {
+			root.render(
+				<HookHarness
+					selectedAgentId={args.selectedAgentId}
+					sendTaskSessionInput={args.sendTaskSessionInput}
+					sendTaskChatMessage={args.sendTaskChatMessage ?? (async () => ({ ok: true }))}
+					onSnapshot={(snapshot) => {
+						latestSnapshot = snapshot;
+					}}
+				/>,
+			);
+			await Promise.resolve();
+		});
+		if (latestSnapshot === null) {
+			throw new Error("Expected a hook snapshot.");
+		}
+		return latestSnapshot;
+	}
+
+	async function flushUntil(predicate: () => boolean): Promise<void> {
+		for (let i = 0; i < 20 && !predicate(); i += 1) {
+			await Promise.resolve();
+		}
+		await Promise.resolve();
+		await Promise.resolve();
+	}
 
 	it("sends commit prompts through the native cline chat API", async () => {
 		const sendTaskSessionInput = vi.fn(async () => ({ ok: true }));
@@ -223,6 +315,128 @@ describe("useGitActions", () => {
 
 		expect(sendTaskChatMessage).toHaveBeenCalledWith("task-1", expect.any(String), { mode: "act" });
 		expect(sendTaskSessionInput).not.toHaveBeenCalled();
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("submits a git-action prompt after a slow session paste lands instead of after a 200ms timer", async () => {
+		useDeliveryFakeTimers();
+		const pasteLandedAfterMs = 400;
+		const startedAt = Date.now();
+		let enterSentAt: number | null = null;
+		const sessionInputCalls: Array<{ text: string; at: number }> = [];
+		fetchWorkspaceStateMock.mockImplementation(async () => {
+			const pasteLanded = Date.now() - startedAt >= pasteLandedAfterMs;
+			const submitted = enterSentAt !== null;
+			return createWorkspaceState(
+				createSessionSummary({
+					lastOutputAt: submitted ? 3000 : pasteLanded ? 2000 : 1000,
+					state: submitted ? "running" : "idle",
+				}),
+			);
+		});
+		const sendTaskSessionInput = vi.fn(async (_taskId: string, text: string) => {
+			const at = Date.now();
+			sessionInputCalls.push({ text, at });
+			if (text === "\r") {
+				enterSentAt = at;
+			}
+			return { ok: true };
+		});
+		const snapshot = await renderHarness({
+			selectedAgentId: "codex",
+			sendTaskSessionInput,
+		});
+
+		let submitted: boolean | undefined;
+		await act(async () => {
+			const actionPromise = snapshot.runAutoReviewGitAction("task-1", "commit");
+			await flushUntil(() => sessionInputCalls.length > 0);
+			expect(sessionInputCalls.some((call) => call.text !== "\r")).toBe(true);
+			await vi.advanceTimersByTimeAsync(200);
+			expect(sessionInputCalls.some((call) => call.text === "\r")).toBe(false);
+			await vi.advanceTimersByTimeAsync(250);
+			submitted = await actionPromise;
+		});
+
+		expect(submitted).toBe(true);
+		const enterCall = sessionInputCalls.find((call) => call.text === "\r");
+		expect(enterCall).toBeDefined();
+		expect((enterCall?.at ?? 0) - startedAt).toBeGreaterThanOrEqual(pasteLandedAfterMs);
+		expect(showAppToastMock).not.toHaveBeenCalled();
+	});
+
+	it("retries submit once and returns failure when the session never becomes active", async () => {
+		useDeliveryFakeTimers();
+		const sessionInputCalls: Array<{ text: string; at: number }> = [];
+		fetchWorkspaceStateMock.mockImplementation(async () => {
+			const pasteSent = sessionInputCalls.some((call) => call.text !== "\r");
+			return createWorkspaceState(
+				createSessionSummary({
+					lastOutputAt: pasteSent ? 2000 : 1000,
+					state: "idle",
+				}),
+			);
+		});
+		const sendTaskSessionInput = vi.fn(async (_taskId: string, text: string) => {
+			sessionInputCalls.push({ text, at: Date.now() });
+			return { ok: true };
+		});
+		const snapshot = await renderHarness({
+			selectedAgentId: "codex",
+			sendTaskSessionInput,
+		});
+
+		let submitted: boolean | undefined;
+		await act(async () => {
+			const actionPromise = snapshot.runAutoReviewGitAction("task-1", "commit");
+			await flushUntil(() => sessionInputCalls.length > 0);
+			await vi.advanceTimersByTimeAsync(10_000);
+			submitted = await actionPromise;
+		});
+
+		expect(submitted).toBe(false);
+		expect(sessionInputCalls.filter((call) => call.text === "\r")).toHaveLength(2);
+		expect(showAppToastMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				intent: "danger",
+				message: "Could not confirm the prompt was submitted to the task session.",
+			}),
+		);
+	});
+
+	it("does not wait 200ms when paste and submit are confirmed immediately", async () => {
+		useDeliveryFakeTimers();
+		const startedAt = Date.now();
+		const sessionInputCalls: Array<{ text: string; at: number }> = [];
+		fetchWorkspaceStateMock.mockImplementation(async () => {
+			const pasteSent = sessionInputCalls.some((call) => call.text !== "\r");
+			const enterSent = sessionInputCalls.some((call) => call.text === "\r");
+			return createWorkspaceState(
+				createSessionSummary({
+					lastOutputAt: enterSent ? 3000 : pasteSent ? 2000 : 1000,
+					state: enterSent ? "running" : "idle",
+				}),
+			);
+		});
+		const sendTaskSessionInput = vi.fn(async (_taskId: string, text: string) => {
+			sessionInputCalls.push({ text, at: Date.now() });
+			return { ok: true };
+		});
+		const snapshot = await renderHarness({
+			selectedAgentId: "codex",
+			sendTaskSessionInput,
+		});
+
+		let submitted: boolean | undefined;
+		await act(async () => {
+			const actionPromise = snapshot.runAutoReviewGitAction("task-1", "commit");
+			await flushUntil(() => sessionInputCalls.some((call) => call.text === "\r"));
+			expect(sessionInputCalls.filter((call) => call.text === "\r")).toHaveLength(1);
+			expect(Date.now() - startedAt).toBeLessThan(200);
+			submitted = await actionPromise;
+		});
+
+		expect(submitted).toBe(true);
 		expect(showAppToastMock).not.toHaveBeenCalled();
 	});
 });

--- a/web-ui/src/hooks/use-git-actions.ts
+++ b/web-ui/src/hooks/use-git-actions.ts
@@ -4,7 +4,13 @@ import { type UseGitHistoryDataResult, useGitHistoryData } from "@/components/gi
 import { buildTaskGitActionPrompt, type TaskGitAction } from "@/git-actions/build-task-git-action-prompt";
 import { isNativeClineAgentSelected } from "@/runtime/native-agent";
 import { getRuntimeTrpcClient } from "@/runtime/trpc-client";
-import type { RuntimeConfigResponse, RuntimeGitSyncAction, RuntimeTaskWorkspaceInfoResponse } from "@/runtime/types";
+import type {
+	RuntimeConfigResponse,
+	RuntimeGitSyncAction,
+	RuntimeTaskSessionSummary,
+	RuntimeTaskWorkspaceInfoResponse,
+} from "@/runtime/types";
+import { fetchWorkspaceState } from "@/runtime/workspace-state-query";
 import { findCardSelection } from "@/state/board-state";
 import {
 	getTaskWorkspaceInfo,
@@ -74,6 +80,17 @@ export interface UseGitActionsResult {
 	resetGitActionState: () => void;
 }
 
+const SESSION_PROMPT_CONFIRM_TIMEOUT_MS = 2_000;
+const SESSION_PROMPT_CONFIRM_POLL_MS = 50;
+
+type SessionActivityBaseline = Pick<RuntimeTaskSessionSummary, "lastOutputAt" | "lastHookAt" | "state">;
+
+const IDLE_SESSION_ACTIVITY_BASELINE: SessionActivityBaseline = {
+	lastOutputAt: null,
+	lastHookAt: null,
+	state: "idle",
+};
+
 function matchesWorkspaceInfoSelection(
 	workspaceInfo: RuntimeTaskWorkspaceInfoResponse | null,
 	card: BoardCard | null,
@@ -82,6 +99,162 @@ function matchesWorkspaceInfoSelection(
 		return false;
 	}
 	return workspaceInfo.taskId === card.id && workspaceInfo.baseRef === card.baseRef;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		window.setTimeout(resolve, ms);
+	});
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+	let timeoutId: number | null = null;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<null>((resolve) => {
+				timeoutId = window.setTimeout(() => {
+					resolve(null);
+				}, ms);
+			}),
+		]);
+	} finally {
+		if (timeoutId !== null) {
+			window.clearTimeout(timeoutId);
+		}
+	}
+}
+
+function toSessionActivityBaseline(summary: RuntimeTaskSessionSummary): SessionActivityBaseline {
+	return {
+		lastOutputAt: summary.lastOutputAt,
+		lastHookAt: summary.lastHookAt,
+		state: summary.state,
+	};
+}
+
+function sessionActivityAdvanced(
+	summary: RuntimeTaskSessionSummary | null,
+	baseline: SessionActivityBaseline,
+): boolean {
+	if (!summary) {
+		return false;
+	}
+	if (
+		summary.lastOutputAt != null &&
+		(baseline.lastOutputAt == null || summary.lastOutputAt > baseline.lastOutputAt)
+	) {
+		return true;
+	}
+	if (summary.lastHookAt != null && (baseline.lastHookAt == null || summary.lastHookAt > baseline.lastHookAt)) {
+		return true;
+	}
+	return baseline.state !== "running" && summary.state === "running";
+}
+
+async function readTaskSessionSummary(projectId: string, taskId: string): Promise<RuntimeTaskSessionSummary | null> {
+	const workspaceState = await fetchWorkspaceState(projectId);
+	return workspaceState.sessions[taskId] ?? null;
+}
+
+async function readSessionActivityBaseline(
+	projectId: string,
+	taskId: string,
+	fallback: SessionActivityBaseline,
+): Promise<SessionActivityBaseline> {
+	try {
+		const summary = await readTaskSessionSummary(projectId, taskId);
+		return summary ? toSessionActivityBaseline(summary) : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+async function waitForSessionActivity(input: {
+	projectId: string;
+	taskId: string;
+	baseline: SessionActivityBaseline;
+	timeoutMs: number;
+}): Promise<boolean> {
+	const deadline = Date.now() + input.timeoutMs;
+	while (true) {
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			return false;
+		}
+		try {
+			const summary = await withTimeout(readTaskSessionSummary(input.projectId, input.taskId), remaining);
+			if (sessionActivityAdvanced(summary, input.baseline)) {
+				return true;
+			}
+		} catch {
+			// Keep polling until the deadline so a transient read cannot hang delivery.
+		}
+		const remainingAfterRead = deadline - Date.now();
+		if (remainingAfterRead <= 0) {
+			return false;
+		}
+		await sleep(Math.min(SESSION_PROMPT_CONFIRM_POLL_MS, remainingAfterRead));
+	}
+}
+
+async function deliverConfirmedTaskSessionPrompt(input: {
+	projectId: string;
+	taskId: string;
+	prompt: string;
+	sendTaskSessionInput: UseGitActionsInput["sendTaskSessionInput"];
+}): Promise<{ ok: boolean; message?: string }> {
+	const pasteBaseline = await readSessionActivityBaseline(
+		input.projectId,
+		input.taskId,
+		IDLE_SESSION_ACTIVITY_BASELINE,
+	);
+	const typed = await input.sendTaskSessionInput(input.taskId, input.prompt, {
+		appendNewline: false,
+		mode: "paste",
+	});
+	if (!typed.ok) {
+		return { ok: false, message: typed.message ?? "Could not send instructions to the task session." };
+	}
+	const pasteLanded = await waitForSessionActivity({
+		projectId: input.projectId,
+		taskId: input.taskId,
+		baseline: pasteBaseline,
+		timeoutMs: SESSION_PROMPT_CONFIRM_TIMEOUT_MS,
+	});
+	if (!pasteLanded) {
+		return { ok: false, message: "Could not confirm the prompt was delivered to the task session." };
+	}
+	const submitBaseline = await readSessionActivityBaseline(input.projectId, input.taskId, pasteBaseline);
+	const submitted = await input.sendTaskSessionInput(input.taskId, "\r", { appendNewline: false });
+	if (!submitted.ok) {
+		return { ok: false, message: submitted.message ?? "Could not submit instructions to the task session." };
+	}
+	if (
+		await waitForSessionActivity({
+			projectId: input.projectId,
+			taskId: input.taskId,
+			baseline: submitBaseline,
+			timeoutMs: SESSION_PROMPT_CONFIRM_TIMEOUT_MS,
+		})
+	) {
+		return { ok: true };
+	}
+	const retried = await input.sendTaskSessionInput(input.taskId, "\r", { appendNewline: false });
+	if (!retried.ok) {
+		return { ok: false, message: retried.message ?? "Could not submit instructions to the task session." };
+	}
+	if (
+		await waitForSessionActivity({
+			projectId: input.projectId,
+			taskId: input.taskId,
+			baseline: submitBaseline,
+			timeoutMs: SESSION_PROMPT_CONFIRM_TIMEOUT_MS,
+		})
+	) {
+		return { ok: true };
+	}
+	return { ok: false, message: "Could not confirm the prompt was submitted to the task session." };
 }
 
 export function useGitActions({
@@ -299,25 +472,26 @@ export function useGitActions({
 					}
 					return true;
 				}
-				const typed = await sendTaskSessionInput(taskId, prompt, { appendNewline: false, mode: "paste" });
-				if (!typed.ok) {
+				if (!currentProjectId) {
 					showAppToast({
 						intent: "danger",
 						icon: "warning-sign",
-						message: typed.message ?? "Could not send instructions to the task session.",
+						message: "Could not confirm prompt delivery because no project is selected.",
 						timeout: 7000,
 					});
 					return false;
 				}
-				await new Promise<void>((resolve) => {
-					window.setTimeout(resolve, 200);
+				const delivered = await deliverConfirmedTaskSessionPrompt({
+					projectId: currentProjectId,
+					taskId,
+					prompt,
+					sendTaskSessionInput,
 				});
-				const submitted = await sendTaskSessionInput(taskId, "\r", { appendNewline: false });
-				if (!submitted.ok) {
+				if (!delivered.ok) {
 					showAppToast({
 						intent: "danger",
 						icon: "warning-sign",
-						message: submitted.message ?? "Could not submit instructions to the task session.",
+						message: delivered.message ?? "Could not send instructions to the task session.",
 						timeout: 7000,
 					});
 					return false;
@@ -329,6 +503,7 @@ export function useGitActions({
 		},
 		[
 			board,
+			currentProjectId,
 			fetchTaskWorkspaceInfo,
 			runtimeProjectConfig,
 			sendTaskChatMessage,


### PR DESCRIPTION
Fixes #227

The generated git-action prompt can stay in the task input bar until you press Enter yourself. The paste works. The submit does not.

The code pastes the prompt. Then it waits 200 ms. Then it sends Enter:

```ts
const typed = await sendTaskSessionInput(taskId, prompt, { appendNewline: false, mode: "paste" });
await new Promise<void>((resolve) => { window.setTimeout(resolve, 200); });
const submitted = await sendTaskSessionInput(taskId, "\r", { appendNewline: false });
```

Nothing proves the paste is in the input before Enter is sent. Nothing proves the session started after Enter. When the terminal UI is still settling, Enter has no effect. The prompt stays in the composer. A later Enter from you sends it at once.

The function also returns `true` as soon as the writes succeed. Callers then arm follow-up work for a prompt that did not send.

After the paste, this change waits for session activity on the existing summary: `lastOutputAt`, `lastHookAt`, or a change from `idle` to `running`. Then it sends Enter. Then it waits for more activity. If the session does not start, it sends Enter once more. If that also fails, it shows an error and returns `false`. When the session answers at once, it does not wait 200 ms.

This wait needs a change in `lastOutputAt`, `lastHookAt`, or `state`. Some terminal UIs show the prompt in the composer without that change. Then the paste wait ends and Enter never fires. The old code sent Enter into a silent no-op. This code shows a failure instead. That is the intended trade.

If no project is selected, the function returns false. The poll of workspace state needs a project id.

Files: `web-ui/src/hooks/use-git-actions.ts` and its tests.

**Before** (old 200 ms timer, new tests):

```
 ✓ sends commit prompts through the native cline chat API
 × submits a git-action prompt after a slow session paste lands instead of after a 200ms timer
   expected true to be false  // Enter already sent at 200ms
 × retries submit once and returns failure when the session never becomes active
   expected true to be false  // returned success after the write
 × does not wait 200ms when paste and submit are confirmed immediately
   expected [] to have a length of 1 but got +0  // Enter still waiting on the timer

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

**After:**

```
 ✓ src/hooks/use-git-actions.test.tsx (4 tests)

 Test Files  1 passed (1)
      Tests  4 passed (4)
```
