### PR TITLE
fix(cline-sdk): strip incomplete tool turns from persisted history before session restart

### DIFF
--- a/src/cline-sdk/cline-task-session-service.ts
+++ b/src/cline-sdk/cline-task-session-service.ts
@@ -159,6 +159,50 @@ function buildClineStartPrompt(prompt: string, startInPlanMode?: boolean): strin
 		trimmedPrompt ? `\n\nTask:\n${trimmedPrompt}` : " Ask the user what they want planned if the task is unclear.",
 	].join(" ");
 }
+
+/**
+ * A crash or force-quit mid-tool-call leaves assistant `tool_use` blocks whose
+ * matching `tool_result` blocks were never persisted. Resuming with that
+ * history fails inside the SDK with "Tool result is missing". Drop everything
+ * from the last assistant message that still has an unresolved tool call so
+ * the resumed session starts from a clean turn boundary.
+ *
+ * Results are collected across the whole history before scanning for
+ * unresolved calls, because a `tool_result` always follows the assistant
+ * message that issued its `tool_use` — a forward-only scan would wrongly mark
+ * healthy trailing turns as incomplete.
+ */
+export function stripIncompleteToolTurns(messages: ClineSdkPersistedMessage[]): ClineSdkPersistedMessage[] {
+	const resolvedToolUseIds = new Set<string>();
+	for (const message of messages) {
+		const blocks = typeof message.content === "string" ? [] : message.content;
+		for (const block of blocks) {
+			if (block.type === "tool_result") {
+				resolvedToolUseIds.add(block.tool_use_id);
+			}
+		}
+	}
+
+	let lastIncompleteIndex = -1;
+	for (const [index, message] of messages.entries()) {
+		if (message.role !== "assistant") {
+			continue;
+		}
+		const blocks = typeof message.content === "string" ? [] : message.content;
+		const hasUnresolvedToolUse = blocks.some(
+			(block) => block.type === "tool_use" && !resolvedToolUseIds.has(block.id),
+		);
+		if (hasUnresolvedToolUse) {
+			lastIncompleteIndex = index;
+		}
+	}
+
+	if (lastIncompleteIndex === -1) {
+		return messages;
+	}
+	return messages.slice(0, lastIncompleteIndex);
+}
+
 export class InMemoryClineTaskSessionService implements ClineTaskSessionService {
 	private readonly pendingTurnCancelTaskIds = new Set<string>();
 	private readonly providerIdByTaskId = new Map<string, string>();
@@ -273,12 +317,15 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 		}
 
 		const persistedSnapshot = await this.sessionRuntime.readPersistedTaskSession(input.taskId);
