### PR TITLE
Add explicit GenPro Supervisor agent integration

### DIFF
--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1125,7 +1125,10 @@ export function registerTaskCommand(program: Command): void {
 		.option("--start-in-plan-mode [value]", "Set plan mode (true|false). Flag-only implies true.")
 		.option("--auto-review-enabled [value]", "Enable auto-review behavior (true|false). Flag-only implies true.")
 		.option("--auto-review-mode <mode>", "Auto-review mode: commit | pr.", parseAutoReviewMode)
-		.option("--agent-id <id>", "Agent override: cline | claude | codex | droid | gemini | opencode | default.")
+		.option(
+			"--agent-id <id>",
+			"Agent override: cline | claude | codex | droid | gemini | opencode | genpro | default.",
+		)
 		.option(
 			"--cline-provider <id>",
 			'Cline provider override (e.g. anthropic, openai, cline). Use "default" for workspace default.',
@@ -1187,7 +1190,7 @@ export function registerTaskCommand(program: Command): void {
 		.option("--auto-review-mode <mode>", "Auto-review mode: commit | pr.", parseAutoReviewMode)
 		.option(
 			"--agent-id <id>",
-			'Agent override: cline | claude | codex | droid | gemini | opencode. Use "default" to clear.',
+			'Agent override: cline | claude | codex | droid | gemini | opencode | genpro. Use "default" to clear.',
 		)
 		.option(
 			"--cline-provider <id>",

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -124,6 +124,7 @@ function normalizeAgentId(agentId: RuntimeAgentId | string | null | undefined): 
 			agentId === "opencode" ||
 			agentId === "droid" ||
 			agentId === "kiro" ||
+			agentId === "genpro" ||
 			agentId === "cline") &&
 		isRuntimeAgentLaunchSupported(agentId)
 	) {

--- a/src/core/agent-catalog.ts
+++ b/src/core/agent-catalog.ts
@@ -66,6 +66,14 @@ export const RUNTIME_AGENT_CATALOG: RuntimeAgentCatalogEntry[] = [
 		autonomousArgs: ["--yolo"],
 		installUrl: "https://github.com/google-gemini/gemini-cli",
 	},
+	{
+		id: "genpro",
+		label: "GenPro Supervisor",
+		binary: "genpro-supervisor-adapter",
+		baseArgs: [],
+		autonomousArgs: [],
+		installUrl: "https://github.com/Starmatrices/GenPro_FSM",
+	},
 ];
 
 // Temporarily keep launch support scoped to the core agent set.
@@ -76,6 +84,7 @@ export const RUNTIME_LAUNCH_SUPPORTED_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"codex",
 	"droid",
 	"kiro",
+	"genpro",
 	// "opencode",
 	// "gemini",
 ];

--- a/src/core/api-contract.ts
+++ b/src/core/api-contract.ts
@@ -71,7 +71,16 @@ export const runtimeSlashCommandsResponseSchema = z.object({
 });
 export type RuntimeSlashCommandsResponse = z.infer<typeof runtimeSlashCommandsResponseSchema>;
 
-export const runtimeAgentIdSchema = z.enum(["claude", "codex", "gemini", "opencode", "droid", "kiro", "cline"]);
+export const runtimeAgentIdSchema = z.enum([
+	"claude",
+	"codex",
+	"gemini",
+	"opencode",
+	"droid",
+	"kiro",
+	"cline",
+	"genpro",
+]);
 export type RuntimeAgentId = z.infer<typeof runtimeAgentIdSchema>;
 
 const runtimeBoardColumnIdEnum = z.enum(["backlog", "in_progress", "review", "trash"]);

--- a/src/prompts/append-system-prompt.ts
+++ b/src/prompts/append-system-prompt.ts
@@ -32,6 +32,7 @@ const APPEND_PROMPT_AGENT_IDS: readonly RuntimeAgentId[] = [
 	"kiro",
 	"gemini",
 	"opencode",
+	"genpro",
 ];
 
 function isRuntimeAgentId(value: string): value is RuntimeAgentId {

--- a/src/terminal/agent-registry.ts
+++ b/src/terminal/agent-registry.ts
@@ -7,6 +7,7 @@ import type {
 	RuntimeConfigResponse,
 } from "../core/api-contract";
 import { isBinaryAvailableOnPath } from "./command-discovery";
+import { resolveOptionalGenproExecutable } from "./genpro-launcher";
 
 export interface ResolvedAgentCommand {
 	agentId: RuntimeAgentId;
@@ -53,7 +54,11 @@ export function detectInstalledCommands(): string[] {
 	const detected: string[] = [];
 
 	for (const candidate of candidates) {
-		if (isBinaryAvailableOnPath(candidate)) {
+		const available =
+			candidate === "genpro-supervisor-adapter"
+				? resolveOptionalGenproExecutable(candidate) !== null
+				: isBinaryAvailableOnPath(candidate);
+		if (available) {
 			detected.push(candidate);
 		}
 	}
@@ -86,12 +91,13 @@ export function resolveAgentCommand(runtimeConfig: RuntimeConfigState): Resolved
 	}
 	const defaultArgs = getDefaultArgs(selected.id);
 	const command = joinCommand(selected.binary, defaultArgs);
-	if (isBinaryAvailableOnPath(selected.binary)) {
+	const resolvedBinary = selected.id === "genpro" ? resolveOptionalGenproExecutable(selected.binary) : null;
+	if (resolvedBinary || (selected.id !== "genpro" && isBinaryAvailableOnPath(selected.binary))) {
 		return {
 			agentId: selected.id,
 			label: selected.label,
 			command,
-			binary: selected.binary,
+			binary: resolvedBinary ?? selected.binary,
 			args: defaultArgs,
 		};
 	}

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -1,5 +1,5 @@
-import { access, readFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -15,6 +15,7 @@ import { lockedFileSystem } from "../fs/locked-file-system";
 import { resolveHomeAgentAppendSystemPrompt } from "../prompts/append-system-prompt";
 import { getRuntimeHomePath } from "../state/workspace-state";
 import { configureCodexHooks, hasCodexConfigOverride } from "./codex-hook-config";
+import { buildGenproProviderDiscoveryEnvironment, resolveGenproExecutable } from "./genpro-launcher";
 import { createHookRuntimeEnv } from "./hook-runtime-context";
 import {
 	getOpenCodeAuthPathCandidates,
@@ -38,6 +39,7 @@ export interface AgentAdapterLaunchInput {
 	resumeFromTrash?: boolean;
 	env?: Record<string, string | undefined>;
 	workspaceId?: string;
+	projectPath?: string;
 }
 
 export type AgentOutputTransitionDetector = (
@@ -1429,6 +1431,62 @@ const clineAdapter: AgentSessionAdapter = {
 	},
 };
 
+const genproAdapter: AgentSessionAdapter = {
+	async prepare(input) {
+		const hooks = resolveHookContext(input);
+		if (!hooks) {
+			throw new Error("GenPro Supervisor requires a task-scoped Kanban workspace");
+		}
+		const projectPath = input.projectPath?.trim();
+		if (!projectPath) {
+			throw new Error("GenPro Supervisor requires a stable project workspace path");
+		}
+		const binary = resolveGenproExecutable(input.binary);
+		const providerDiscoveryEnvironment = buildGenproProviderDiscoveryEnvironment();
+
+		const promptDirectory = await mkdtemp(join(tmpdir(), "kanban-genpro-"));
+		const promptPath = join(promptDirectory, "prompt.txt");
+		try {
+			await writeFile(promptPath, input.prompt, { encoding: "utf8", mode: 0o600 });
+		} catch (error) {
+			await rm(promptDirectory, { recursive: true, force: true });
+			throw error;
+		}
+
+		const args = [
+			...input.args,
+			"--task-id",
+			input.taskId,
+			"--workspace-id",
+			hooks.workspaceId,
+			"--project-path",
+			projectPath,
+			"--working-directory",
+			input.cwd,
+			"--prompt-file",
+			promptPath,
+		];
+		if (input.startInPlanMode) {
+			args.push("--start-in-plan-mode");
+		}
+		if (input.resumeFromTrash) {
+			args.push("--resume-from-trash");
+		}
+
+		return {
+			binary,
+			args,
+			env: {
+				...createHookRuntimeEnv(hooks),
+				...providerDiscoveryEnvironment,
+			},
+			cleanup: async () => {
+				await rm(promptDirectory, { recursive: true, force: true });
+			},
+		};
+	},
+};
+
 const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	claude: claudeAdapter,
 	codex: codexAdapter,
@@ -1437,6 +1495,7 @@ const ADAPTERS: Record<RuntimeAgentId, AgentSessionAdapter> = {
 	droid: droidAdapter,
 	kiro: kiroAdapter,
 	cline: clineAdapter,
+	genpro: genproAdapter,
 };
 
 export async function prepareAgentLaunch(input: AgentAdapterLaunchInput): Promise<PreparedAgentLaunch> {

--- a/src/terminal/agent-session-adapters.ts
+++ b/src/terminal/agent-session-adapters.ts
@@ -1433,6 +1433,11 @@ const clineAdapter: AgentSessionAdapter = {
 
 const genproAdapter: AgentSessionAdapter = {
 	async prepare(input) {
+		if (input.autonomousModeEnabled) {
+			throw new Error(
+				"Autonomous mode is unsupported for the GenPro Supervisor adapter; ForgePilot governs execution policy.",
+			);
+		}
 		const hooks = resolveHookContext(input);
 		if (!hooks) {
 			throw new Error("GenPro Supervisor requires a task-scoped Kanban workspace");

--- a/src/terminal/command-discovery.ts
+++ b/src/terminal/command-discovery.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants } from "node:fs";
-import { delimiter, join } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 
 function canAccessPath(path: string): boolean {
 	try {
@@ -10,8 +10,8 @@ function canAccessPath(path: string): boolean {
 	}
 }
 
-function getWindowsExecutableCandidates(binary: string): string[] {
-	const pathext = process.env.PATHEXT?.split(";").filter(Boolean) ?? [".COM", ".EXE", ".BAT", ".CMD"];
+function getWindowsExecutableCandidates(binary: string, environment: NodeJS.ProcessEnv): string[] {
+	const pathext = environment.PATHEXT?.split(";").filter(Boolean) ?? [".COM", ".EXE", ".BAT", ".CMD"];
 	const lowerBinary = binary.toLowerCase();
 	if (pathext.some((extension) => lowerBinary.endsWith(extension.toLowerCase()))) {
 		return [binary];
@@ -44,35 +44,41 @@ function getWindowsExecutableCandidates(binary: string): string[] {
 // environment the Kanban process already has, instead of silently relying on hidden shell
 // side effects.
 export function isBinaryAvailableOnPath(binary: string): boolean {
+	return resolveBinaryOnPath(binary) !== null;
+}
+
+export function resolveBinaryOnPath(binary: string, environment: NodeJS.ProcessEnv = process.env): string | null {
 	const trimmed = binary.trim();
 	if (!trimmed) {
-		return false;
+		return null;
 	}
 	if (trimmed.includes("/") || trimmed.includes("\\")) {
-		return canAccessPath(trimmed);
+		return canAccessPath(trimmed) ? resolve(trimmed) : null;
 	}
 
-	const pathEntries = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+	const pathEntries = (environment.PATH ?? "").split(delimiter).filter(Boolean);
 	if (pathEntries.length === 0) {
-		return false;
+		return null;
 	}
 
 	if (process.platform === "win32") {
-		const candidates = getWindowsExecutableCandidates(trimmed);
+		const candidates = getWindowsExecutableCandidates(trimmed, environment);
 		for (const entry of pathEntries) {
 			for (const candidate of candidates) {
-				if (canAccessPath(join(entry, candidate))) {
-					return true;
+				const candidatePath = join(entry, candidate);
+				if (canAccessPath(candidatePath)) {
+					return resolve(candidatePath);
 				}
 			}
 		}
-		return false;
+		return null;
 	}
 
 	for (const entry of pathEntries) {
-		if (canAccessPath(join(entry, trimmed))) {
-			return true;
+		const candidatePath = join(entry, trimmed);
+		if (canAccessPath(candidatePath)) {
+			return resolve(candidatePath);
 		}
 	}
-	return false;
+	return null;
 }

--- a/src/terminal/genpro-launcher.ts
+++ b/src/terminal/genpro-launcher.ts
@@ -1,0 +1,72 @@
+import { basename, delimiter, dirname, isAbsolute } from "node:path";
+
+import { resolveBinaryOnPath } from "./command-discovery";
+
+export const GENPRO_EXECUTABLE_ENV = "KANBAN_GENPRO_EXECUTABLE";
+export const GENPRO_CODEX_EXECUTABLE_ENV = "KANBAN_GENPRO_CODEX_EXECUTABLE";
+
+function configuredAbsoluteExecutable(
+	environment: NodeJS.ProcessEnv,
+	name: typeof GENPRO_EXECUTABLE_ENV | typeof GENPRO_CODEX_EXECUTABLE_ENV,
+): string | null {
+	if (!Object.hasOwn(environment, name)) {
+		return null;
+	}
+	const configured = environment[name]?.trim() ?? "";
+	if (!configured) {
+		throw new Error(`${name} must be a non-empty absolute executable path`);
+	}
+	if (!isAbsolute(configured)) {
+		throw new Error(`${name} must be an absolute executable path`);
+	}
+	const resolved = resolveBinaryOnPath(configured);
+	if (!resolved) {
+		throw new Error(`${name} does not identify an accessible executable: ${configured}`);
+	}
+	return resolved;
+}
+
+export function resolveGenproExecutable(
+	requestedBinary = "genpro-supervisor-adapter",
+	environment: NodeJS.ProcessEnv = process.env,
+): string {
+	const configured = configuredAbsoluteExecutable(environment, GENPRO_EXECUTABLE_ENV);
+	if (configured) {
+		return configured;
+	}
+	const discovered = resolveBinaryOnPath(requestedBinary, environment);
+	if (!discovered) {
+		throw new Error(
+			`GenPro Supervisor launcher was not found; set ${GENPRO_EXECUTABLE_ENV} to its absolute executable path`,
+		);
+	}
+	return discovered;
+}
+
+export function resolveOptionalGenproExecutable(
+	requestedBinary = "genpro-supervisor-adapter",
+	environment: NodeJS.ProcessEnv = process.env,
+): string | null {
+	try {
+		return resolveGenproExecutable(requestedBinary, environment);
+	} catch {
+		return null;
+	}
+}
+
+export function buildGenproProviderDiscoveryEnvironment(
+	environment: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const codexExecutable = configuredAbsoluteExecutable(environment, GENPRO_CODEX_EXECUTABLE_ENV);
+	if (!codexExecutable) {
+		return {};
+	}
+	const executableName = process.platform === "win32" ? "codex.exe" : "codex";
+	if (basename(codexExecutable).toLowerCase() !== executableName) {
+		throw new Error(`${GENPRO_CODEX_EXECUTABLE_ENV} must identify an executable named ${executableName}`);
+	}
+	const currentPath = environment.PATH?.trim();
+	return {
+		PATH: currentPath ? `${dirname(codexExecutable)}${delimiter}${currentPath}` : dirname(codexExecutable),
+	};
+}

--- a/src/terminal/session-manager.ts
+++ b/src/terminal/session-manager.ts
@@ -90,6 +90,7 @@ export interface StartTaskSessionRequest {
 	rows?: number;
 	env?: Record<string, string | undefined>;
 	workspaceId?: string;
+	projectPath?: string;
 }
 
 export interface StartShellSessionRequest {
@@ -334,6 +335,7 @@ export class TerminalSessionManager implements TerminalSessionService {
 			resumeFromTrash: request.resumeFromTrash,
 			env: request.env,
 			workspaceId: request.workspaceId,
+			projectPath: request.projectPath,
 		});
 
 		const env = buildTerminalEnvironment(request.env, launch.env);

--- a/src/trpc/runtime-api.ts
+++ b/src/trpc/runtime-api.ts
@@ -292,6 +292,7 @@ export function createRuntimeApi(deps: CreateRuntimeApiDependencies): RuntimeTrp
 					cols: body.cols,
 					rows: body.rows,
 					workspaceId: workspaceScope.workspaceId,
+					projectPath: workspaceScope.workspacePath,
 				});
 
 				let nextSummary = summary;

--- a/test/runtime/terminal/agent-registry.test.ts
+++ b/test/runtime/terminal/agent-registry.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const commandDiscoveryMocks = vi.hoisted(() => ({
 	isBinaryAvailableOnPath: vi.fn(),
+	resolveOptionalGenproExecutable: vi.fn(),
 }));
 
 vi.mock("../../../src/terminal/command-discovery.js", () => ({
 	isBinaryAvailableOnPath: commandDiscoveryMocks.isBinaryAvailableOnPath,
+}));
+
+vi.mock("../../../src/terminal/genpro-launcher.js", () => ({
+	resolveOptionalGenproExecutable: commandDiscoveryMocks.resolveOptionalGenproExecutable,
 }));
 
 import type { RuntimeConfigState } from "../../../src/config/runtime-config";
@@ -35,6 +40,8 @@ function createRuntimeConfigState(overrides: Partial<RuntimeConfigState> = {}): 
 beforeEach(() => {
 	commandDiscoveryMocks.isBinaryAvailableOnPath.mockReset();
 	commandDiscoveryMocks.isBinaryAvailableOnPath.mockReturnValue(false);
+	commandDiscoveryMocks.resolveOptionalGenproExecutable.mockReset();
+	commandDiscoveryMocks.resolveOptionalGenproExecutable.mockReturnValue(null);
 	delete process.env.KANBAN_DEBUG_MODE;
 	delete process.env.DEBUG_MODE;
 	delete process.env.debug_mode;
@@ -48,6 +55,18 @@ describe("agent-registry", () => {
 
 		expect(detected).toEqual(["claude"]);
 		expect(commandDiscoveryMocks.isBinaryAvailableOnPath).toHaveBeenCalledTimes(8);
+	});
+
+	it("resolves the configured GenPro launcher without changing other agents", () => {
+		commandDiscoveryMocks.resolveOptionalGenproExecutable.mockReturnValue(
+			"/opt/genpro/bin/genpro-supervisor-adapter",
+		);
+
+		const genpro = resolveAgentCommand(createRuntimeConfigState({ selectedAgentId: "genpro" }));
+		const claude = resolveAgentCommand(createRuntimeConfigState({ selectedAgentId: "claude" }));
+
+		expect(genpro?.binary).toBe("/opt/genpro/bin/genpro-supervisor-adapter");
+		expect(claude).toBeNull();
 	});
 
 	it("treats shell-only agents as unavailable", () => {
@@ -78,12 +97,13 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(true);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro", "genpro"]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "droid")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "kiro")?.defaultArgs).toEqual(["chat"]);
+		expect(response.agents.find((agent) => agent.id === "genpro")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.installed).toBe(true);
 	});
 
@@ -106,7 +126,7 @@ describe("buildRuntimeConfigResponse", () => {
 		});
 
 		expect(response.agentAutonomousModeEnabled).toBe(false);
-		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro"]);
+		expect(response.agents.map((agent) => agent.id)).toEqual(["claude", "codex", "cline", "droid", "kiro", "genpro"]);
 		expect(response.agents.find((agent) => agent.id === "claude")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "codex")?.defaultArgs).toEqual([]);
 		expect(response.agents.find((agent) => agent.id === "cline")?.defaultArgs).toEqual([]);

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -105,7 +105,7 @@ describe("prepareAgentLaunch hook strategies", () => {
 			agentId: "genpro",
 			binary: "genpro-supervisor-adapter",
 			args: [],
-			autonomousModeEnabled: true,
+			autonomousModeEnabled: false,
 			cwd: "/tmp/worktree",
 			prompt,
 			workspaceId: "workspace-1",
@@ -142,6 +142,24 @@ describe("prepareAgentLaunch hook strategies", () => {
 
 		await launch.cleanup?.();
 		expect(existsSync(promptPath)).toBe(false);
+	});
+
+	it("rejects autonomous GenPro before resolving its launcher", async () => {
+		await expect(
+			prepareAgentLaunch({
+				taskId: "task-genpro-auto",
+				agentId: "genpro",
+				binary: "genpro-supervisor-adapter",
+				args: [],
+				autonomousModeEnabled: true,
+				cwd: "/tmp/worktree",
+				prompt: "task prompt",
+				workspaceId: "workspace-1",
+				projectPath: "/tmp/project",
+			}),
+		).rejects.toThrow(
+			"Autonomous mode is unsupported for the GenPro Supervisor adapter; ForgePilot governs execution policy.",
+		);
 	});
 
 	it("refuses an unscoped GenPro launch before creating prompt evidence", async () => {

--- a/test/runtime/terminal/agent-session-adapters.test.ts
+++ b/test/runtime/terminal/agent-session-adapters.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,6 +9,8 @@ import { prepareAgentLaunch } from "../../../src/terminal/agent-session-adapters
 const originalHome = process.env.HOME;
 const originalAppData = process.env.APPDATA;
 const originalLocalAppData = process.env.LOCALAPPDATA;
+const originalGenproExecutable = process.env.KANBAN_GENPRO_EXECUTABLE;
+const originalGenproCodexExecutable = process.env.KANBAN_GENPRO_CODEX_EXECUTABLE;
 let tempHome: string | null = null;
 const originalArgv = [...process.argv];
 const originalExecArgv = [...process.execArgv];
@@ -72,6 +74,16 @@ afterEach(() => {
 	} else {
 		process.env.LOCALAPPDATA = originalLocalAppData;
 	}
+	if (originalGenproExecutable === undefined) {
+		delete process.env.KANBAN_GENPRO_EXECUTABLE;
+	} else {
+		process.env.KANBAN_GENPRO_EXECUTABLE = originalGenproExecutable;
+	}
+	if (originalGenproCodexExecutable === undefined) {
+		delete process.env.KANBAN_GENPRO_CODEX_EXECUTABLE;
+	} else {
+		process.env.KANBAN_GENPRO_CODEX_EXECUTABLE = originalGenproCodexExecutable;
+	}
 	process.argv = [...originalArgv];
 	process.execArgv = [...originalExecArgv];
 	Object.defineProperty(process, "execPath", {
@@ -81,6 +93,84 @@ afterEach(() => {
 });
 
 describe("prepareAgentLaunch hook strategies", () => {
+	it("prepares a task-scoped GenPro launch without exposing the prompt in argv", async () => {
+		const root = setupTempHome();
+		const executable = join(root, "genpro-supervisor-adapter");
+		writeFileSync(executable, "#!/bin/sh\n", { mode: 0o700 });
+		chmodSync(executable, 0o700);
+		process.env.KANBAN_GENPRO_EXECUTABLE = executable;
+		const prompt = "Implement the private task without bypass permissions";
+		const launch = await prepareAgentLaunch({
+			taskId: "task-genpro",
+			agentId: "genpro",
+			binary: "genpro-supervisor-adapter",
+			args: [],
+			autonomousModeEnabled: true,
+			cwd: "/tmp/worktree",
+			prompt,
+			workspaceId: "workspace-1",
+			projectPath: "/tmp/project",
+		});
+
+		const promptFlagIndex = launch.args.indexOf("--prompt-file");
+		expect(promptFlagIndex).toBeGreaterThan(-1);
+		const promptPath = launch.args[promptFlagIndex + 1];
+		expect(promptPath).toBeTruthy();
+		expect(readFileSync(promptPath, "utf8")).toBe(prompt);
+		if (process.platform !== "win32") {
+			expect(statSync(promptPath).mode & 0o777).toBe(0o600);
+		}
+		expect(launch.args).toEqual(
+			expect.arrayContaining([
+				"--task-id",
+				"task-genpro",
+				"--workspace-id",
+				"workspace-1",
+				"--project-path",
+				"/tmp/project",
+				"--working-directory",
+				"/tmp/worktree",
+			]),
+		);
+		expect(launch.args).not.toContain(prompt);
+		expect(launch.args).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+		expect(launch.binary).toBe(executable);
+		expect(launch.env).toEqual({
+			KANBAN_HOOK_TASK_ID: "task-genpro",
+			KANBAN_HOOK_WORKSPACE_ID: "workspace-1",
+		});
+
+		await launch.cleanup?.();
+		expect(existsSync(promptPath)).toBe(false);
+	});
+
+	it("refuses an unscoped GenPro launch before creating prompt evidence", async () => {
+		await expect(
+			prepareAgentLaunch({
+				taskId: "task-genpro",
+				agentId: "genpro",
+				binary: "genpro-supervisor-adapter",
+				args: [],
+				cwd: "/tmp/worktree",
+				prompt: "task prompt",
+			}),
+		).rejects.toThrow("requires a task-scoped Kanban workspace");
+	});
+
+	it("refuses a GenPro launch without a stable project path", async () => {
+		await expect(
+			prepareAgentLaunch({
+				taskId: "task-genpro",
+				agentId: "genpro",
+				binary: "genpro-supervisor-adapter",
+				args: [],
+				cwd: "/tmp/worktree",
+				prompt: "task prompt",
+				workspaceId: "workspace-1",
+			}),
+		).rejects.toThrow("requires a stable project workspace path");
+	});
+
 	it("configures Codex hooks without legacy notify", async () => {
 		setupTempHome();
 		const launch = await prepareAgentLaunch({

--- a/test/runtime/terminal/genpro-launcher.test.ts
+++ b/test/runtime/terminal/genpro-launcher.test.ts
@@ -1,0 +1,65 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	buildGenproProviderDiscoveryEnvironment,
+	resolveGenproExecutable,
+} from "../../../src/terminal/genpro-launcher";
+
+let temporaryRoot: string | null = null;
+
+function executable(name: string): string {
+	temporaryRoot ??= mkdtempSync(join(tmpdir(), "kanban-genpro-launcher-"));
+	const path = join(temporaryRoot, name);
+	writeFileSync(path, "#!/bin/sh\n", { mode: 0o700 });
+	chmodSync(path, 0o700);
+	return path;
+}
+
+afterEach(() => {
+	if (temporaryRoot) {
+		rmSync(temporaryRoot, { recursive: true, force: true });
+		temporaryRoot = null;
+	}
+});
+
+describe("GenPro launcher resolution", () => {
+	it("fails clearly when the configured launcher is missing or unusable", () => {
+		expect(() => resolveGenproExecutable(undefined, { KANBAN_GENPRO_EXECUTABLE: "" })).toThrow(
+			"must be a non-empty absolute executable path",
+		);
+		expect(() =>
+			resolveGenproExecutable(undefined, { KANBAN_GENPRO_EXECUTABLE: "/missing/genpro-supervisor-adapter" }),
+		).toThrow("does not identify an accessible executable");
+	});
+
+	it("resolves an explicit executable and a PATH-discoverable executable", () => {
+		const launcher = executable("genpro-supervisor-adapter");
+		expect(resolveGenproExecutable(undefined, { KANBAN_GENPRO_EXECUTABLE: launcher })).toBe(launcher);
+		expect(resolveGenproExecutable(undefined, { PATH: temporaryRoot ?? "" })).toBe(launcher);
+	});
+
+	it("prepends only the configured Codex directory to the GenPro child PATH", () => {
+		const codex = executable(process.platform === "win32" ? "codex.exe" : "codex");
+		const result = buildGenproProviderDiscoveryEnvironment({
+			KANBAN_GENPRO_CODEX_EXECUTABLE: codex,
+			PATH: "/checkout/node_modules/.bin:/usr/bin",
+		});
+		expect(result).toEqual({
+			PATH: `${temporaryRoot}${delimiter}/checkout/node_modules/.bin:/usr/bin`,
+		});
+	});
+
+	it("rejects a missing or ambiguously named Codex executable", () => {
+		expect(() =>
+			buildGenproProviderDiscoveryEnvironment({ KANBAN_GENPRO_CODEX_EXECUTABLE: "relative/codex" }),
+		).toThrow("must be an absolute executable path");
+		const other = executable("not-codex");
+		expect(() => buildGenproProviderDiscoveryEnvironment({ KANBAN_GENPRO_CODEX_EXECUTABLE: other })).toThrow(
+			"must identify an executable named",
+		);
+	});
+});

--- a/web-ui/src/components/runtime-settings-dialog.tsx
+++ b/web-ui/src/components/runtime-settings-dialog.tsx
@@ -92,7 +92,7 @@ const GIT_PROMPT_VARIANT_OPTIONS: Array<{ value: TaskGitAction; label: string }>
 
 export type RuntimeSettingsSection = "shortcuts";
 
-const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "claude", "codex", "droid", "kiro"];
+const SETTINGS_AGENT_ORDER: readonly RuntimeAgentId[] = ["cline", "genpro", "claude", "codex", "droid", "kiro"];
 
 type SettingsNavId = "general" | "cline" | "git-prompts" | "notifications" | "appearance" | "project";
 

--- a/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
+++ b/web-ui/src/components/task-start-agent-onboarding-carousel.tsx
@@ -305,6 +305,9 @@ function resolveInstallInstructions(agentId: RuntimeAgentId): string {
 	if (agentId === "kiro") {
 		return "Amazon's coding agent with access to the latest frontier models.";
 	}
+	if (agentId === "genpro") {
+		return "GenPro's policy-bound router and quota-aware execution supervisor.";
+	}
 	return "Install from the official docs.";
 }
 


### PR DESCRIPTION
## Summary

Adds an explicit GenPro Supervisor agent integration to Cline Kanban.

### Changes

- registers GenPro as an explicit agent
- adds scoped GenPro launcher resolution
- supports `KANBAN_GENPRO_EXECUTABLE`
- supports `KANBAN_GENPRO_CODEX_EXECUTABLE`
- preserves the task-worktree execution boundary
- avoids any broad `~/.local/bin` PATH modification
- does not enable unattended or automatic merge behavior

## Validation

- focused GenPro tests: 36 passed
- desktop PATH tests: 13 passed
- type checking passed
- 557 fast tests passed in commit hooks
- bounded integration task `947f1` completed successfully through Kanban → ForgePilot → Codex
- task worktree remained clean

This integration is intended for controlled development-agent execution and does not introduce autonomous Git or merge operations.
