### PR TITLE
fix(cli): include title in task record JSON

### DIFF
--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -345,6 +345,7 @@ function formatTaskRecord(
 	const session = state.sessions[task.id] ?? null;
 	return {
 		id: task.id,
+		title: task.title,
 		prompt: task.prompt,
 		column: columnId,
 		baseRef: task.baseRef,


### PR DESCRIPTION
## Context

`formatTaskRecord` in `src/commands/task.ts` builds the record for `task list`, `task show` and `task update`, and its object literal has no `title`. Only `createTask` builds its response separately and includes `title: created.title`, which is why `create` behaves differently from every other read.

The result is reported in #624: `kanban task list`, `task show` and `task update` never include `title` in their JSON, even though the value is stored and rendered. Since the CLI is the only way a scripted agent can read the board, a card with a perfectly good title is indistinguishable over the CLI from one with none.

Storage is correct before and after `task update` — the title is set, only the echo omits it. `task update` reads as if the flag were discarded, and `select(.title != null)` returns 0 across every card, which nearly caused the team to remove the flag from the tooling that sets it.

This is a separate bug from #623 (the 64 KiB pipe truncation), though the two compound: both make `task list` an unreliable basis for "is this already carded?".

## Decision

Add `title: task.title` to the record. `resolveTaskTitle` always returns a non-empty string, so there is no null case to handle.

## Verification

- The title is already stored and rendered in the web UI; this only restores it to the CLI JSON contract.
- Type check clean, lint clean.

Fixes #624