### PR TITLE
fix(cline-sdk): cache persisted session lookups, pre-warm SDK host, fix subscription leak

### DIFF
--- a/src/cline-sdk/cline-session-runtime.ts
+++ b/src/cline-sdk/cline-session-runtime.ts
@@ -118,6 +118,8 @@ export interface ClineSessionRuntime {
 	getTaskProviderId(taskId: string): string | null;
 	canRestartTaskSession(taskId: string): boolean;
 	readPersistedTaskSession(taskId: string): Promise<ClinePersistedTaskSessionSnapshot | null>;
+	/** Eagerly create the SDK session host so the first user interaction does not pay the cold-start cost. */
+	prewarm(): Promise<void>;
 	dispose(): Promise<void>;
 }
 
@@ -156,6 +158,12 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 	>();
 	private readonly mcpToolBundleByTaskId = new Map<string, ClineMcpToolBundle>();
 	private sessionHostPromise: Promise<ClineSessionHostBoundary> | null = null;
+	private sessionHostUnsubscribe: (() => void) | null = null;
+	// Cache of persisted session records keyed by taskId so repeated card opens
+	// and rebind attempts do not trigger a full sessionHost.list() scan (which
+	// runs dead-session reconciliation + N manifest reads). Invalidated on
+	// session start, stop, abort, and clear.
+	private readonly persistedRecordByTaskId = new Map<string, ClineSdkSessionRecord>();
 
 	constructor(options: CreateInMemoryClineSessionRuntimeOptions = {}) {
 		this.onTaskEvent = options.onTaskEvent ?? null;
@@ -398,6 +406,7 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 			this.taskIdBySessionId.delete(sessionId);
 		}
 		this.clearTaskSessionBinding(taskId);
+		this.persistedRecordByTaskId.delete(taskId);
 		await this.releaseTaskMcpToolBundle(taskId);
 	}
 
@@ -426,9 +435,27 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 		};
 	}
 
+	async prewarm(): Promise<void> {
+		try {
+			await this.ensureSessionHost();
+		} catch {
+			// Best-effort pre-warming; the first real interaction will surface any errors.
+		}
+	}
+
 	async dispose(): Promise<void> {
 		const hostPromise = this.sessionHostPromise;
 		this.sessionHostPromise = null;
+		// Unsubscribe from the SDK event stream before disposing the host so the
+		// orphaned listener does not retain a reference to this runtime instance.
+		if (this.sessionHostUnsubscribe) {
+			try {
+				this.sessionHostUnsubscribe();
+			} catch {
+				// Ignore unsubscribe errors during shutdown.
+			}
+			this.sessionHostUnsubscribe = null;
+		}
 		if (hostPromise) {
 			try {
 				const host = await hostPromise;
@@ -440,6 +467,7 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 		this.sessionIdByTaskId.clear();
 		this.taskIdBySessionId.clear();
 		this.lastStartRequestByTaskId.clear();
+		this.persistedRecordByTaskId.clear();
 
 		const mcpBundles = [...this.mcpToolBundleByTaskId.values()];
 		this.mcpToolBundleByTaskId.clear();
@@ -477,6 +505,8 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 		}
 		this.sessionIdByTaskId.set(taskId, sessionId);
 		this.taskIdBySessionId.set(sessionId, taskId);
+		// Invalidate the persisted-record cache: a new session has been bound.
+		this.persistedRecordByTaskId.delete(taskId);
 	}
 
 	private clearTaskSessionBinding(taskId: string, sessionId?: string): void {
@@ -503,6 +533,19 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 			}
 		}
 
+		// Return the cached record if we already resolved this taskId via a list()
+		// scan. This avoids repeating the expensive sessionHost.list() call
+		// (which runs dead-session reconciliation + N manifest file reads) on
+		// every card open or rebind attempt for the same task.
+		const cachedRecord = this.persistedRecordByTaskId.get(taskId);
+		if (cachedRecord) {
+			const refreshedRecord = (await sessionHost.get(cachedRecord.sessionId)) ?? null;
+			if (refreshedRecord) {
+				return refreshedRecord;
+			}
+			this.persistedRecordByTaskId.delete(taskId);
+		}
+
 		const sessionIdPrefix = buildSessionIdPrefix(taskId);
 		const records: ClineSdkSessionRecord[] = await sessionHost.list();
 		const matchingRecord = records
@@ -512,13 +555,16 @@ export class InMemoryClineSessionRuntime implements ClineSessionRuntime {
 				const rightTimestamp = Date.parse(right.updatedAt || right.startedAt);
 				return rightTimestamp - leftTimestamp;
 			})[0];
