### PR TITLE
fix(cli): drain stdout before exit to stop 64 KiB pipe truncation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -742,6 +742,23 @@ async function run(): Promise<void> {
 	await program.parseAsync(argv, { from: "user" });
 	if (!shouldAutoOpenBrowserTabForInvocation(argv)) {
 		await Promise.allSettled([disposeCliTelemetryService(), flushNodeTelemetry()]);
+		// process.stdout is asynchronous when it points at a pipe. Calling
+		// process.exit() before the write queue drains truncates the output at
+		// the pipe buffer size (64 KiB on Linux). Wait for stdout to flush so
+		// JSON commands stay complete when piped. See #623.
+		//
+		// If the pipe consumer closes early (EPIPE), the drain callback still
+		// fires, but Node emits an unhandled "error" event on stdout that would
+		// crash the process. Attach a no-op error handler for the drain so a
+		// closed pipe exits cleanly instead of throwing.
+		if (process.stdout.writableLength > 0) {
+			const drainErrorHandler = () => {};
+			process.stdout.once("error", drainErrorHandler);
+			await new Promise<void>((resolve) => {
+				process.stdout.write("", () => resolve());
+			});
+			process.stdout.off("error", drainErrorHandler);
+		}
 		process.exit(process.exitCode ?? 0);
 	}
 }


### PR DESCRIPTION
## Context

For one-shot CLI invocations, `run()` called `process.exit()` right after the command finished. Task commands write JSON with `process.stdout.write()`, which is asynchronous when stdout is a pipe. `process.exit()` terminated the process before the pipe drained, so output past the 64 KiB pipe buffer was dropped.

This matches the symptom reported in #623: `kanban task list` intermittently truncates at exactly 65536 bytes when piped. The failure only appears once a workspace's `task list` output exceeds 64 KiB, which is why it can surface suddenly on a board that has worked for months. To a file it is complete and valid every time; only the pipe path loses the tail.

It is the same teardown-race family as #221.

## Decision

Flush the stdout write queue before `process.exit()` so JSON output stays complete when piped. This covers every JSON command that uses the exit path, not only `task list`.

One detail that matters: the write callback is `(err?) => void`, so the Promise resolve is wrapped as `() => resolve()` to satisfy the type. The flush is awaited before exit, and the callback only resolves once — the previous code could exit before the callback fired, which is exactly the bug being fixed.

## Verification

- Reproduce on main: pipe `task list` output through `head`/`cut` and observe truncation at 64 KiB. After this change the full payload arrives.
- Type check clean, lint clean.

Fixes #623