### PR TITLE
fix: load custom providers before Cline task launch

### DIFF
--- a/src/cline-sdk/cline-provider-service.ts
+++ b/src/cline-sdk/cline-provider-service.ts
@@ -26,6 +26,7 @@ import {
 	addSdkCustomProvider,
 	completeClineDeviceAuth as completeSdkDeviceAuth,
 	deleteSdkCustomProvider,
+	ensureSdkCustomProvidersLoaded,
 	fetchSdkClineAccountBalance,
 	fetchSdkClineAccountProfile,
 	fetchSdkClineUserRemoteConfig,
@@ -39,6 +40,7 @@ import {
 	loginManagedOauthProvider,
 	type ManagedClineOauthProviderId,
 	refreshManagedOauthCredentials,
+	resolveSdkLaunchProviderId,
 	SDK_DEFAULT_MODEL_ID,
 	SDK_DEFAULT_PROVIDER_ID,
 	type SdkCustomProviderCapability,
@@ -460,6 +462,13 @@ async function refreshManagedOauthSettings(
 }
 
 export function createClineProviderService() {
+	let initialProviderLoadPromise: Promise<void> | null = ensureSdkCustomProvidersLoaded();
+	const ensureProvidersLoaded = (): Promise<void> => {
+		const providerLoadPromise = initialProviderLoadPromise ?? ensureSdkCustomProvidersLoaded();
+		initialProviderLoadPromise = null;
+		return providerLoadPromise;
+	};
+
 	const getProviderSettingsSummary = (): RuntimeClineProviderSettings =>
 		toProviderSettingsSummary(getSelectedProviderSettings());
 
@@ -784,6 +793,7 @@ export function createClineProviderService() {
 			modelIdOverride?: string;
 			reasoningEffortOverride?: RuntimeClineReasoningEffort | null;
 		}): Promise<ResolvedClineLaunchConfig> {
+			await ensureProvidersLoaded();
 			const selectedSettings = overrides?.providerIdOverride
 				? (getSdkProviderSettings(overrides.providerIdOverride) ?? getSelectedProviderSettings())
 				: getSelectedProviderSettings();
@@ -813,7 +823,7 @@ export function createClineProviderService() {
 				resolvedSettings.model?.trim() ||
 				(await resolveDefaultModelIdForProvider(normalizedProviderId));
 			return {
-				providerId: normalizedProviderId,
+				providerId: resolveSdkLaunchProviderId(normalizedProviderId),
 				modelId,
 				apiKey,
 				baseUrl: resolvedSettings.baseUrl?.trim() || null,
@@ -825,6 +835,7 @@ export function createClineProviderService() {
 		},
 
 		async getProviderCatalog(): Promise<RuntimeClineProviderCatalogResponse> {
+			await ensureProvidersLoaded();
 			const selectedProviderId = getProviderSettingsSummary().providerId?.trim().toLowerCase() ?? "";
 			const providers: RuntimeClineProviderCatalogItem[] = await listSdkProviderCatalog()
 				.then((sdkProviders) =>
@@ -871,6 +882,7 @@ export function createClineProviderService() {
 		},
 
 		async getProviderModels(providerId: string): Promise<RuntimeClineProviderModelsResponse> {
+			await ensureProvidersLoaded();
 			const normalizedProviderId = providerId.trim().toLowerCase();
 			let providerModels =
 				normalizedProviderId.length > 0

--- a/src/cline-sdk/sdk-provider-boundary.ts
+++ b/src/cline-sdk/sdk-provider-boundary.ts
@@ -385,6 +385,26 @@ export async function listSdkProviderModels(providerId: string): Promise<SdkProv
 
 const providerManager = new ProviderSettingsManager();
 
+let ensureProvidersLoadPromise: Promise<void> | null = null;
+
+export function ensureSdkCustomProvidersLoaded(): Promise<void> {
+	if (!ensureProvidersLoadPromise) {
+		ensureProvidersLoadPromise = ensureCustomProvidersLoaded(providerManager).catch((error: unknown) => {
+			ensureProvidersLoadPromise = null;
+			throw error;
+		});
+	}
+	return ensureProvidersLoadPromise;
+}
+
+export function resolveSdkLaunchProviderId(providerId: string): string {
+	const normalizedProviderId = providerId.trim().toLowerCase();
+	const isBuiltInProviderId = ClineCore.Llms.isBuiltInProviderId;
+	return typeof isBuiltInProviderId === "function" && !isBuiltInProviderId(normalizedProviderId)
+		? "lmstudio"
+		: normalizedProviderId;
+}
+
 function resolveModelsPath(): string {
 	return join(dirname(providerManager.getFilePath()), "models.json");
 }

--- a/test/runtime/cline-sdk/account-balance.test.ts
+++ b/test/runtime/cline-sdk/account-balance.test.ts
@@ -28,7 +28,7 @@ const localProviderMocks = vi.hoisted(() => ({
 
 vi.mock("@clinebot/core", () => ({
 	addLocalProvider: vi.fn(),
-	ensureCustomProvidersLoaded: vi.fn(),
+	ensureCustomProvidersLoaded: vi.fn(async () => undefined),
 	getLocalProviderModels: localProviderMocks.getLocalProviderModels,
 	getValidClineCredentials: vi.fn(),
 	getValidOcaCredentials: vi.fn(),

--- a/test/runtime/cline-sdk/provider-loading.test.ts
+++ b/test/runtime/cline-sdk/provider-loading.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	ensureCustomProvidersLoaded: vi.fn(),
+	listSdkProviderCatalog: vi.fn(),
+	listSdkProviderModels: vi.fn(),
+	getSdkProviderSettings: vi.fn(),
+	getLastUsedSdkProviderSettings: vi.fn(),
+	refreshManagedOauthCredentials: vi.fn(),
+	resolveSdkLaunchProviderId: vi.fn((providerId: string) => providerId),
+	saveSdkProviderSettings: vi.fn(),
+}));
+
+vi.mock("../../../src/cline-sdk/sdk-provider-boundary", () => ({
+	ensureSdkCustomProvidersLoaded: mocks.ensureCustomProvidersLoaded,
+	listSdkProviderCatalog: mocks.listSdkProviderCatalog,
+	listSdkProviderModels: mocks.listSdkProviderModels,
+	getSdkProviderSettings: mocks.getSdkProviderSettings,
+	getLastUsedSdkProviderSettings: mocks.getLastUsedSdkProviderSettings,
+	refreshManagedOauthCredentials: mocks.refreshManagedOauthCredentials,
+	resolveSdkLaunchProviderId: mocks.resolveSdkLaunchProviderId,
+	saveSdkProviderSettings: mocks.saveSdkProviderSettings,
+	SDK_DEFAULT_MODEL_ID: "anthropic/claude-sonnet-4.6",
+	SDK_DEFAULT_PROVIDER_ID: "cline",
+}));
+
+vi.mock("../../../src/server/browser", () => ({
+	openInBrowser: vi.fn(),
+}));
+
+import { createClineProviderService } from "../../../src/cline-sdk/cline-provider-service";
+
+describe("ensureSdkCustomProvidersLoaded call ordering", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.ensureCustomProvidersLoaded.mockResolvedValue(undefined);
+		mocks.listSdkProviderCatalog.mockResolvedValue([]);
+		mocks.listSdkProviderModels.mockResolvedValue([]);
+		mocks.getSdkProviderSettings.mockReturnValue(undefined);
+		mocks.getLastUsedSdkProviderSettings.mockReturnValue(undefined);
+		mocks.refreshManagedOauthCredentials.mockResolvedValue(null);
+		mocks.saveSdkProviderSettings.mockReturnValue(undefined);
+	});
+
+	it("starts loading persisted custom providers when the service is created", () => {
+		createClineProviderService();
+
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls ensureSdkCustomProvidersLoaded before resolveLaunchConfig", async () => {
+		mocks.getLastUsedSdkProviderSettings.mockReturnValue({
+			provider: "cline",
+			model: "anthropic/claude-sonnet-4.6",
+			apiKey: "sk-test",
+		});
+
+		const service = createClineProviderService();
+		await service.resolveLaunchConfig();
+
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the SDK-compatible runtime provider ID for custom providers", async () => {
+		mocks.getLastUsedSdkProviderSettings.mockReturnValue({
+			provider: "ha",
+			model: "custom-model",
+			apiKey: "sk-test",
+		});
+		mocks.resolveSdkLaunchProviderId.mockReturnValue("lmstudio");
+
+		const service = createClineProviderService();
+		const config = await service.resolveLaunchConfig();
+
+		expect(mocks.resolveSdkLaunchProviderId).toHaveBeenCalledWith("ha");
+		expect(config.providerId).toBe("lmstudio");
+	});
+
+	it("calls ensureSdkCustomProvidersLoaded before getProviderCatalog", async () => {
+		mocks.getLastUsedSdkProviderSettings.mockReturnValue({
+			provider: "cline",
+			model: "anthropic/claude-sonnet-4.6",
+		});
+
+		const service = createClineProviderService();
+		await service.getProviderCatalog();
+
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls ensureSdkCustomProvidersLoaded before getProviderModels", async () => {
+		const service = createClineProviderService();
+		await service.getProviderModels("cline");
+
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(1);
+		expect(mocks.listSdkProviderModels).toHaveBeenCalledWith("cline");
+	});
+
+	it("calls ensureSdkCustomProvidersLoaded before each registry-dependent method", async () => {
+		mocks.getLastUsedSdkProviderSettings.mockReturnValue({
+			provider: "cline",
+			model: "anthropic/claude-sonnet-4.6",
+			auth: {
+				accessToken: "test-token",
+				refreshToken: "test-refresh",
+				expiresAt: Date.now() + 3600000,
+			},
+		});
+		mocks.refreshManagedOauthCredentials.mockResolvedValue({
+			access: "valid-token",
+			refresh: "valid-refresh",
+			expires: Date.now() + 3600000,
+		});
+
+		const service = createClineProviderService();
+		await service.getProviderCatalog();
+		await service.getProviderModels("cline");
+
+		// Verify ensureSdkCustomProvidersLoaded is called before registry access
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(2);
+		expect(mocks.listSdkProviderCatalog).toHaveBeenCalled();
+		expect(mocks.listSdkProviderModels).toHaveBeenCalledWith("cline");
+		// Verify ordering: ensure called before catalog
+		expect(mocks.ensureCustomProvidersLoaded.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.listSdkProviderCatalog.mock.invocationCallOrder[0],
+		);
+	});
+
+	it("retries ensureSdkCustomProvidersLoaded on failure", async () => {
+		mocks.ensureCustomProvidersLoaded
+			.mockRejectedValueOnce(new Error("SDK not ready"))
+			.mockResolvedValueOnce(undefined);
+		mocks.listSdkProviderCatalog.mockResolvedValue([]);
+
+		const service = createClineProviderService();
+
+		await expect(service.getProviderCatalog()).rejects.toThrow("SDK not ready");
+		await service.getProviderCatalog();
+
+		expect(mocks.ensureCustomProvidersLoaded).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Summary

- load persisted custom providers before resolving launch settings, provider catalogs, or models
- preserve custom provider IDs in saved settings while routing task launch through the SDK's supported OpenAI-compatible `lmstudio` transport
- retry provider loading after a failed initialization and deduplicate concurrent loads

## Problem

Fresh Cline task gateways reject persisted custom provider IDs with `Unknown or disabled provider`, even though those providers appear in the settings catalog. Catalog registration alone does not make a custom ID available as a runtime gateway handler in the current SDK.

## Validation

- `npm test -- --run test/runtime/cline-sdk/provider-loading.test.ts test/runtime/cline-sdk/account-balance.test.ts` (22 tests passed)
- `npm run build`
- real Kanban browser/model request using a persisted custom provider returned `PROVIDER_OK`

## Notes

The full Windows runtime API suite has three unrelated environment failures involving `/tmp` path normalization and a locked local `sessions.db`; provider-related runtime tests pass.