+		if (matchingRecord) {
+			this.persistedRecordByTaskId.set(taskId, matchingRecord);
+		}
 		return matchingRecord ?? null;
 	}
 
 	private async ensureSessionHost(): Promise<ClineSessionHostBoundary> {
 		if (!this.sessionHostPromise) {
 			this.sessionHostPromise = this.createSessionHost().then((sessionHost: ClineSessionHostBoundary) => {
-				sessionHost.subscribe((event: unknown) => {
+				this.sessionHostUnsubscribe = sessionHost.subscribe((event: unknown) => {
 					this.handleSessionEvent(event);
 				});
 				return sessionHost;

--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -98,6 +98,8 @@ export interface ClineTaskSessionService {
 	listSlashCommands(workspacePath: string): Promise<ClineSdkSlashCommand[]>;
 	loadTaskSessionMessages(taskId: string): Promise<ClineTaskMessage[]>;
 	applyTurnCheckpoint(taskId: string, checkpoint: RuntimeTaskTurnCheckpoint): RuntimeTaskSessionSummary | null;
+	/** Eagerly initialize the SDK session host so the first card open or action does not pay the cold-start cost. */
+	prewarm(): Promise<void>;
 	dispose(): Promise<void>;
 }
 
@@ -793,6 +795,10 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 		}
 		this.emitSummary(summary);
 		return summary;
+	}
+
+	async prewarm(): Promise<void> {
+		await this.sessionRuntime.prewarm();
 	}
 
 	async dispose(): Promise<void> {

--- a/src/server/runtime-server.ts
+++ b/src/server/runtime-server.ts
@@ -151,6 +151,12 @@ export async function createRuntimeServer(deps: CreateRuntimeServerDependencies)
 			service = createInMemoryClineTaskSessionService({
 				watcherRegistry: clineWatcherRegistry,
 			});
+			// Pre-warm the SDK session host in the background so the first card
+			// open or agent action does not pay the ClineCore.create cold-start
+			// cost (hub discovery + local runtime host initialization). Prewarm
+			// before registering the service; ensureSessionHost memoizes its
+			// promise, so ordering does not matter.
+			void service.prewarm().catch(() => undefined);
 			clineTaskSessionServiceByWorkspaceId.set(scope.workspaceId, service);
 			deps.runtimeStateHub.trackClineTaskSessionService(scope.workspaceId, scope.workspacePath, service);
 		}

--- a/test/runtime/cline-sdk/cline-task-session-service.test.ts
+++ b/test/runtime/cline-sdk/cline-task-session-service.test.ts
@@ -227,6 +227,7 @@ function createFakeClineSessionRuntime(): FakeClineSessionRuntimeController {
 			async readPersistedTaskSession(taskId: string): Promise<ClinePersistedTaskSessionSnapshot | null> {
 				return await readPersistedTaskSessionMock(taskId);
 			},
+			async prewarm(): Promise<void> {},
 			async dispose(): Promise<void> {
 				sessionIdByTaskId.clear();
 				taskIdBySessionId.clear();


### PR DESCRIPTION
## What this changes

Opening a Cline task card was slow for any task not in memory — after a restart, or for tasks that ran in a previous process. The first message sent to such a task hit the same delay.

The cause was findPersistedTaskSessionRecord in src/cline-sdk/cline-session-runtime.ts. With no active session binding, it called sessionHost.list(), and one list() call in the local runtime host does dead-session reconciliation (3 store queries plus process-liveness checks), one more store query for the list, and one manifest file read per session for titles. The result was then filtered in JavaScript by session id prefix. This repeated on every card open for the same task.

This PR makes three changes:

1. **Cache the persisted session record per task id.** After the first lookup, later lookups refresh the record with a single-record get() call instead of the full list() scan. The cache is invalidated when a session starts, when task sessions are cleared, and on dispose.
2. **Pre-warm the SDK session host.** ClineCore.create ran lazily on first use, so the first card open paid the cold-start cost (hub discovery plus local runtime host setup). A new prewarm() method now runs in the background when a workspace service is created, so the first user action does not wait for it. Errors are ignored; the first real use surfaces them.
3. **Fix an event subscription leak.** ensureSessionHost subscribed to the SDK event stream but threw away the unsubscribe function. The listener kept a reference to the runtime after dispose, which blocked garbage collection. The unsubscribe is now stored and called in dispose().

## Verification

- The full cline-sdk test suite passes (62 tests in the two touched files at merge time).
- Type check clean, lint clean.
- All three problems are pre-existing on main.

Fixes #630