+		const persistedMessages = persistedSnapshot?.messages;
 		const restartedSession = await this.sessionRuntime.restartTaskSession({
 			taskId: input.taskId,
 			prompt: input.prompt,
 			mode: input.mode,
 			images: input.images,
-			initialMessages: persistedSnapshot?.messages,
+			// Drop a trailing incomplete tool turn (crash mid-tool-call) so the
+			// SDK does not reject the resume with "Tool result is missing".
+			initialMessages: persistedMessages ? stripIncompleteToolTurns(persistedMessages) : undefined,
 		});
 		return {
 			result: restartedSession.result,
@@ -309,7 +356,9 @@ export class InMemoryClineTaskSessionService implements ClineTaskSessionService 
 			prompt: input.prompt,
 			mode: input.mode,
 			images: input.images,
-			initialMessages: compactedMessages,
+			// Compaction can carry a crashed turn's unresolved tool_use into the
+			// replacement session; strip it so the restart is not rejected.
+			initialMessages: stripIncompleteToolTurns(compactedMessages),
 		});
 		return {
 			result: restartedSession.result,

--- a/test/runtime/cline-sdk/cline-task-session-service.test.ts
+++ b/test/runtime/cline-sdk/cline-task-session-service.test.ts
@@ -10,8 +10,12 @@ import type {
 } from "../../../src/cline-sdk/cline-session-runtime";
 import { createSessionId } from "../../../src/cline-sdk/cline-session-state";
 import type { ClineTaskSessionService } from "../../../src/cline-sdk/cline-task-session-service";
-import { createInMemoryClineTaskSessionService } from "../../../src/cline-sdk/cline-task-session-service";
+import {
+	createInMemoryClineTaskSessionService,
+	stripIncompleteToolTurns,
+} from "../../../src/cline-sdk/cline-task-session-service";
 import { createClineWatcherRegistry } from "../../../src/cline-sdk/cline-watcher-registry";
+import type { ClineSdkPersistedMessage } from "../../../src/cline-sdk/sdk-runtime-boundary";
 import type { RuntimeTaskImage, RuntimeTaskSessionMode } from "../../../src/core/api-contract";
 
 const originalArgv = [...process.argv];
@@ -1841,5 +1845,110 @@ describe("InMemoryClineTaskSessionService", () => {
 			.filter((message) => message.role === "assistant")
 			.map((message) => message.content);
 		expect(assistantMessages).toEqual(["Done."]);
+	});
+});
+
+describe("stripIncompleteToolTurns", () => {
+	type PersistedMessage = ClineSdkPersistedMessage;
+
+	it("returns the input unchanged when there are no tool calls", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: "plan the feature" },
+			{ role: "assistant", content: "Here is the plan." },
+		];
+		expect(stripIncompleteToolTurns(messages)).toBe(messages);
+	});
+
+	it("returns the input unchanged when every tool call is resolved", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: "run the tests" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Running tests." },
+					{ type: "tool_use", id: "call-1", name: "run_tests", input: {} },
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "call-1", name: "run_tests", content: "all passing" }],
+			},
+			{ role: "assistant", content: "All tests passed." },
+		];
+		expect(stripIncompleteToolTurns(messages)).toBe(messages);
+	});
+
+	it("drops the trailing assistant message when its tool call has no result", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: "run the tests" },
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "call-1", name: "run_tests", input: {} }],
+			},
+		];
+		const stripped = stripIncompleteToolTurns(messages);
+		expect(stripped).toHaveLength(1);
+		expect(stripped[0]?.role).toBe("user");
+	});
+
+	it("drops the incomplete turn and everything after it, keeping earlier complete turns", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: "first" },
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "call-1", name: "read_file", input: {} }],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "call-1", name: "read_file", content: "file body" }],
+			},
+			{ role: "assistant", content: "First step done." },
+			{ role: "user", content: "second" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Crashed mid-call." },
+					{ type: "tool_use", id: "call-2", name: "edit_file", input: {} },
+				],
+			},
+			{ role: "assistant", content: "never persisted" },
+		];
+		const stripped = stripIncompleteToolTurns(messages);
+		expect(stripped).toHaveLength(5);
+		expect(stripped.at(-1)?.role).toBe("user");
+		expect(stripped.some((message) => JSON.stringify(message).includes("call-2"))).toBe(false);
+	});
+
+	it("keeps a partially resolved turn only when at least one call is unresolved", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: "do both" },
+			{
+				role: "assistant",
+				content: [
+					{ type: "tool_use", id: "call-1", name: "step_one", input: {} },
+					{ type: "tool_use", id: "call-2", name: "step_two", input: {} },
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "call-1", name: "step_one", content: "done" }],
+			},
+		];
+		// call-2 has no result, so the whole turn is dropped from the assistant message on.
+		const stripped = stripIncompleteToolTurns(messages);
+		expect(stripped).toHaveLength(1);
+		expect(stripped[0]?.role).toBe("user");
+	});
+
+	it("ignores string content and non-assistant tool blocks", () => {
+		const messages: PersistedMessage[] = [
+			{ role: "user", content: [{ type: "tool_result", tool_use_id: "call-x", name: "noop", content: "stray" }] },
+			{ role: "assistant", content: "plain text only" },
+		];
+		expect(stripIncompleteToolTurns(messages)).toBe(messages);
+	});
+
+	it("returns an empty array for empty input", () => {
+		expect(stripIncompleteToolTurns([])).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What this changes

When Kanban crashes or is force-quit during a tool call, the persisted history keeps an assistant message with a tool_use block whose tool_result was never written. Seeding a replacement session with that history fails inside the SDK with Tool result is missing, so the task cannot resume.

This PR adds stripIncompleteToolTurns() to src/cline-sdk/cline-task-session-service.ts and applies it at both restart paths that seed a session with persisted history:

- restartTaskSession (the normal restart path)
- the context-overflow retry path, where compaction could carry the same broken tail into the replacement session

The function drops the last assistant message that still has an unresolved tool_use, plus everything after it, so the session resumes from a clean turn boundary.

### One detail that matters

The scan collects every tool_result id across the whole history first, then looks for unresolved tool_use blocks. A tool_result always comes after the assistant message that made the call, so a forward-only scan would mark healthy trailing turns as incomplete and delete good history. The two-pass order avoids that. This difference from a naive implementation is covered by a dedicated test (returns the input unchanged when every tool call is resolved).

### Scope note

This PR takes only the history-filtering part. The recovery logic in #558 (rebuilding a launch config from the persisted record) is not included, because the existing rebind path already recovers sessions with a full launch config, system prompt, and credentials — restarting with an empty system prompt and no api key would be a regression.

## Verification

- 7 new unit tests: healthy histories returned unchanged, trailing incomplete turns dropped, earlier complete turns preserved, partially resolved turns dropped, string content ignored, empty input.
- Full cline-sdk suite passes (133 tests at merge time). Type check clean, lint clean.

Fixes #632

Extracted and improved from the filtering half of #558.